### PR TITLE
Release v0.1.2: Tier 0/1 indexing, hybrid query, and security hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "lint-ai"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "Inflector",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lint-ai"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Semantic wiki and docs linting for contradictions, stale claims, orphan pages, and missing cross-references"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The query pipeline uses hybrid scoring with:
 
 Download the latest release binary from the GitHub Releases page for this repo, then verify the checksum.
 
-Release artifacts (v0.1.0):
+Release artifacts (v0.1.2):
 
 ```
 lint-ai-linux-x86_64

--- a/docs/releases/0.1.2.md
+++ b/docs/releases/0.1.2.md
@@ -1,0 +1,55 @@
+# Release Notes: v0.1.2
+
+## Summary
+This release introduces Tier 0/Tier 1 indexing foundations, hybrid retrieval, and security hardening for indexing/query workflows.
+
+## Highlights
+
+### Tier 0
+- Added structured Tier 0 ingestion records per document:
+  - `id`, `source`, `timestamp`, `author_agent`, `doc_length`, `metadata`
+- Added Tier 0 index output command:
+  - `--tier0-index-out` (defaults to `tier0-index.json`)
+
+### Tier 1
+- Added Tier 1 key-entity extraction with pluggable rankers:
+  - `heuristic`
+  - `spacy` (local subprocess integration)
+- Added Tier 1 important-term extraction with pluggable rankers:
+  - `yake`, `rake`, `cvalue`, `textrank`
+
+### Hybrid In-Memory Indexing and Query
+- Added in-memory index build and query flow:
+  - `--index`
+  - `--query "..."`
+- Added hybrid scoring and score breakdown in query output.
+- Added BM25 lexical component via Tantivy, combined with:
+  - entity overlap
+  - term overlap
+  - topic/doc-type boosts
+
+### Security and Safety Hardening
+- Redacted raw `content` from serialized index output.
+- Added `--index-redacted` mode for safer index sharing.
+- Added spaCy model allowlist in `scripts/spacy_ner.py`.
+- Added spaCy subprocess timeout and kill behavior.
+- Added warning logs for lexical index/query fallback conditions.
+- Added query length and token caps for defensive resource control.
+
+## CLI Additions and Changes
+- Added:
+  - `--show-tier0`
+  - `--show-tier1-entities`
+  - `--show-tier1-terms`
+  - `--tier1-ner-provider`
+  - `--tier1-term-ranker`
+  - `--index`
+  - `--index-redacted`
+  - `--query`
+- Renamed query/index flow from earlier memory-prefixed naming to:
+  - `--index`
+  - `--query`
+
+## Upgrade Notes
+- Rust toolchain was upgraded during development to ensure dependency compatibility with current search stack.
+- Existing lint commands remain available; new indexing/query commands are additive.

--- a/scripts/spacy_ner.py
+++ b/scripts/spacy_ner.py
@@ -2,6 +2,12 @@
 import json
 import sys
 
+ALLOWED_MODELS = {
+    "en_core_web_sm",
+    "en_core_web_md",
+    "en_core_web_lg",
+}
+
 
 def main() -> int:
     try:
@@ -11,6 +17,19 @@ def main() -> int:
         return 2
 
     model = payload.get("model", "en_core_web_sm")
+    if model not in ALLOWED_MODELS:
+        print(
+            json.dumps(
+                {
+                    "error": (
+                        f"spacy_model_not_allowed({model}); "
+                        f"allowed={sorted(ALLOWED_MODELS)}"
+                    )
+                }
+            ),
+            file=sys.stderr,
+        )
+        return 5
     docs = payload.get("documents", [])
 
     try:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,8 @@ pub struct Args {
     #[arg(long)]
     pub index: bool,
     #[arg(long)]
+    pub index_redacted: bool,
+    #[arg(long)]
     pub query: Option<String>,
     #[arg(long, num_args = 0..=1, default_missing_value = "tier0-index.json")]
     pub tier0_index_out: Option<String>,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -593,9 +593,17 @@ fn build_memory_index(
                 model: spacy_model.to_string(),
                 script_path: "scripts/spacy_ner.py".to_string(),
             };
-            spacy
-                .rank_docs(&docs)
-                .unwrap_or_else(|_| heuristic.rank_docs(&docs).unwrap_or_default())
+            match spacy.rank_docs(&docs) {
+                Ok(out) => out,
+                Err(err) => {
+                    eprintln!(
+                        "warning: {} ranker unavailable ({}), falling back to heuristic",
+                        spacy.name(),
+                        err
+                    );
+                    heuristic.rank_docs(&docs).unwrap_or_default()
+                }
+            }
         }
     };
 
@@ -744,7 +752,7 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         show_tier1_terms(&graph, &args.tier1_term_ranker)?;
         return Ok(());
     }
-    if args.index || args.query.is_some() {
+    if args.index || args.index_redacted || args.query.is_some() {
         let index = build_memory_index(
             &graph,
             &args.tier1_ner_provider,
@@ -754,6 +762,8 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         if let Some(query) = args.query.as_deref() {
             let results = index.query(query, 20);
             println!("{}", serde_json::to_string_pretty(&results)?);
+        } else if args.index_redacted {
+            println!("{}", serde_json::to_string_pretty(&index.redacted_for_export())?);
         } else {
             println!("{}", serde_json::to_string_pretty(&index)?);
         }

--- a/src/index.rs
+++ b/src/index.rs
@@ -6,9 +6,9 @@ use serde::Serialize;
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
 use tantivy::schema::document::TantivyDocument;
-use tantivy::schema::{Schema, STORED, STRING, TEXT};
+use tantivy::schema::{Field, Schema, STORED, STRING, TEXT};
 use tantivy::schema::Value;
-use tantivy::{doc, Index};
+use tantivy::{doc, Index, IndexReader};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Serialize)]
@@ -32,6 +32,7 @@ pub struct Claim {
 pub struct DocRecord {
     pub doc_id: String,
     pub source: String,
+    #[serde(skip_serializing)]
     pub content: String,
     pub timestamp: Option<String>,
     pub doc_length: usize,
@@ -58,13 +59,25 @@ pub struct TermPosting {
     pub score: f32,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Serialize)]
 pub struct MemoryIndex {
     pub docs: HashMap<String, DocRecord>,
     pub entity_to_docs: HashMap<String, Vec<EntityPosting>>,
     pub term_to_docs: HashMap<String, Vec<TermPosting>>,
     pub topic_to_docs: HashMap<String, Vec<String>>,
     pub doc_type_to_docs: HashMap<String, Vec<String>>,
+    #[serde(skip_serializing)]
+    lexical: Option<LexicalIndex>,
+}
+
+struct LexicalIndex {
+    index: Index,
+    reader: IndexReader,
+    doc_id_f: Field,
+    content_f: Field,
+    headings_f: Field,
+    terms_f: Field,
+    entities_f: Field,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]
@@ -87,6 +100,24 @@ pub struct SearchResult {
     pub matched_terms: Vec<String>,
     pub probable_topic: Option<String>,
     pub doc_type_guess: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RedactedDocRecord {
+    pub doc_id: String,
+    pub source: String,
+    pub timestamp: Option<String>,
+    pub doc_length: usize,
+    pub probable_topic: Option<String>,
+    pub doc_type_guess: Option<String>,
+    pub provenance: Provenance,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RedactedMemoryIndex {
+    pub docs: HashMap<String, RedactedDocRecord>,
+    pub topic_to_docs: HashMap<String, Vec<String>>,
+    pub doc_type_to_docs: HashMap<String, Vec<String>>,
 }
 
 impl MemoryIndex {
@@ -156,16 +187,25 @@ impl MemoryIndex {
             });
         }
 
+        let lexical = match Self::build_lexical_index(&docs) {
+            Ok(index) => Some(index),
+            Err(err) => {
+                eprintln!("warning: lexical BM25 index disabled: {}", err);
+                None
+            }
+        };
+
         Self {
             docs,
             entity_to_docs,
             term_to_docs,
             topic_to_docs,
             doc_type_to_docs,
+            lexical,
         }
     }
 
-    fn lexical_bm25(&self, query: &str, top_k: usize) -> Result<HashMap<String, f32>> {
+    fn build_lexical_index(docs: &HashMap<String, DocRecord>) -> Result<LexicalIndex> {
         let mut schema_builder = Schema::builder();
         let doc_id_f = schema_builder.add_text_field("doc_id", STRING | STORED);
         let content_f = schema_builder.add_text_field("content", TEXT);
@@ -174,9 +214,9 @@ impl MemoryIndex {
         let entities_f = schema_builder.add_text_field("entities", TEXT);
         let schema = schema_builder.build();
 
-        let index = Index::create_in_ram(schema.clone());
+        let index = Index::create_in_ram(schema);
         let mut writer = index.writer(50_000_000)?;
-        for doc in self.docs.values() {
+        for doc in docs.values() {
             let headings_text = doc.headings.join(" ");
             let terms_text = doc
                 .important_terms
@@ -200,21 +240,35 @@ impl MemoryIndex {
         }
         writer.commit()?;
         let reader = index.reader()?;
-        let searcher = reader.searcher();
+        Ok(LexicalIndex {
+            index,
+            reader,
+            doc_id_f,
+            content_f,
+            headings_f,
+            terms_f,
+            entities_f,
+        })
+    }
 
+    fn lexical_bm25(&self, query: &str, top_k: usize) -> Result<HashMap<String, f32>> {
+        let Some(lex) = self.lexical.as_ref() else {
+            return Ok(HashMap::new());
+        };
+        let searcher = lex.reader.searcher();
         let mut query_parser =
-            QueryParser::for_index(&index, vec![content_f, headings_f, terms_f, entities_f]);
-        query_parser.set_field_boost(content_f, 1.0);
-        query_parser.set_field_boost(headings_f, 1.4);
-        query_parser.set_field_boost(terms_f, 2.0);
-        query_parser.set_field_boost(entities_f, 2.4);
+            QueryParser::for_index(&lex.index, vec![lex.content_f, lex.headings_f, lex.terms_f, lex.entities_f]);
+        query_parser.set_field_boost(lex.content_f, 1.0);
+        query_parser.set_field_boost(lex.headings_f, 1.4);
+        query_parser.set_field_boost(lex.terms_f, 2.0);
+        query_parser.set_field_boost(lex.entities_f, 2.4);
         let parsed = query_parser.parse_query(query)?;
         let top_docs = searcher.search(&parsed, &TopDocs::with_limit(top_k))?;
 
         let mut out = HashMap::new();
         for (score, addr) in top_docs {
             let retrieved: TantivyDocument = searcher.doc(addr)?;
-            if let Some(v) = retrieved.get_first(doc_id_f) {
+            if let Some(v) = retrieved.get_first(lex.doc_id_f) {
                 if let Some(doc_id) = v.as_str() {
                     out.insert(doc_id.to_string(), score);
                 }
@@ -224,11 +278,29 @@ impl MemoryIndex {
     }
 
     pub fn query(&self, query: &str, top_k: usize) -> Vec<SearchResult> {
-        let q = normalize_for_index(query);
+        const MAX_QUERY_CHARS: usize = 4096;
+        const MAX_QUERY_TOKENS: usize = 128;
+
+        let truncated = if query.len() > MAX_QUERY_CHARS {
+            let mut cut = 0usize;
+            for (idx, _) in query.char_indices() {
+                if idx > MAX_QUERY_CHARS {
+                    break;
+                }
+                cut = idx;
+            }
+            &query[..cut]
+        } else {
+            query
+        };
+        let q = normalize_for_index(truncated);
         if q.is_empty() {
             return Vec::new();
         }
         let mut q_terms: Vec<String> = tokenize_query_terms(&q);
+        if q_terms.len() > MAX_QUERY_TOKENS {
+            q_terms.truncate(MAX_QUERY_TOKENS);
+        }
         if q_terms.is_empty() {
             q_terms.push(q.clone());
         }
@@ -239,10 +311,15 @@ impl MemoryIndex {
         let mut matched_terms: HashMap<String, Vec<String>> = HashMap::new();
         let query_set: HashSet<String> = q_terms.iter().cloned().collect();
 
-        if let Ok(lexical_hits) = self.lexical_bm25(&q, top_k.saturating_mul(5).max(20)) {
-            for (doc_id, bm25_score) in lexical_hits {
-                *scores.entry(doc_id.clone()).or_insert(0.0) += bm25_score;
-                breakdowns.entry(doc_id).or_default().lexical_score += bm25_score;
+        match self.lexical_bm25(&q, top_k.saturating_mul(5).max(20)) {
+            Ok(lexical_hits) => {
+                for (doc_id, bm25_score) in lexical_hits {
+                    *scores.entry(doc_id.clone()).or_insert(0.0) += bm25_score;
+                    breakdowns.entry(doc_id).or_default().lexical_score += bm25_score;
+                }
+            }
+            Err(err) => {
+                eprintln!("warning: lexical BM25 query component failed: {}", err);
             }
         }
 
@@ -345,6 +422,32 @@ impl MemoryIndex {
         });
         out.truncate(top_k);
         out
+    }
+
+    pub fn redacted_for_export(&self) -> RedactedMemoryIndex {
+        let docs = self
+            .docs
+            .iter()
+            .map(|(id, d)| {
+                (
+                    id.clone(),
+                    RedactedDocRecord {
+                        doc_id: d.doc_id.clone(),
+                        source: d.source.clone(),
+                        timestamp: d.timestamp.clone(),
+                        doc_length: d.doc_length,
+                        probable_topic: d.probable_topic.clone(),
+                        doc_type_guess: d.doc_type_guess.clone(),
+                        provenance: d.provenance.clone(),
+                    },
+                )
+            })
+            .collect();
+        RedactedMemoryIndex {
+            docs,
+            topic_to_docs: self.topic_to_docs.clone(),
+            doc_type_to_docs: self.doc_type_to_docs.clone(),
+        }
     }
 }
 

--- a/src/tier1.rs
+++ b/src/tier1.rs
@@ -5,6 +5,8 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone)]
 pub struct Tier1DocInput {
@@ -277,6 +279,24 @@ impl KeyEntityRanker for SpacyKeyEntityRanker {
             .spawn()?;
         if let Some(stdin) = child.stdin.as_mut() {
             stdin.write_all(input_json.as_bytes())?;
+        }
+        let timeout = Duration::from_secs(20);
+        let start = Instant::now();
+        loop {
+            if let Some(status) = child.try_wait()? {
+                if !status.success() {
+                    let output = child.wait_with_output()?;
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    anyhow::bail!("spaCy subprocess failed: {}", stderr.trim());
+                }
+                break;
+            }
+            if start.elapsed() >= timeout {
+                let _ = child.kill();
+                let _ = child.wait();
+                anyhow::bail!("spaCy subprocess timed out after {}s", timeout.as_secs());
+            }
+            sleep(Duration::from_millis(50));
         }
         let output = child.wait_with_output()?;
         if !output.status.success() {


### PR DESCRIPTION
## Release v0.1.2

This PR prepares v0.1.2 with version bump, release notes, indexing/query improvements, and security hardening.

## Included
- bump crate version to `0.1.2`
- add release note: `docs/releases/0.1.2.md`
- update README release section label to `v0.1.2`
- security fixes:
  - hide raw document `content` in serialized `--index` output
  - add `--index-redacted` mode
  - add spaCy model allowlist
  - add spaCy subprocess timeout/kill behavior
  - add warnings for lexical fallback paths
  - add query length/token caps
- hybrid retrieval improvements remain in place (`--index`, `--query`, BM25 + entity/term signals)

## Validation
- `cargo test -q` passes

## Release tagging
- annotated tag planned: `v0.1.2`