### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lint-ai"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Semantic wiki and docs linting for contradictions, stale claims, orphan pages, and missing cross-references"
 license = "Apache-2.0"


### PR DESCRIPTION
Summary:
- Bump crate version to 0.1.1

Testing:
- Not required (version bump only)