### PR TITLE
Add crates.io metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2021"
 description = "Semantic wiki and docs linting for contradictions, stale claims, orphan pages, and missing cross-references"
 license = "Apache-2.0"
+repository = "https://github.com/RooAGI/Lint-AI"
+homepage = "https://www.rooagi.com"
+readme = "README.md"
+keywords = ["lint", "documentation", "markdown", "knowledge-base", "graph", "ai", "llm", "agents"]
+categories = ["text-processing", "command-line-utilities"]
 
 [lib]
 name = "lint_ai"


### PR DESCRIPTION
Summary:
- Add repository, homepage, readme, keywords, and categories for crates.io

Testing:
- Not required (metadata-only)