### PR TITLE
Graph-based linting improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,10 +236,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -246,6 +264,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -275,6 +303,7 @@ dependencies = [
  "clap",
  "comrak",
  "deunicode",
+ "petgraph",
  "regex",
  "serde",
  "serde_json",
@@ -299,6 +328,16 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ comrak = { version = "0.20", default-features = false }
 Inflector = "0.11"
 unicode-normalization = "0.1"
 deunicode = "1"
+petgraph = "0.5"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ islands, and keep a large doc set coherent.
 
 ## Usage
 
+### How To Use
+
+Run the linter against a docs directory:
+
+```bash
+./lint-ai /path/to/repo
+```
+
 ### Download Release Binaries
 
 Download the latest release binary from the GitHub Releases page for this repo, then verify the checksum.
@@ -35,11 +43,7 @@ sha256sum lint-ai-linux-x86_64
 shasum -a 256 lint-ai-macos-x86_64
 ```
 
-Run the linter against a docs directory:
-
-```bash
-./lint-ai /path/to/repo
-```
+## Advanced
 
 By default the linter skips files larger than 5MB and stops after 50k files. Override these limits:
 
@@ -240,4 +244,21 @@ group_messages
 groupmessages
 group message
 group messages
+```
+
+## Output Examples
+
+Sample findings now include severity tags and link‑debt signals:
+
+```
+Missing cross-ref in docs/channels/discord.md -> [[signal]] (high)
+Low link density in docs/channels/location.md (outgoing 1, avg 4.2)
+Unreachable page: docs/channels/legacy.md
+Orphan page: docs/channels/unused.md
+```
+
+Orphan detection example command:
+
+```bash
+./lint-ai /path/to/openclaw/docs/channels
 ```

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,5 @@
 use crate::config::{load_config, normalize_list, Config};
+use crate::filters::is_noise_concept;
 use crate::graph::{normalize_concept, Graph};
 use crate::report::Report;
 use crate::rules::orphan_pages::check_orphans;
@@ -27,32 +28,6 @@ fn surface_forms(raw: &str) -> Vec<String> {
     forms.into_iter().filter(|s| !s.is_empty()).collect()
 }
 
-fn is_stopword(concept: &str) -> bool {
-    const STOP: &[&str] = &[
-        "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "if", "in", "is",
-        "it", "its", "of", "on", "or", "the", "to", "via", "with",
-        "api", "app", "apps", "auth", "build", "config", "data", "doc", "docs", "feature",
-        "features", "file", "files", "guide", "help", "id", "index", "info", "issue", "issues",
-        "key", "keys", "log", "logs", "model", "models", "page", "pages", "role", "roles",
-        "run", "runs", "service", "services", "setup", "status", "system", "test", "tests",
-        "tool", "tools", "user", "users", "web", "cli", "sdk", "repo", "project",
-    ];
-    STOP.contains(&concept)
-}
-
-fn is_noise_concept(concept: &str, cfg: &Config) -> bool {
-    if concept.len() < 3 {
-        return true;
-    }
-    if concept.chars().all(|c| c.is_ascii_digit()) {
-        return true;
-    }
-    if is_stopword(concept) {
-        return true;
-    }
-    let extra = normalize_list(&cfg.stopwords);
-    extra.contains(&concept.to_string())
-}
 
 fn build_matcher(
     graph: &Graph,

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,0 +1,28 @@
+use crate::config::{normalize_list, Config};
+
+pub fn is_stopword(concept: &str) -> bool {
+    const STOP: &[&str] = &[
+        "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "if", "in", "is",
+        "it", "its", "of", "on", "or", "the", "to", "via", "with",
+        "api", "app", "apps", "auth", "build", "config", "data", "doc", "docs", "feature",
+        "features", "file", "files", "guide", "help", "id", "index", "info", "issue", "issues",
+        "key", "keys", "log", "logs", "model", "models", "page", "pages", "role", "roles",
+        "run", "runs", "service", "services", "setup", "status", "system", "test", "tests",
+        "tool", "tools", "user", "users", "web", "cli", "sdk", "repo", "project",
+    ];
+    STOP.contains(&concept)
+}
+
+pub fn is_noise_concept(concept: &str, cfg: &Config) -> bool {
+    if concept.len() < 3 {
+        return true;
+    }
+    if concept.chars().all(|c| c.is_ascii_digit()) {
+        return true;
+    }
+    if is_stopword(concept) {
+        return true;
+    }
+    let extra = normalize_list(&cfg.stopwords);
+    extra.contains(&concept.to_string())
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use comrak::{nodes::NodeValue, parse_document, Arena, ComrakOptions};
 use deunicode::deunicode;
+use petgraph::graph::{DiGraph, NodeIndex};
 use regex::Regex;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use unicode_normalization::UnicodeNormalization;
@@ -21,6 +22,8 @@ pub struct Page {
 
 pub struct Graph {
     pub pages: Vec<Page>,
+    pub index: HashMap<String, NodeIndex>,
+    pub graph: DiGraph<String, ()>,
 }
 
 pub fn normalize_concept(s: &str) -> String {
@@ -207,7 +210,22 @@ impl Graph {
             pages.push(page);
         }
 
-        Ok(Self { pages })
+        let mut graph = DiGraph::<String, ()>::new();
+        let mut index: HashMap<String, NodeIndex> = HashMap::new();
+        for page in &pages {
+            let node = graph.add_node(page.rel_path.clone());
+            index.insert(page.concept.clone(), node);
+        }
+        for page in &pages {
+            if let Some(&from) = index.get(&page.concept) {
+                for link in &page.links {
+                    if let Some(&to) = index.get(link) {
+                        graph.add_edge(from, to, ());
+                    }
+                }
+            }
+        }
+        Ok(Self { pages, index, graph })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod config;
 pub mod engine;
+pub mod filters;
 pub mod graph;
 pub mod report;
 pub mod rules;

--- a/src/rules/cross_refs.rs
+++ b/src/rules/cross_refs.rs
@@ -1,4 +1,5 @@
 use crate::config::{normalize_list, Config};
+use crate::filters::is_noise_concept;
 use crate::graph::{normalize_concept, Graph};
 use crate::report::Report;
 use aho_corasick::AhoCorasick;
@@ -6,6 +7,7 @@ use deunicode::deunicode;
 use inflector::Inflector;
 use std::collections::{HashMap, HashSet};
 use unicode_normalization::UnicodeNormalization;
+use petgraph::algo::kosaraju_scc;
 
 fn is_word_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '_' || c == '-'
@@ -51,34 +53,19 @@ fn surface_forms(raw: &str) -> Vec<String> {
     forms.into_iter().filter(|s| !s.is_empty()).collect()
 }
 
-fn is_stopword(concept: &str) -> bool {
-    const STOP: &[&str] = &[
-        "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "if", "in", "is",
-        "it", "its", "of", "on", "or", "the", "to", "via", "with",
-        "api", "app", "apps", "auth", "build", "config", "data", "doc", "docs", "feature",
-        "features", "file", "files", "guide", "help", "id", "index", "info", "issue", "issues",
-        "key", "keys", "log", "logs", "model", "models", "page", "pages", "role", "roles",
-        "run", "runs", "service", "services", "setup", "status", "system", "test", "tests",
-        "tool", "tools", "user", "users", "web", "cli", "sdk", "repo", "project",
-    ];
-    STOP.contains(&concept)
-}
-
-fn is_noise_concept(concept: &str, cfg: &Config) -> bool {
-    if concept.len() < 3 {
-        return true;
-    }
-    if concept.chars().all(|c| c.is_ascii_digit()) {
-        return true;
-    }
-    if is_stopword(concept) {
-        return true;
-    }
-    let extra = normalize_list(&cfg.stopwords);
-    extra.contains(&concept.to_string())
-}
 
 pub fn check_cross_refs(graph: &Graph, report: &mut Report, cfg: &Config) {
+    let sccs = kosaraju_scc(&graph.graph);
+    let mut component: HashMap<petgraph::graph::NodeIndex, usize> = HashMap::new();
+    for (idx, nodes) in sccs.iter().enumerate() {
+        for node in nodes {
+            component.insert(*node, idx);
+        }
+    }
+    let mut avg_rank = 0.0;
+    if graph.graph.node_count() > 0 {
+        avg_rank = graph.graph.edge_count() as f64 / graph.graph.node_count() as f64;
+    }
     let allowlist = normalize_list(&cfg.allowlist_concepts);
     let ignore_sections = normalize_list(&cfg.ignore_crossref_sections);
     let scope_prefix = cfg.scope_prefix.as_ref().map(|s| s.to_lowercase());
@@ -234,9 +221,21 @@ pub fn check_cross_refs(graph: &Graph, report: &mut Report, cfg: &Config) {
                 continue;
             }
             if !linked.contains(&concept) {
+                let mut severity = "low";
+                if let Some(idx) = graph.index.get(&concept) {
+                    let degree = graph.graph.edges(*idx).count() as f64;
+                    if degree >= avg_rank {
+                        severity = "high";
+                    }
+                    if let Some(src_idx) = graph.index.get(&page.concept) {
+                        if component.get(src_idx) != component.get(idx) {
+                            severity = "high";
+                        }
+                    }
+                }
                 report.add(format!(
-                    "Missing cross-ref in {} -> [[{}]]",
-                    page.rel_path, concept
+                    "Missing cross-ref in {} -> [[{}]] ({})",
+                    page.rel_path, concept, severity
                 ));
             }
         }

--- a/src/rules/orphan_pages.rs
+++ b/src/rules/orphan_pages.rs
@@ -1,18 +1,63 @@
 use crate::graph::Graph;
 use crate::report::Report;
+use petgraph::visit::Dfs;
 use std::collections::HashSet;
 
 pub fn check_orphans(graph: &Graph, report: &mut Report) {
-    let mut referenced: HashSet<String> = HashSet::new();
+    let avg_out = if graph.graph.node_count() > 0 {
+        graph.graph.edge_count() as f64 / graph.graph.node_count() as f64
+    } else {
+        0.0
+    };
 
+    for page in &graph.pages {
+        if let Some(idx) = graph.index.get(&page.concept) {
+            let out_degree = graph.graph.edges(*idx).count() as f64;
+            if avg_out > 0.0 && out_degree < (avg_out * 0.5) {
+                report.add(format!(
+                    "Low link density in {} (outgoing {:.0}, avg {:.1})",
+                    page.rel_path, out_degree, avg_out
+                ));
+            }
+        }
+    }
+
+    let mut index_nodes = Vec::new();
+    for (_concept, idx) in &graph.index {
+        if let Some(label) = graph.graph.node_weight(*idx) {
+            if label.ends_with("index.md") {
+                index_nodes.push(*idx);
+            }
+        }
+    }
+
+    if !index_nodes.is_empty() {
+        let mut reachable: HashSet<petgraph::graph::NodeIndex> = HashSet::new();
+        for root in index_nodes {
+            let mut dfs = Dfs::new(&graph.graph, root);
+            while let Some(nx) = dfs.next(&graph.graph) {
+                reachable.insert(nx);
+            }
+        }
+
+        for page in &graph.pages {
+            if let Some(idx) = graph.index.get(&page.concept) {
+                if !reachable.contains(idx) {
+                    report.add(format!("Unreachable page: {}", page.rel_path));
+                }
+            }
+        }
+        return;
+    }
+
+    let mut referenced: HashSet<String> = HashSet::new();
     for page in &graph.pages {
         for link in &page.links {
             referenced.insert(link.clone());
         }
     }
-
     for page in &graph.pages {
-        if !referenced.contains(&page.concept) {
+        if !referenced.contains(&page.concept) && graph.pages.len() > 1 {
             report.add(format!("Orphan page: {}", page.rel_path));
         }
     }


### PR DESCRIPTION
Summary:
- Add shared stopword/noise filter module
- Build doc graph and use it for reachability + severity
- Add link-density findings and cluster-aware severity
- Update README to group advanced usage

Testing:
- cargo test