### PR TITLE
cover public API docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lint-ai"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "Inflector",
  "aho-corasick",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[command(name = "lint-ai")]
+/// CLI arguments for the lint-ai binary.
 pub struct Args {
     pub path: String,
     #[arg(long)]
@@ -28,6 +29,7 @@ pub struct Args {
     pub max_total_bytes: usize,
 }
 
+/// Parse CLI arguments from the environment.
 pub fn parse() -> Args {
     Args::parse()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,16 +5,22 @@ use std::path::Path;
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Config {
+    /// Extra stopwords to ignore during matching.
     #[serde(default)]
     pub stopwords: Vec<String>,
+    /// Sections to ignore in the concept summary view.
     #[serde(default)]
     pub ignore_sections: Vec<String>,
+    /// Sections to ignore during cross-reference checks.
     #[serde(default)]
     pub ignore_crossref_sections: Vec<String>,
+    /// Path fragments to ignore during traversal.
     #[serde(default)]
     pub ignore_paths: Vec<String>,
+    /// Optional allowlist of concepts to enforce linking for.
     #[serde(default)]
     pub allowlist_concepts: Vec<String>,
+    /// Optional path prefix to scope concepts and checks to.
     #[serde(default)]
     pub scope_prefix: Option<String>,
 }
@@ -28,6 +34,13 @@ fn load_from_path(path: &Path, max_bytes: u64) -> Result<Config, String> {
     serde_json::from_str(&raw).map_err(|e| e.to_string())
 }
 
+/// Load config from a JSON file, or default if none is found.
+///
+/// Example:
+/// ```
+/// use lint_ai::config::load_config;
+/// let cfg = load_config(None, "docs", false, 2_000_000).unwrap();
+/// ```
 pub fn load_config(
     config_path: Option<&str>,
     target_path: &str,
@@ -79,6 +92,7 @@ pub fn load_config(
     Ok(Config::default())
 }
 
+/// Normalize a list of strings for matching (trim + lowercase).
 pub fn normalize_list(values: &[String]) -> Vec<String> {
     values
         .iter()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -279,6 +279,7 @@ fn debug_phrase_matches(
     out
 }
 
+/// Normalize a section heading to a stable bucket name.
 pub fn normalize_heading(name: &str) -> String {
     let lower = name.trim().to_lowercase();
     if lower.is_empty() || lower == "(unscoped)" || lower == "(untitled section)" {
@@ -369,6 +370,7 @@ fn common_dir_prefix(paths: &[String]) -> Option<String> {
     }
 }
 
+/// Generate the `--analyze` output for tests and snapshotting.
 pub fn analyze_for_tests(graph: &Graph, cfg: &Config) -> String {
     let (ac, forms, form_to_concept) = build_matcher(graph, cfg);
     let ac = match ac {
@@ -457,6 +459,9 @@ fn analyze_corpus(graph: &Graph, cfg: &Config) {
     print!("{}", out);
 }
 
+/// Run the lint pipeline using CLI arguments.
+///
+/// This is the main entry point used by the CLI wrapper in `main.rs`.
 pub fn run(args: crate::cli::Args) -> Result<()> {
     let cfg = load_config(
         args.config.as_deref(),

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,5 +1,6 @@
 use crate::config::{normalize_list, Config};
 
+/// Return true if the concept is a built-in stopword.
 pub fn is_stopword(concept: &str) -> bool {
     const STOP: &[&str] = &[
         "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "if", "in", "is",
@@ -13,6 +14,7 @@ pub fn is_stopword(concept: &str) -> bool {
     STOP.contains(&concept)
 }
 
+/// Return true if the concept should be ignored for matching.
 pub fn is_noise_concept(concept: &str, cfg: &Config) -> bool {
     if concept.len() < 3 {
         return true;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -11,21 +11,32 @@ use walkdir::WalkDir;
 
 #[derive(Debug, Clone)]
 pub struct Page {
+    /// Absolute path to the file.
     pub path: String,
+    /// Path relative to the root used for traversal.
     pub rel_path: String,
+    /// Normalized concept name derived from the file name.
     pub concept: String,
+    /// Raw concept name derived from the file name.
     pub raw_concept: String,
+    /// Full file contents.
     pub content: String,
+    /// Normalized outbound link targets.
     pub links: HashSet<String>,
+    /// Markdown headings extracted from the file.
     pub headings: Vec<String>,
 }
 
 pub struct Graph {
+    /// All parsed pages.
     pub pages: Vec<Page>,
+    /// Map of concept -> node index in the graph.
     pub index: HashMap<String, NodeIndex>,
+    /// Directed graph of page links.
     pub graph: DiGraph<String, ()>,
 }
 
+/// Normalize a concept string for matching (unicode + deunicode + case fold).
 pub fn normalize_concept(s: &str) -> String {
     let normalized: String = s
         .nfc()
@@ -85,6 +96,14 @@ fn docs_dir(root: &Path) -> PathBuf {
 }
 
 impl Graph {
+    /// Build a graph from the given path, applying size and depth limits.
+    ///
+    /// Example:
+    /// ```
+    /// use lint_ai::graph::Graph;
+    /// let graph = Graph::build("docs", 5_000_000, 50_000, 20, 100_000_000).unwrap();
+    /// println!("pages: {}", graph.pages.len());
+    /// ```
     pub fn build(
         path: &str,
         max_bytes: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,23 @@
+//! Lint AI — semantic linting for Markdown documentation.
+//!
+//! This crate provides the core pipeline for building a concept inventory from
+//! a Markdown corpus, matching mentions, and reporting missing cross-references
+//! and orphan/unreachable pages.
+//!
+//! Basic usage:
+//! ```
+//! use lint_ai::graph::Graph;
+//! use lint_ai::report::Report;
+//! use lint_ai::rules::{cross_refs::check_cross_refs, orphan_pages::check_orphans};
+//! use lint_ai::config::Config;
+//!
+//! let graph = Graph::build("docs", 5_000_000, 50_000, 20, 100_000_000).unwrap();
+//! let mut report = Report::new();
+//! let cfg = Config::default();
+//! check_orphans(&graph, &mut report);
+//! check_cross_refs(&graph, &mut report, &cfg);
+//! ```
+
 pub mod cli;
 pub mod config;
 pub mod engine;

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,14 +3,17 @@ pub struct Report {
 }
 
 impl Report {
+    /// Create an empty report.
     pub fn new() -> Self {
         Self { issues: vec![] }
     }
 
+    /// Add a new issue line.
     pub fn add(&mut self, msg: String) {
         self.issues.push(msg);
     }
 
+    /// Print issues to stdout.
     pub fn print(&self) {
         if self.issues.is_empty() {
             println!("No issues found");
@@ -22,6 +25,7 @@ impl Report {
         }
     }
 
+    /// Render issues as a single string.
     pub fn to_string(&self) -> String {
         if self.issues.is_empty() {
             "No issues found".to_string()

--- a/src/rules/cross_refs.rs
+++ b/src/rules/cross_refs.rs
@@ -54,6 +54,7 @@ fn surface_forms(raw: &str) -> Vec<String> {
 }
 
 
+/// Check for missing cross-references based on concept mentions.
 pub fn check_cross_refs(graph: &Graph, report: &mut Report, cfg: &Config) {
     let sccs = kosaraju_scc(&graph.graph);
     let mut component: HashMap<petgraph::graph::NodeIndex, usize> = HashMap::new();

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,2 +1,6 @@
+//! Lint rules for the documentation graph.
+//!
+//! Each rule inspects the graph and appends findings to a `Report`.
+
 pub mod orphan_pages;
 pub mod cross_refs;

--- a/src/rules/orphan_pages.rs
+++ b/src/rules/orphan_pages.rs
@@ -3,6 +3,7 @@ use crate::report::Report;
 use petgraph::visit::Dfs;
 use std::collections::HashSet;
 
+/// Report unreachable or orphan pages based on graph reachability.
 pub fn check_orphans(graph: &Graph, report: &mut Report) {
     let avg_out = if graph.graph.node_count() > 0 {
         graph.graph.edge_count() as f64 / graph.graph.node_count() as f64


### PR DESCRIPTION
## Summary
- add missing rustdoc comments across public API surface
- document CLI args, config helpers, filters, graph normalization, and rules
- include crate-level usage example

## Testing
- `cargo doc --no-deps`
