### PR TITLE
Release v0.1.3: indexing performance, chunk strategy, and cache correctness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,11 +650,12 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "lint-ai"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "Inflector",
  "aho-corasick",
  "anyhow",
+ "bincode",
  "clap",
  "comrak",
  "deunicode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lint-ai"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Semantic wiki and docs linting for contradictions, stale claims, orphan pages, and missing cross-references"
 license = "Apache-2.0"
@@ -28,3 +28,4 @@ unicode-normalization = "0.1"
 deunicode = "1"
 petgraph = "0.5"
 tantivy = "0.22"
+bincode = "1.3"

--- a/README.md
+++ b/README.md
@@ -75,17 +75,6 @@ Lint-AI builds on techniques such as:
 
 These are used as part of a larger system for fact extraction and alignment reasoning.
 
-## What Lint-AI is NOT
-
-Lint-AI is not:
-- a Markdown style checker
-- a grammar tool
-- a fixed template enforcer
-
-It does not require documents to follow a rigid schema.
-
-Instead, it focuses on understanding what documents *mean* and how they relate to each other.
-
 ## Usage
 
 ### How To Use
@@ -148,6 +137,18 @@ Query the corpus (index is built automatically behind the scenes):
 ./lint-ai --query "docker install linux" /path/to/repo/docs
 ```
 
+Query output includes:
+- `query`
+- `elapsed_ms`
+- `result_count`
+- `results`
+
+Chunking options:
+
+```bash
+./lint-ai --index /path/to/repo/docs --chunk-strategy hybrid --chunk-lines 40 --chunk-overlap 10 --chunk-target-tokens 450 --chunk-max-tokens 800
+```
+
 The query pipeline uses hybrid scoring with:
 - BM25 lexical scoring
 - key-entity overlap
@@ -155,11 +156,13 @@ The query pipeline uses hybrid scoring with:
 - topic/doc-type boosts when available
 - score breakdown output for transparency
 
+Chunk strategy details: `docs/chunk-strategy.md`
+
 ### Download Release Binaries
 
 Download the latest release binary from the GitHub Releases page for this repo, then verify the checksum.
 
-Release artifacts (v0.1.2):
+Release artifacts (v0.1.3):
 
 ```
 lint-ai-linux-x86_64

--- a/data/lexical/conceptnet_subset.json
+++ b/data/lexical/conceptnet_subset.json
@@ -1,0 +1,38 @@
+[
+  {
+    "term": "install",
+    "related": [
+      {"term": "bootstrap", "relation": "RelatedTo", "confidence": 0.91},
+      {"term": "provision", "relation": "SimilarTo", "confidence": 0.88},
+      {"term": "set up", "relation": "Synonym", "confidence": 0.96}
+    ]
+  },
+  {
+    "term": "docker",
+    "related": [
+      {"term": "containerization", "relation": "RelatedTo", "confidence": 0.89},
+      {"term": "podman", "relation": "SimilarTo", "confidence": 0.83}
+    ]
+  },
+  {
+    "term": "query",
+    "related": [
+      {"term": "search", "relation": "Synonym", "confidence": 0.95},
+      {"term": "lookup", "relation": "SimilarTo", "confidence": 0.84}
+    ]
+  },
+  {
+    "term": "drift",
+    "related": [
+      {"term": "divergence", "relation": "SimilarTo", "confidence": 0.86},
+      {"term": "misalignment", "relation": "RelatedTo", "confidence": 0.9}
+    ]
+  },
+  {
+    "term": "virtual machine",
+    "related": [
+      {"term": "vm", "relation": "Synonym", "confidence": 0.97},
+      {"term": "compute instance", "relation": "SimilarTo", "confidence": 0.84}
+    ]
+  }
+]

--- a/data/lexical/wordnet_subset.json
+++ b/data/lexical/wordnet_subset.json
@@ -1,0 +1,38 @@
+[
+  {
+    "term": "install",
+    "related": [
+      {"term": "setup", "relation": "Synonym", "confidence": 0.98},
+      {"term": "configure", "relation": "SimilarTo", "confidence": 0.86},
+      {"term": "deploy", "relation": "SimilarTo", "confidence": 0.84}
+    ]
+  },
+  {
+    "term": "docker",
+    "related": [
+      {"term": "container", "relation": "SimilarTo", "confidence": 0.87},
+      {"term": "container runtime", "relation": "SimilarTo", "confidence": 0.83}
+    ]
+  },
+  {
+    "term": "linux",
+    "related": [
+      {"term": "gnu linux", "relation": "Synonym", "confidence": 0.95},
+      {"term": "unix-like", "relation": "SimilarTo", "confidence": 0.81}
+    ]
+  },
+  {
+    "term": "auth",
+    "related": [
+      {"term": "authentication", "relation": "Synonym", "confidence": 0.97},
+      {"term": "authorization", "relation": "RelatedTo", "confidence": 0.72}
+    ]
+  },
+  {
+    "term": "vm",
+    "related": [
+      {"term": "virtual machine", "relation": "Synonym", "confidence": 0.97},
+      {"term": "instance", "relation": "SimilarTo", "confidence": 0.79}
+    ]
+  }
+]

--- a/docs/chunk-strategy.md
+++ b/docs/chunk-strategy.md
@@ -1,0 +1,90 @@
+# Chunk Strategy Design
+
+This document defines how Lint-AI chunks documents for Tier 1 indexing and query retrieval.
+
+## Goals
+- Keep chunks small enough for LLM context windows.
+- Keep chunk IDs stable enough for incremental updates.
+- Preserve document structure where possible.
+
+## Available Strategies
+
+### 1. `heading` (default)
+Splits content by Markdown headings (`#` to `######`).
+
+Rules:
+- Text before first heading becomes a `(document)` chunk.
+- Each heading section becomes one chunk.
+- If no headings exist, the whole file is one chunk.
+
+Best for:
+- Well-structured Markdown docs.
+- Section-aware retrieval and explanation.
+
+### 2. `line`
+Splits by fixed line windows.
+
+Rules:
+- Uses `--chunk-lines` as window size.
+- Uses `--chunk-overlap` as overlap between windows.
+- Produces line-ranged headings like `lines 1-40`.
+
+Best for:
+- Stable diffs and incremental updates.
+- Documents with weak heading quality.
+
+### 3. `hybrid`
+Line-stable chunking + token-aware splitting.
+
+Rules:
+- First chunk by line windows (`--chunk-lines`, `--chunk-overlap`).
+- Estimate token size for each line chunk.
+- If chunk exceeds token budget, split further into smaller parts.
+- Controlled by:
+  - `--chunk-target-tokens` (preferred size)
+  - `--chunk-max-tokens` (hard cap)
+
+Best for:
+- LLM context-fit retrieval with stable change tracking.
+- Large documents where fixed line windows can be too large.
+
+## CLI Flags
+- `--chunk-strategy heading|line|hybrid`
+- `--chunk-lines <N>` (default: `40`)
+- `--chunk-overlap <N>` (default: `10`)
+- `--chunk-target-tokens <N>` (default: `450`)
+- `--chunk-max-tokens <N>` (default: `800`)
+
+## Recommended Defaults
+For general use:
+- `--chunk-strategy hybrid`
+- `--chunk-lines 40`
+- `--chunk-overlap 10`
+- `--chunk-target-tokens 450`
+- `--chunk-max-tokens 800`
+
+## Example Commands
+Build index with hybrid chunking:
+
+```bash
+./target/debug/lint-ai --index /path/to/docs --chunk-strategy hybrid --chunk-lines 40 --chunk-overlap 10 --chunk-target-tokens 450 --chunk-max-tokens 800
+```
+
+Query with same chunk strategy:
+
+```bash
+./target/debug/lint-ai --query "linux install docker compose" /path/to/docs --chunk-strategy hybrid
+```
+
+## Notes on Caching
+Query cache validity includes chunk settings. Changing strategy or chunk parameters triggers rebuild.
+
+## Internal Chunk Schema
+Each chunk stores:
+- `chunk_id`
+- `heading`
+- `content`
+- `key_entities`
+- `important_terms`
+
+Chunk IDs are generated as `doc_id::index`.

--- a/docs/releases/0.1.3.md
+++ b/docs/releases/0.1.3.md
@@ -1,0 +1,47 @@
+# Release Notes: v0.1.3
+
+## Summary
+This release improves query performance, chunk-aware indexing internals, and cache correctness for repeated query workflows.
+
+## Highlights
+
+### Query and Index Performance
+- Added persistent Tantivy lexical index reuse across CLI runs.
+- Added binary core snapshot cache for fast in-memory index restoration.
+- Added dense `doc_u32` score accumulators and segment-tree top-k selection.
+- Added trie-backed term/entity lookup with conservative prefix fallback.
+
+### Chunking and Retrieval Structure
+- Added section chunk metadata with line ranges (`start_line`, `end_line`).
+- Added `hybrid` chunking strategy (line-stable + token-aware splitting).
+- Added configurable chunk parameters:
+  - `--chunk-strategy heading|line|hybrid`
+  - `--chunk-lines`
+  - `--chunk-overlap`
+  - `--chunk-target-tokens`
+  - `--chunk-max-tokens`
+
+### Incremental/Change Awareness
+- Added corpus fingerprint validation for cache reuse.
+- Fingerprint now includes content hashing for robust change detection.
+- Cache reload now rebuilds only when source corpus/settings fingerprints differ.
+
+### Query Output and UX
+- Query output now includes elapsed time metadata:
+  - `elapsed_ms`
+  - `result_count`
+  - `results`
+- Deduplicated `matched_entities` and `matched_terms` in query results.
+
+### Internal Data Structures
+- Added chunk-level postings and forward indexes.
+- Added doc↔chunk adjacency mappings.
+- Added interval-tree support for changed line-range to chunk impact mapping.
+
+## Compatibility
+- Existing CLI commands remain compatible.
+- Query command remains:
+  - `--query "..."`
+- Index command remains:
+  - `--index`
+- JSON cache remains available for readability; binary cache is additive.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,13 @@ pub enum Tier1TermRankerKind {
     Textrank,
 }
 
+#[derive(Debug, Clone, ValueEnum)]
+pub enum ChunkStrategy {
+    Heading,
+    Line,
+    Hybrid,
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "lint-ai")]
 /// CLI arguments for the lint-ai binary.
@@ -43,6 +50,16 @@ pub struct Args {
     pub tier1_term_ranker: Tier1TermRankerKind,
     #[arg(long, default_value = "en_core_web_sm")]
     pub spacy_model: String,
+    #[arg(long, value_enum, default_value = "heading")]
+    pub chunk_strategy: ChunkStrategy,
+    #[arg(long, default_value_t = 40)]
+    pub chunk_lines: usize,
+    #[arg(long, default_value_t = 10)]
+    pub chunk_overlap: usize,
+    #[arg(long, default_value_t = 450)]
+    pub chunk_target_tokens: usize,
+    #[arg(long, default_value_t = 800)]
+    pub chunk_max_tokens: usize,
     #[arg(long)]
     pub debug_matches: bool,
     #[arg(long)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,8 +1,8 @@
-use crate::cli::{Tier1NerProvider, Tier1TermRankerKind};
+use crate::cli::{ChunkStrategy, Tier1NerProvider, Tier1TermRankerKind};
 use crate::config::{load_config, normalize_list, Config};
 use crate::filters::is_noise_concept;
 use crate::graph::{normalize_concept, Graph, Tier0Record};
-use crate::index::{DocRecord, MemoryIndex, Provenance};
+use crate::index::{DocRecord, MemoryIndex, Provenance, SectionChunk};
 use crate::report::Report;
 use crate::rules::cross_refs::check_cross_refs;
 use crate::rules::orphan_pages::check_orphans;
@@ -19,12 +19,15 @@ use comrak::{
 };
 use deunicode::deunicode;
 use inflector::Inflector;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
-use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use unicode_normalization::UnicodeNormalization;
+use regex::Regex;
+use walkdir::WalkDir;
 
 fn surface_forms(raw: &str) -> Vec<String> {
     let raw = raw.trim();
@@ -567,11 +570,256 @@ fn select_term_ranker(ranker_kind: &Tier1TermRankerKind) -> Box<dyn ImportantTer
     }
 }
 
+fn chunk_document_sections(content: &str, doc_id: &str) -> Vec<SectionChunk> {
+    let heading_re = Regex::new(r"(?m)^#{1,6}\s+(.*)$").expect("valid heading regex");
+    let mut chunks = Vec::new();
+    let mut last_start = 0usize;
+    let mut current_heading = "(document)".to_string();
+    let mut idx = 0usize;
+
+    for cap in heading_re.captures_iter(content) {
+        let m = match cap.get(0) {
+            Some(v) => v,
+            None => continue,
+        };
+        if m.start() > last_start {
+            let body = content[last_start..m.start()].trim();
+            if !body.is_empty() {
+                let start_line = content[..last_start].lines().count().max(1);
+                let end_line = content[..m.start()].lines().count().max(start_line);
+                chunks.push(SectionChunk {
+                    chunk_id: format!("{}::{}", doc_id, idx),
+                    heading: current_heading.clone(),
+                    content: body.to_string(),
+                    start_line,
+                    end_line,
+                    key_entities: Vec::new(),
+                    important_terms: Vec::new(),
+                });
+                idx += 1;
+            }
+        }
+        current_heading = cap
+            .get(1)
+            .map(|v| v.as_str().trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "(section)".to_string());
+        last_start = m.end();
+    }
+
+    let tail = content[last_start..].trim();
+    if !tail.is_empty() {
+        let start_line = content[..last_start].lines().count().max(1);
+        let end_line = content.lines().count().max(start_line);
+        chunks.push(SectionChunk {
+            chunk_id: format!("{}::{}", doc_id, idx),
+            heading: current_heading,
+            content: tail.to_string(),
+            start_line,
+            end_line,
+            key_entities: Vec::new(),
+            important_terms: Vec::new(),
+        });
+    }
+
+    if chunks.is_empty() {
+        chunks.push(SectionChunk {
+            chunk_id: format!("{}::0", doc_id),
+            heading: "(document)".to_string(),
+            content: content.to_string(),
+            start_line: 1,
+            end_line: content.lines().count().max(1),
+            key_entities: Vec::new(),
+            important_terms: Vec::new(),
+        });
+    }
+    chunks
+}
+
+fn chunk_document_lines(
+    content: &str,
+    doc_id: &str,
+    lines_per_chunk: usize,
+    overlap: usize,
+) -> Vec<SectionChunk> {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        return vec![SectionChunk {
+            chunk_id: format!("{}::0", doc_id),
+            heading: "(document)".to_string(),
+            content: content.to_string(),
+            start_line: 1,
+            end_line: 1,
+            key_entities: Vec::new(),
+            important_terms: Vec::new(),
+        }];
+    }
+    let size = lines_per_chunk.clamp(1, 500);
+    let ov = overlap.min(size.saturating_sub(1));
+    let step = (size - ov).max(1);
+
+    let mut chunks = Vec::new();
+    let mut idx = 0usize;
+    let mut start = 0usize;
+    while start < lines.len() {
+        let end = (start + size).min(lines.len());
+        let body = lines[start..end].join("\n").trim().to_string();
+        if !body.is_empty() {
+            chunks.push(SectionChunk {
+                chunk_id: format!("{}::{}", doc_id, idx),
+                heading: format!("lines {}-{}", start + 1, end),
+                content: body,
+                start_line: start + 1,
+                end_line: end,
+                key_entities: Vec::new(),
+                important_terms: Vec::new(),
+            });
+            idx += 1;
+        }
+        if end == lines.len() {
+            break;
+        }
+        start += step;
+    }
+    if chunks.is_empty() {
+        chunks.push(SectionChunk {
+            chunk_id: format!("{}::0", doc_id),
+            heading: "(document)".to_string(),
+            content: content.to_string(),
+            start_line: 1,
+            end_line: lines.len().max(1),
+            key_entities: Vec::new(),
+            important_terms: Vec::new(),
+        });
+    }
+    chunks
+}
+
+fn estimate_tokens(text: &str) -> usize {
+    let words = text.split_whitespace().count();
+    ((words as f32) * 1.3).ceil() as usize
+}
+
+fn chunk_document_hybrid(
+    content: &str,
+    doc_id: &str,
+    lines_per_chunk: usize,
+    overlap: usize,
+    target_tokens: usize,
+    max_tokens: usize,
+) -> Vec<SectionChunk> {
+    let base = chunk_document_lines(content, doc_id, lines_per_chunk, overlap);
+    let mut out = Vec::new();
+    let mut idx = 0usize;
+    let safe_target = target_tokens.clamp(100, max_tokens.max(100));
+    let safe_max = max_tokens.max(safe_target);
+
+    for chunk in base {
+        if estimate_tokens(&chunk.content) <= safe_max {
+            out.push(SectionChunk {
+                chunk_id: format!("{}::{}", doc_id, idx),
+                heading: chunk.heading,
+                content: chunk.content,
+                start_line: chunk.start_line,
+                end_line: chunk.end_line,
+                key_entities: Vec::new(),
+                important_terms: Vec::new(),
+            });
+            idx += 1;
+            continue;
+        }
+
+        let lines: Vec<&str> = chunk.content.lines().collect();
+        let mut start = 0usize;
+        while start < lines.len() {
+            let mut end = start + 1;
+            let mut best_end = end;
+            while end <= lines.len() {
+                let candidate = lines[start..end].join("\n");
+                let toks = estimate_tokens(&candidate);
+                if toks <= safe_target {
+                    best_end = end;
+                    end += 1;
+                    continue;
+                }
+                if toks <= safe_max && best_end == start + 1 {
+                    best_end = end;
+                }
+                break;
+            }
+            if best_end <= start {
+                best_end = (start + 1).min(lines.len());
+            }
+            let body = lines[start..best_end].join("\n").trim().to_string();
+            if !body.is_empty() {
+                out.push(SectionChunk {
+                    chunk_id: format!("{}::{}", doc_id, idx),
+                    heading: format!("{} (part {})", chunk.heading, idx),
+                    content: body,
+                    start_line: chunk.start_line.saturating_add(start),
+                    end_line: chunk.start_line.saturating_add(best_end).saturating_sub(1),
+                    key_entities: Vec::new(),
+                    important_terms: Vec::new(),
+                });
+                idx += 1;
+            }
+            if best_end == lines.len() {
+                break;
+            }
+            start = best_end;
+        }
+    }
+
+    if out.is_empty() {
+        return chunk_document_lines(content, doc_id, lines_per_chunk, overlap);
+    }
+    out
+}
+
+fn enrich_section_chunks(
+    mut chunks: Vec<SectionChunk>,
+    key_entities: &[crate::tier1::Tier1Entity],
+    important_terms: &[crate::tier1::RankedTerm],
+) -> Vec<SectionChunk> {
+    for chunk in &mut chunks {
+        let chunk_l = chunk.content.to_lowercase();
+        for ent in key_entities {
+            let term = ent.text.trim();
+            if term.len() < 2 {
+                continue;
+            }
+            if chunk_l.contains(&term.to_lowercase()) {
+                chunk.key_entities.push(term.to_string());
+            }
+        }
+        for term in important_terms {
+            let t = term.term.trim();
+            if t.len() < 2 {
+                continue;
+            }
+            if chunk_l.contains(&t.to_lowercase()) {
+                chunk.important_terms.push(t.to_string());
+            }
+        }
+        chunk.key_entities.sort();
+        chunk.key_entities.dedup();
+        chunk.important_terms.sort();
+        chunk.important_terms.dedup();
+    }
+    chunks
+}
+
 fn build_memory_index(
     graph: &Graph,
     provider: &Tier1NerProvider,
     spacy_model: &str,
     ranker_kind: &Tier1TermRankerKind,
+    chunk_strategy: &ChunkStrategy,
+    chunk_lines: usize,
+    chunk_overlap: usize,
+    chunk_target_tokens: usize,
+    chunk_max_tokens: usize,
+    lexical_dir: Option<&Path>,
 ) -> Result<MemoryIndex> {
     let docs: Vec<Tier1DocInput> = graph
         .pages
@@ -648,6 +896,21 @@ fn build_memory_index(
         } else {
             None
         };
+        let base_chunks = match chunk_strategy {
+            ChunkStrategy::Heading => chunk_document_sections(&doc.content, &doc.id),
+            ChunkStrategy::Line => {
+                chunk_document_lines(&doc.content, &doc.id, chunk_lines, chunk_overlap)
+            }
+            ChunkStrategy::Hybrid => chunk_document_hybrid(
+                &doc.content,
+                &doc.id,
+                chunk_lines,
+                chunk_overlap,
+                chunk_target_tokens,
+                chunk_max_tokens,
+            ),
+        };
+        let section_chunks = enrich_section_chunks(base_chunks, &key_entities, &important_terms);
         records.push(DocRecord {
             doc_id: doc.id.clone(),
             source: doc.source.clone(),
@@ -660,6 +923,7 @@ fn build_memory_index(
             headings: doc.headings.clone(),
             key_entities,
             important_terms,
+            section_chunks,
             embedding: None,
             top_claims: Vec::new(),
             provenance: Provenance {
@@ -671,7 +935,228 @@ fn build_memory_index(
             },
         });
     }
-    Ok(MemoryIndex::from_records(records))
+    Ok(MemoryIndex::from_records_with_lexical_dir(records, lexical_dir))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CachedQueryIndex {
+    version: String,
+    path: String,
+    ner_provider: String,
+    term_ranker: String,
+    spacy_model: String,
+    chunk_strategy: String,
+    chunk_lines: usize,
+    chunk_overlap: usize,
+    chunk_target_tokens: usize,
+    chunk_max_tokens: usize,
+    corpus_fingerprint: String,
+    records: Vec<DocRecord>,
+}
+
+const QUERY_CACHE_VERSION: &str = "v1-query-cache";
+
+#[derive(Debug, Clone)]
+struct CacheSettings<'a> {
+    root_path: &'a str,
+    ner_provider: &'a Tier1NerProvider,
+    term_ranker: &'a Tier1TermRankerKind,
+    spacy_model: &'a str,
+    chunk_strategy: &'a ChunkStrategy,
+    chunk_lines: usize,
+    chunk_overlap: usize,
+    chunk_target_tokens: usize,
+    chunk_max_tokens: usize,
+}
+
+fn query_cache_key(s: &CacheSettings<'_>) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    s.root_path.hash(&mut hasher);
+    format!("{:?}", s.ner_provider).to_lowercase().hash(&mut hasher);
+    format!("{:?}", s.term_ranker).to_lowercase().hash(&mut hasher);
+    s.spacy_model.hash(&mut hasher);
+    format!("{:?}", s.chunk_strategy).to_lowercase().hash(&mut hasher);
+    s.chunk_lines.hash(&mut hasher);
+    s.chunk_overlap.hash(&mut hasher);
+    s.chunk_target_tokens.hash(&mut hasher);
+    s.chunk_max_tokens.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn query_cache_file(s: &CacheSettings<'_>) -> PathBuf {
+    Path::new(".lint-ai-cache").join(format!("{}.json", query_cache_key(s)))
+}
+
+fn query_cache_lexical_dir(s: &CacheSettings<'_>) -> PathBuf {
+    Path::new(".lint-ai-cache").join(format!("{}.tantivy", query_cache_key(s)))
+}
+
+fn query_cache_core_file(s: &CacheSettings<'_>) -> PathBuf {
+    Path::new(".lint-ai-cache").join(format!("{}.core.bin", query_cache_key(s)))
+}
+
+fn fingerprint_base_path(root_path: &str) -> PathBuf {
+    let root = Path::new(root_path);
+    if root.is_file() {
+        return root.parent().unwrap_or(root).to_path_buf();
+    }
+    let docs = root.join("docs");
+    if docs.is_dir() {
+        docs
+    } else {
+        root.to_path_buf()
+    }
+}
+
+fn compute_corpus_fingerprint(
+    root_path: &str,
+    max_files: usize,
+    max_depth: usize,
+    max_total_bytes: usize,
+) -> String {
+    let root = Path::new(root_path);
+    let base = fingerprint_base_path(root_path);
+    let single_file = if root.is_file() {
+        Some(root.to_path_buf())
+    } else {
+        None
+    };
+    let rel_root = if root.is_file() {
+        base.clone()
+    } else {
+        root.to_path_buf()
+    };
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    root_path.hash(&mut hasher);
+    let mut files_seen = 0usize;
+    let mut total_bytes = 0usize;
+    let mut items: Vec<(String, u64, u64, u64)> = Vec::new();
+
+    for entry in WalkDir::new(base).max_depth(max_depth) {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if let Some(ref only) = single_file {
+            if entry.path() != only {
+                continue;
+            }
+        }
+        let ext = entry
+            .path()
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        if ext != "md" {
+            continue;
+        }
+        files_seen += 1;
+        if files_seen > max_files {
+            break;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        total_bytes = total_bytes.saturating_add(metadata.len() as usize);
+        if total_bytes > max_total_bytes {
+            break;
+        }
+        let rel = entry
+            .path()
+            .strip_prefix(&rel_root)
+            .unwrap_or(entry.path())
+            .display()
+            .to_string();
+        let mut mtime_secs = 0u64;
+        if let Ok(modified) = metadata.modified() {
+            if let Ok(dur) = modified.duration_since(UNIX_EPOCH) {
+                mtime_secs = dur.as_secs();
+            }
+        }
+        let content_hash = match fs::read(entry.path()) {
+            Ok(bytes) => {
+                let mut h = std::collections::hash_map::DefaultHasher::new();
+                bytes.hash(&mut h);
+                h.finish()
+            }
+            Err(_) => 0,
+        };
+        items.push((rel, metadata.len(), mtime_secs, content_hash));
+    }
+
+    items.sort_by(|a, b| a.0.cmp(&b.0));
+    for (rel, len, mtime_secs, content_hash) in items {
+        rel.hash(&mut hasher);
+        len.hash(&mut hasher);
+        mtime_secs.hash(&mut hasher);
+        content_hash.hash(&mut hasher);
+    }
+    format!("{:016x}", hasher.finish())
+}
+
+fn load_cached_query_index(s: &CacheSettings<'_>, corpus_fingerprint: &str) -> Option<MemoryIndex> {
+    let cache_file = query_cache_file(s);
+    let data = fs::read_to_string(&cache_file).ok()?;
+    let cached: CachedQueryIndex = serde_json::from_str(&data).ok()?;
+    if cached.version != QUERY_CACHE_VERSION
+        || cached.path != s.root_path
+        || cached.ner_provider != format!("{:?}", s.ner_provider).to_lowercase()
+        || cached.term_ranker != format!("{:?}", s.term_ranker).to_lowercase()
+        || cached.spacy_model != s.spacy_model
+        || cached.chunk_strategy != format!("{:?}", s.chunk_strategy).to_lowercase()
+        || cached.chunk_lines != s.chunk_lines
+        || cached.chunk_overlap != s.chunk_overlap
+        || cached.chunk_target_tokens != s.chunk_target_tokens
+        || cached.chunk_max_tokens != s.chunk_max_tokens
+        || cached.corpus_fingerprint != corpus_fingerprint
+    {
+        return None;
+    }
+    let lexical_dir = query_cache_lexical_dir(s);
+    let core_file = query_cache_core_file(s);
+    match MemoryIndex::load_with_binary_core(cached.records.clone(), &core_file, Some(&lexical_dir)) {
+        Ok(index) => return Some(index),
+        Err(err) => {
+            eprintln!("warning: binary core cache load failed (falling back): {}", err);
+        }
+    }
+    Some(MemoryIndex::from_records_with_lexical_dir(
+        cached.records,
+        Some(&lexical_dir),
+    ))
+}
+
+fn save_cached_query_index(
+    s: &CacheSettings<'_>,
+    corpus_fingerprint: &str,
+    index: &MemoryIndex,
+) -> Result<()> {
+    let cache_file = query_cache_file(s);
+    if let Some(parent) = cache_file.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let records = index.docs.values().cloned().collect::<Vec<_>>();
+    let payload = CachedQueryIndex {
+        version: QUERY_CACHE_VERSION.to_string(),
+        path: s.root_path.to_string(),
+        ner_provider: format!("{:?}", s.ner_provider).to_lowercase(),
+        term_ranker: format!("{:?}", s.term_ranker).to_lowercase(),
+        spacy_model: s.spacy_model.to_string(),
+        chunk_strategy: format!("{:?}", s.chunk_strategy).to_lowercase(),
+        chunk_lines: s.chunk_lines,
+        chunk_overlap: s.chunk_overlap,
+        chunk_target_tokens: s.chunk_target_tokens,
+        chunk_max_tokens: s.chunk_max_tokens,
+        corpus_fingerprint: corpus_fingerprint.to_string(),
+        records,
+    };
+    fs::write(cache_file, serde_json::to_string(&payload)?)?;
+    let core_file = query_cache_core_file(s);
+    index.save_binary_core(&core_file)?;
+    Ok(())
 }
 
 #[derive(Serialize)]
@@ -681,6 +1166,14 @@ struct Tier0IndexFile {
     path: String,
     document_count: usize,
     documents_by_id: BTreeMap<String, Tier0Record>,
+}
+
+#[derive(Serialize)]
+struct QueryOutput {
+    query: String,
+    elapsed_ms: u128,
+    result_count: usize,
+    results: Vec<crate::index::SearchResult>,
 }
 
 fn write_tier0_index(path: &str, records: &[Tier0Record], scanned_path: &str) -> Result<String> {
@@ -724,6 +1217,76 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         args.max_config_bytes,
     )
     .map_err(|err| anyhow::anyhow!(err))?;
+    if args.query.is_some() {
+        let cache_settings = CacheSettings {
+            root_path: &args.path,
+            ner_provider: &args.tier1_ner_provider,
+            term_ranker: &args.tier1_term_ranker,
+            spacy_model: &args.spacy_model,
+            chunk_strategy: &args.chunk_strategy,
+            chunk_lines: args.chunk_lines,
+            chunk_overlap: args.chunk_overlap,
+            chunk_target_tokens: args.chunk_target_tokens,
+            chunk_max_tokens: args.chunk_max_tokens,
+        };
+        let corpus_fingerprint = compute_corpus_fingerprint(
+            &args.path,
+            args.max_files,
+            args.max_depth,
+            args.max_total_bytes,
+        );
+        let lexical_dir = query_cache_lexical_dir(&cache_settings);
+        let index = if let Some(cached) = load_cached_query_index(&cache_settings, &corpus_fingerprint) {
+            cached
+        } else {
+            let mut graph = Graph::build(
+                &args.path,
+                args.max_bytes,
+                args.max_files,
+                args.max_depth,
+                args.max_total_bytes,
+            )?;
+            if !cfg.ignore_paths.is_empty() {
+                let ignore = normalize_list(&cfg.ignore_paths);
+                graph.pages.retain(|p| {
+                    let rel = p.rel_path.to_lowercase();
+                    !ignore.iter().any(|pat| rel.contains(pat))
+                });
+                let retained: HashSet<String> =
+                    graph.pages.iter().map(|p| p.rel_path.clone()).collect();
+                graph.tier0_records.retain(|r| retained.contains(&r.source));
+            }
+            let built = build_memory_index(
+                &graph,
+                &args.tier1_ner_provider,
+                &args.spacy_model,
+                &args.tier1_term_ranker,
+                &args.chunk_strategy,
+                args.chunk_lines,
+                args.chunk_overlap,
+                args.chunk_target_tokens,
+                args.chunk_max_tokens,
+                Some(&lexical_dir),
+            )?;
+            if let Err(err) = save_cached_query_index(&cache_settings, &corpus_fingerprint, &built) {
+                eprintln!("warning: unable to persist query cache: {}", err);
+            }
+            built
+        };
+        if let Some(query) = args.query.as_deref() {
+            let started = Instant::now();
+            let results = index.query(query, 20);
+            let payload = QueryOutput {
+                query: query.to_string(),
+                elapsed_ms: started.elapsed().as_millis(),
+                result_count: results.len(),
+                results,
+            };
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        }
+        return Ok(());
+    }
+
     let mut graph = Graph::build(
         &args.path,
         args.max_bytes,
@@ -752,17 +1315,41 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         show_tier1_terms(&graph, &args.tier1_term_ranker)?;
         return Ok(());
     }
-    if args.index || args.index_redacted || args.query.is_some() {
+    if args.index || args.index_redacted {
+        let cache_settings = CacheSettings {
+            root_path: &args.path,
+            ner_provider: &args.tier1_ner_provider,
+            term_ranker: &args.tier1_term_ranker,
+            spacy_model: &args.spacy_model,
+            chunk_strategy: &args.chunk_strategy,
+            chunk_lines: args.chunk_lines,
+            chunk_overlap: args.chunk_overlap,
+            chunk_target_tokens: args.chunk_target_tokens,
+            chunk_max_tokens: args.chunk_max_tokens,
+        };
+        let corpus_fingerprint = compute_corpus_fingerprint(
+            &args.path,
+            args.max_files,
+            args.max_depth,
+            args.max_total_bytes,
+        );
+        let lexical_dir = query_cache_lexical_dir(&cache_settings);
         let index = build_memory_index(
             &graph,
             &args.tier1_ner_provider,
             &args.spacy_model,
             &args.tier1_term_ranker,
+            &args.chunk_strategy,
+            args.chunk_lines,
+            args.chunk_overlap,
+            args.chunk_target_tokens,
+            args.chunk_max_tokens,
+            Some(&lexical_dir),
         )?;
-        if let Some(query) = args.query.as_deref() {
-            let results = index.query(query, 20);
-            println!("{}", serde_json::to_string_pretty(&results)?);
-        } else if args.index_redacted {
+        if let Err(err) = save_cached_query_index(&cache_settings, &corpus_fingerprint, &index) {
+            eprintln!("warning: unable to persist query cache: {}", err);
+        }
+        if args.index_redacted {
             println!("{}", serde_json::to_string_pretty(&index.redacted_for_export())?);
         } else {
             println!("{}", serde_json::to_string_pretty(&index)?);

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,8 +1,8 @@
+use crate::query_expansion::{expand_query_terms, normalize_for_index};
 use crate::tier1::{RankedTerm, Tier1Entity};
 use anyhow::Result;
-use deunicode::deunicode;
 use regex::Regex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
 use tantivy::schema::document::TantivyDocument;
@@ -10,8 +10,11 @@ use tantivy::schema::{Field, Schema, STORED, STRING, TEXT};
 use tantivy::schema::Value;
 use tantivy::{doc, Index, IndexReader};
 use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+use std::sync::OnceLock;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Provenance {
     pub source: String,
     pub timestamp: Option<String>,
@@ -20,7 +23,7 @@ pub struct Provenance {
     pub index_version: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Claim {
     pub subject: String,
     pub predicate: String,
@@ -28,7 +31,20 @@ pub struct Claim {
     pub confidence: f32,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SectionChunk {
+    pub chunk_id: String,
+    pub heading: String,
+    pub content: String,
+    #[serde(default)]
+    pub start_line: usize,
+    #[serde(default)]
+    pub end_line: usize,
+    pub key_entities: Vec<String>,
+    pub important_terms: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DocRecord {
     pub doc_id: String,
     pub source: String,
@@ -42,21 +58,176 @@ pub struct DocRecord {
     pub headings: Vec<String>,
     pub key_entities: Vec<Tier1Entity>,
     pub important_terms: Vec<RankedTerm>,
+    pub section_chunks: Vec<SectionChunk>,
     pub embedding: Option<Vec<f32>>,
     pub top_claims: Vec<Claim>,
     pub provenance: Provenance,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntityPosting {
     pub doc_id: String,
     pub score: f32,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TermPosting {
     pub doc_id: String,
     pub score: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ChunkMeta {
+    doc_u32: u32,
+    chunk_id: String,
+    start_line: usize,
+    end_line: usize,
+}
+
+#[derive(Debug, Default, Clone)]
+struct TrieNode {
+    children: HashMap<char, usize>,
+    value: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct LexiconTrie {
+    nodes: Vec<TrieNode>,
+}
+
+impl LexiconTrie {
+    fn new() -> Self {
+        Self {
+            nodes: vec![TrieNode::default()],
+        }
+    }
+
+    fn insert(&mut self, key: &str, value: u32) {
+        let mut cur = 0usize;
+        for ch in key.chars() {
+            let next = if let Some(idx) = self.nodes[cur].children.get(&ch) {
+                *idx
+            } else {
+                let idx = self.nodes.len();
+                self.nodes.push(TrieNode::default());
+                self.nodes[cur].children.insert(ch, idx);
+                idx
+            };
+            cur = next;
+        }
+        self.nodes[cur].value = Some(value);
+    }
+
+    fn get(&self, key: &str) -> Option<u32> {
+        let mut cur = 0usize;
+        for ch in key.chars() {
+            cur = *self.nodes.get(cur)?.children.get(&ch)?;
+        }
+        self.nodes.get(cur)?.value
+    }
+
+    fn prefix_ids(&self, prefix: &str, limit: usize) -> Vec<u32> {
+        let mut cur = 0usize;
+        for ch in prefix.chars() {
+            let Some(next) = self.nodes.get(cur).and_then(|n| n.children.get(&ch)).copied() else {
+                return Vec::new();
+            };
+            cur = next;
+        }
+        let mut out = Vec::new();
+        let mut stack = vec![cur];
+        while let Some(idx) = stack.pop() {
+            if let Some(v) = self.nodes[idx].value {
+                out.push(v);
+                if out.len() >= limit {
+                    break;
+                }
+            }
+            for next in self.nodes[idx].children.values() {
+                stack.push(*next);
+            }
+        }
+        out
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IntervalEntry {
+    start: usize,
+    end: usize,
+    chunk_u32: u32,
+}
+
+#[derive(Debug, Clone)]
+struct IntervalNode {
+    center: usize,
+    overlaps: Vec<IntervalEntry>,
+    left: Option<Box<IntervalNode>>,
+    right: Option<Box<IntervalNode>>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct IntervalTree {
+    root: Option<Box<IntervalNode>>,
+}
+
+impl IntervalTree {
+    fn build(entries: Vec<IntervalEntry>) -> Self {
+        fn build_rec(mut entries: Vec<IntervalEntry>) -> Option<Box<IntervalNode>> {
+            if entries.is_empty() {
+                return None;
+            }
+            let mut points = entries
+                .iter()
+                .map(|e| e.start + (e.end.saturating_sub(e.start) / 2))
+                .collect::<Vec<_>>();
+            points.sort_unstable();
+            let center = points[points.len() / 2];
+            let mut left = Vec::new();
+            let mut right = Vec::new();
+            let mut overlaps = Vec::new();
+            for e in entries.drain(..) {
+                if e.end < center {
+                    left.push(e);
+                } else if e.start > center {
+                    right.push(e);
+                } else {
+                    overlaps.push(e);
+                }
+            }
+            Some(Box::new(IntervalNode {
+                center,
+                overlaps,
+                left: build_rec(left),
+                right: build_rec(right),
+            }))
+        }
+        Self {
+            root: build_rec(entries),
+        }
+    }
+
+    fn query(&self, start: usize, end: usize) -> Vec<u32> {
+        fn walk(node: &Option<Box<IntervalNode>>, start: usize, end: usize, out: &mut Vec<u32>) {
+            let Some(node) = node else {
+                return;
+            };
+            for e in &node.overlaps {
+                if e.start <= end && start <= e.end {
+                    out.push(e.chunk_u32);
+                }
+            }
+            if start <= node.center {
+                walk(&node.left, start, end, out);
+            }
+            if end >= node.center {
+                walk(&node.right, start, end, out);
+            }
+        }
+        let mut out = Vec::new();
+        walk(&self.root, start, end, &mut out);
+        out
+    }
 }
 
 #[derive(Serialize)]
@@ -68,6 +239,41 @@ pub struct MemoryIndex {
     pub doc_type_to_docs: HashMap<String, Vec<String>>,
     #[serde(skip_serializing)]
     lexical: Option<LexicalIndex>,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    doc_id_to_u32: HashMap<String, u32>,
+    #[serde(skip_serializing)]
+    doc_u32_to_id: Vec<String>,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    chunk_id_to_u32: HashMap<String, u32>,
+    #[serde(skip_serializing)]
+    chunks: Vec<ChunkMeta>,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    doc_to_chunks: Vec<Vec<u32>>,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    term_lexicon: HashMap<String, u32>,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    entity_lexicon: HashMap<String, u32>,
+    #[serde(skip_serializing)]
+    term_postings_chunk: Vec<Vec<(u32, f32)>>,
+    #[serde(skip_serializing)]
+    entity_postings_chunk: Vec<Vec<(u32, f32)>>,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    chunk_terms: Vec<Vec<u32>>,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    chunk_entities: Vec<Vec<u32>>,
+    #[serde(skip_serializing)]
+    term_trie: LexiconTrie,
+    #[serde(skip_serializing)]
+    entity_trie: LexiconTrie,
+    #[serde(skip_serializing)]
+    doc_interval_trees: Vec<IntervalTree>,
 }
 
 struct LexicalIndex {
@@ -120,16 +326,126 @@ pub struct RedactedMemoryIndex {
     pub doc_type_to_docs: HashMap<String, Vec<String>>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedMemoryCore {
+    entity_to_docs: HashMap<String, Vec<EntityPosting>>,
+    term_to_docs: HashMap<String, Vec<TermPosting>>,
+    topic_to_docs: HashMap<String, Vec<String>>,
+    doc_type_to_docs: HashMap<String, Vec<String>>,
+    doc_id_to_u32: HashMap<String, u32>,
+    doc_u32_to_id: Vec<String>,
+    chunk_id_to_u32: HashMap<String, u32>,
+    chunks: Vec<ChunkMeta>,
+    doc_to_chunks: Vec<Vec<u32>>,
+    term_lexicon: HashMap<String, u32>,
+    entity_lexicon: HashMap<String, u32>,
+    term_postings_chunk: Vec<Vec<(u32, f32)>>,
+    entity_postings_chunk: Vec<Vec<(u32, f32)>>,
+    chunk_terms: Vec<Vec<u32>>,
+    chunk_entities: Vec<Vec<u32>>,
+}
+
 impl MemoryIndex {
     pub fn from_records(records: Vec<DocRecord>) -> Self {
+        Self::from_records_with_lexical_dir(records, None)
+    }
+
+    pub fn from_records_with_lexical_dir(records: Vec<DocRecord>, lexical_dir: Option<&Path>) -> Self {
         let mut docs = HashMap::new();
         let mut entity_to_docs: HashMap<String, Vec<EntityPosting>> = HashMap::new();
         let mut term_to_docs: HashMap<String, Vec<TermPosting>> = HashMap::new();
         let mut topic_to_docs: HashMap<String, Vec<String>> = HashMap::new();
         let mut doc_type_to_docs: HashMap<String, Vec<String>> = HashMap::new();
+        let mut doc_id_to_u32: HashMap<String, u32> = HashMap::new();
+        let mut doc_u32_to_id: Vec<String> = Vec::new();
+        let mut chunk_id_to_u32: HashMap<String, u32> = HashMap::new();
+        let mut chunks: Vec<ChunkMeta> = Vec::new();
+        let mut doc_to_chunks: Vec<Vec<u32>> = Vec::new();
+        let mut term_lexicon: HashMap<String, u32> = HashMap::new();
+        let mut entity_lexicon: HashMap<String, u32> = HashMap::new();
+        let mut term_postings_chunk: Vec<Vec<(u32, f32)>> = Vec::new();
+        let mut entity_postings_chunk: Vec<Vec<(u32, f32)>> = Vec::new();
+        let mut chunk_terms: Vec<Vec<u32>> = Vec::new();
+        let mut chunk_entities: Vec<Vec<u32>> = Vec::new();
 
-        for record in records {
+        for mut record in records {
             let doc_id = record.doc_id.clone();
+            let doc_u32 = doc_u32_to_id.len() as u32;
+            doc_id_to_u32.insert(doc_id.clone(), doc_u32);
+            doc_u32_to_id.push(doc_id.clone());
+            doc_to_chunks.push(Vec::new());
+            if record.section_chunks.is_empty() {
+                record.section_chunks.push(SectionChunk {
+                    chunk_id: format!("{}::0", doc_id),
+                    heading: record
+                        .headings
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "(document)".to_string()),
+                    content: record.content.clone(),
+                    start_line: 1,
+                    end_line: record.content.lines().count().max(1),
+                    key_entities: record
+                        .key_entities
+                        .iter()
+                        .map(|e| normalize_for_index(&e.text))
+                        .filter(|v| !v.is_empty())
+                        .collect(),
+                    important_terms: record
+                        .important_terms
+                        .iter()
+                        .map(|t| normalize_for_index(&t.term))
+                        .filter(|v| !v.is_empty())
+                        .collect(),
+                });
+            }
+            for chunk in &record.section_chunks {
+                let chunk_u32 = chunks.len() as u32;
+                chunk_id_to_u32.insert(chunk.chunk_id.clone(), chunk_u32);
+                chunks.push(ChunkMeta {
+                    doc_u32,
+                    chunk_id: chunk.chunk_id.clone(),
+                    start_line: chunk.start_line,
+                    end_line: chunk.end_line,
+                });
+                doc_to_chunks[doc_u32 as usize].push(chunk_u32);
+                chunk_terms.push(Vec::new());
+                chunk_entities.push(Vec::new());
+
+                for term in &chunk.important_terms {
+                    let key = normalize_for_index(term);
+                    if key.is_empty() {
+                        continue;
+                    }
+                    let term_u32 = *term_lexicon.entry(key).or_insert_with(|| {
+                        term_postings_chunk.push(Vec::new());
+                        (term_postings_chunk.len() - 1) as u32
+                    });
+                    term_postings_chunk[term_u32 as usize].push((chunk_u32, 0.8));
+                    chunk_terms[chunk_u32 as usize].push(term_u32);
+                }
+                let heading_tokens = tokenize_query_terms(&chunk.heading);
+                for token in heading_tokens {
+                    let term_u32 = *term_lexicon.entry(token).or_insert_with(|| {
+                        term_postings_chunk.push(Vec::new());
+                        (term_postings_chunk.len() - 1) as u32
+                    });
+                    term_postings_chunk[term_u32 as usize].push((chunk_u32, 0.4));
+                    chunk_terms[chunk_u32 as usize].push(term_u32);
+                }
+                for entity in &chunk.key_entities {
+                    let key = normalize_for_index(entity);
+                    if key.is_empty() {
+                        continue;
+                    }
+                    let entity_u32 = *entity_lexicon.entry(key).or_insert_with(|| {
+                        entity_postings_chunk.push(Vec::new());
+                        (entity_postings_chunk.len() - 1) as u32
+                    });
+                    entity_postings_chunk[entity_u32 as usize].push((chunk_u32, 0.9));
+                    chunk_entities[chunk_u32 as usize].push(entity_u32);
+                }
+            }
             for entity in &record.key_entities {
                 let key = normalize_for_index(&entity.text);
                 if key.is_empty() {
@@ -140,22 +456,6 @@ impl MemoryIndex {
                     doc_id: doc_id.clone(),
                     score,
                 });
-            }
-            for term in &record.important_terms {
-                let key = term.term.to_lowercase();
-                term_to_docs.entry(key).or_default().push(TermPosting {
-                    doc_id: doc_id.clone(),
-                    score: term.score,
-                });
-            }
-            for heading in &record.headings {
-                let heading_tokens = tokenize_query_terms(heading);
-                for token in heading_tokens {
-                    term_to_docs.entry(token).or_default().push(TermPosting {
-                        doc_id: doc_id.clone(),
-                        score: 0.4,
-                    });
-                }
             }
             if let Some(topic) = record.probable_topic.as_ref() {
                 topic_to_docs
@@ -172,6 +472,47 @@ impl MemoryIndex {
             docs.insert(doc_id, record);
         }
 
+        let mut term_u32_to_key: Vec<String> = vec![String::new(); term_lexicon.len()];
+        for (k, &v) in &term_lexicon {
+            term_u32_to_key[v as usize] = k.clone();
+        }
+        let mut entity_u32_to_key: Vec<String> = vec![String::new(); entity_lexicon.len()];
+        for (k, &v) in &entity_lexicon {
+            entity_u32_to_key[v as usize] = k.clone();
+        }
+
+        term_to_docs.clear();
+        entity_to_docs.clear();
+        for (term_u32, postings) in term_postings_chunk.iter().enumerate() {
+            let key = &term_u32_to_key[term_u32];
+            for (chunk_u32, score) in postings {
+                let doc_u32 = chunks[*chunk_u32 as usize].doc_u32;
+                let doc_id = &doc_u32_to_id[doc_u32 as usize];
+                term_to_docs.entry(key.clone()).or_default().push(TermPosting {
+                    doc_id: doc_id.clone(),
+                    score: *score,
+                });
+            }
+        }
+        for (entity_u32, postings) in entity_postings_chunk.iter().enumerate() {
+            let key = &entity_u32_to_key[entity_u32];
+            for (chunk_u32, score) in postings {
+                let doc_u32 = chunks[*chunk_u32 as usize].doc_u32;
+                let doc_id = &doc_u32_to_id[doc_u32 as usize];
+                entity_to_docs.entry(key.clone()).or_default().push(EntityPosting {
+                    doc_id: doc_id.clone(),
+                    score: *score,
+                });
+            }
+        }
+
+        let (term_trie, entity_trie, doc_interval_trees) = Self::build_runtime_helpers(
+            &term_lexicon,
+            &entity_lexicon,
+            &chunks,
+            doc_u32_to_id.len(),
+        );
+
         for postings in entity_to_docs.values_mut() {
             postings.sort_by(|a, b| {
                 b.score
@@ -187,7 +528,7 @@ impl MemoryIndex {
             });
         }
 
-        let lexical = match Self::build_lexical_index(&docs) {
+        let lexical = match Self::build_lexical_index(&docs, lexical_dir) {
             Ok(index) => Some(index),
             Err(err) => {
                 eprintln!("warning: lexical BM25 index disabled: {}", err);
@@ -202,10 +543,156 @@ impl MemoryIndex {
             topic_to_docs,
             doc_type_to_docs,
             lexical,
+            doc_id_to_u32,
+            doc_u32_to_id,
+            chunk_id_to_u32,
+            chunks,
+            doc_to_chunks,
+            term_lexicon,
+            entity_lexicon,
+            term_postings_chunk,
+            entity_postings_chunk,
+            chunk_terms,
+            chunk_entities,
+            term_trie,
+            entity_trie,
+            doc_interval_trees,
         }
     }
 
-    fn build_lexical_index(docs: &HashMap<String, DocRecord>) -> Result<LexicalIndex> {
+    fn build_runtime_helpers(
+        term_lexicon: &HashMap<String, u32>,
+        entity_lexicon: &HashMap<String, u32>,
+        chunks: &[ChunkMeta],
+        doc_count: usize,
+    ) -> (LexiconTrie, LexiconTrie, Vec<IntervalTree>) {
+        let mut term_trie = LexiconTrie::new();
+        for (key, &id) in term_lexicon {
+            term_trie.insert(key, id);
+        }
+        let mut entity_trie = LexiconTrie::new();
+        for (key, &id) in entity_lexicon {
+            entity_trie.insert(key, id);
+        }
+        let mut interval_entries_by_doc: Vec<Vec<IntervalEntry>> = vec![Vec::new(); doc_count];
+        for (chunk_u32, meta) in chunks.iter().enumerate() {
+            if meta.end_line >= meta.start_line && meta.end_line > 0 && (meta.doc_u32 as usize) < doc_count {
+                interval_entries_by_doc[meta.doc_u32 as usize].push(IntervalEntry {
+                    start: meta.start_line.max(1),
+                    end: meta.end_line,
+                    chunk_u32: chunk_u32 as u32,
+                });
+            }
+        }
+        let trees = interval_entries_by_doc
+            .into_iter()
+            .map(IntervalTree::build)
+            .collect::<Vec<_>>();
+        (term_trie, entity_trie, trees)
+    }
+
+    pub fn load_with_binary_core(
+        records: Vec<DocRecord>,
+        core_path: &Path,
+        lexical_dir: Option<&Path>,
+    ) -> Result<Self> {
+        let bytes = fs::read(core_path)?;
+        let core: PersistedMemoryCore = bincode::deserialize(&bytes)?;
+        if core.doc_u32_to_id.is_empty() && !records.is_empty() {
+            anyhow::bail!("invalid binary core: empty doc table");
+        }
+        let mut docs = HashMap::new();
+        for mut record in records {
+            if record.section_chunks.is_empty() {
+                record.section_chunks.push(SectionChunk {
+                    chunk_id: format!("{}::0", record.doc_id),
+                    heading: record
+                        .headings
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "(document)".to_string()),
+                    content: record.content.clone(),
+                    start_line: 1,
+                    end_line: record.content.lines().count().max(1),
+                    key_entities: record
+                        .key_entities
+                        .iter()
+                        .map(|e| normalize_for_index(&e.text))
+                        .filter(|v| !v.is_empty())
+                        .collect(),
+                    important_terms: record
+                        .important_terms
+                        .iter()
+                        .map(|t| normalize_for_index(&t.term))
+                        .filter(|v| !v.is_empty())
+                        .collect(),
+                });
+            }
+            docs.insert(record.doc_id.clone(), record);
+        }
+        let lexical = match Self::build_lexical_index(&docs, lexical_dir) {
+            Ok(index) => Some(index),
+            Err(err) => {
+                eprintln!("warning: lexical BM25 index disabled: {}", err);
+                None
+            }
+        };
+        let (term_trie, entity_trie, doc_interval_trees) = Self::build_runtime_helpers(
+            &core.term_lexicon,
+            &core.entity_lexicon,
+            &core.chunks,
+            core.doc_u32_to_id.len(),
+        );
+        Ok(Self {
+            docs,
+            entity_to_docs: core.entity_to_docs,
+            term_to_docs: core.term_to_docs,
+            topic_to_docs: core.topic_to_docs,
+            doc_type_to_docs: core.doc_type_to_docs,
+            lexical,
+            doc_id_to_u32: core.doc_id_to_u32,
+            doc_u32_to_id: core.doc_u32_to_id,
+            chunk_id_to_u32: core.chunk_id_to_u32,
+            chunks: core.chunks,
+            doc_to_chunks: core.doc_to_chunks,
+            term_lexicon: core.term_lexicon,
+            entity_lexicon: core.entity_lexicon,
+            term_postings_chunk: core.term_postings_chunk,
+            entity_postings_chunk: core.entity_postings_chunk,
+            chunk_terms: core.chunk_terms,
+            chunk_entities: core.chunk_entities,
+            term_trie,
+            entity_trie,
+            doc_interval_trees,
+        })
+    }
+
+    pub fn save_binary_core(&self, core_path: &Path) -> Result<()> {
+        if let Some(parent) = core_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let core = PersistedMemoryCore {
+            entity_to_docs: self.entity_to_docs.clone(),
+            term_to_docs: self.term_to_docs.clone(),
+            topic_to_docs: self.topic_to_docs.clone(),
+            doc_type_to_docs: self.doc_type_to_docs.clone(),
+            doc_id_to_u32: self.doc_id_to_u32.clone(),
+            doc_u32_to_id: self.doc_u32_to_id.clone(),
+            chunk_id_to_u32: self.chunk_id_to_u32.clone(),
+            chunks: self.chunks.clone(),
+            doc_to_chunks: self.doc_to_chunks.clone(),
+            term_lexicon: self.term_lexicon.clone(),
+            entity_lexicon: self.entity_lexicon.clone(),
+            term_postings_chunk: self.term_postings_chunk.clone(),
+            entity_postings_chunk: self.entity_postings_chunk.clone(),
+            chunk_terms: self.chunk_terms.clone(),
+            chunk_entities: self.chunk_entities.clone(),
+        };
+        fs::write(core_path, bincode::serialize(&core)?)?;
+        Ok(())
+    }
+
+    fn build_lexical_index(docs: &HashMap<String, DocRecord>, lexical_dir: Option<&Path>) -> Result<LexicalIndex> {
         let mut schema_builder = Schema::builder();
         let doc_id_f = schema_builder.add_text_field("doc_id", STRING | STORED);
         let content_f = schema_builder.add_text_field("content", TEXT);
@@ -213,42 +700,101 @@ impl MemoryIndex {
         let terms_f = schema_builder.add_text_field("important_terms", TEXT);
         let entities_f = schema_builder.add_text_field("entities", TEXT);
         let schema = schema_builder.build();
-
-        let index = Index::create_in_ram(schema);
-        let mut writer = index.writer(50_000_000)?;
-        for doc in docs.values() {
-            let headings_text = doc.headings.join(" ");
-            let terms_text = doc
-                .important_terms
-                .iter()
-                .map(|t| t.term.as_str())
-                .collect::<Vec<_>>()
-                .join(" ");
-            let entities_text = doc
-                .key_entities
-                .iter()
-                .map(|e| e.text.as_str())
-                .collect::<Vec<_>>()
-                .join(" ");
-            writer.add_document(doc!(
-                doc_id_f => doc.doc_id.clone(),
-                content_f => doc.content.clone(),
-                headings_f => headings_text,
-                terms_f => terms_text,
-                entities_f => entities_text
-            ))?;
-        }
-        writer.commit()?;
+        let index = if let Some(dir) = lexical_dir {
+            fs::create_dir_all(dir)?;
+            match Index::open_in_dir(dir) {
+                Ok(existing) => existing,
+                Err(_) => {
+                    if dir.exists() {
+                        let _ = fs::remove_dir_all(dir);
+                        fs::create_dir_all(dir)?;
+                    }
+                    let created = Index::create_in_dir(dir, schema.clone())?;
+                    let mut writer = created.writer(50_000_000)?;
+                    for doc in docs.values() {
+                        let headings_text = doc
+                            .section_chunks
+                            .iter()
+                            .map(|c| c.heading.as_str())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        let terms_text = doc
+                            .section_chunks
+                            .iter()
+                            .flat_map(|c| c.important_terms.iter().map(String::as_str))
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        let entities_text = doc
+                            .section_chunks
+                            .iter()
+                            .flat_map(|c| c.key_entities.iter().map(String::as_str))
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        let content_text = doc
+                            .section_chunks
+                            .iter()
+                            .map(|c| c.content.as_str())
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        writer.add_document(doc!(
+                            doc_id_f => doc.doc_id.clone(),
+                            content_f => content_text,
+                            headings_f => headings_text,
+                            terms_f => terms_text,
+                            entities_f => entities_text
+                        ))?;
+                    }
+                    writer.commit()?;
+                    created
+                }
+            }
+        } else {
+            let ram = Index::create_in_ram(schema);
+            let mut writer = ram.writer(50_000_000)?;
+            for doc in docs.values() {
+                let headings_text = doc
+                    .section_chunks
+                    .iter()
+                    .map(|c| c.heading.as_str())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let terms_text = doc
+                    .section_chunks
+                    .iter()
+                    .flat_map(|c| c.important_terms.iter().map(String::as_str))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let entities_text = doc
+                    .section_chunks
+                    .iter()
+                    .flat_map(|c| c.key_entities.iter().map(String::as_str))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let content_text = doc
+                    .section_chunks
+                    .iter()
+                    .map(|c| c.content.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                writer.add_document(doc!(
+                    doc_id_f => doc.doc_id.clone(),
+                    content_f => content_text,
+                    headings_f => headings_text,
+                    terms_f => terms_text,
+                    entities_f => entities_text
+                ))?;
+            }
+            writer.commit()?;
+            ram
+        };
         let reader = index.reader()?;
-        Ok(LexicalIndex {
-            index,
-            reader,
-            doc_id_f,
-            content_f,
-            headings_f,
-            terms_f,
-            entities_f,
-        })
+        let schema_ref = index.schema();
+        let doc_id_f = schema_ref.get_field("doc_id")?;
+        let content_f = schema_ref.get_field("content")?;
+        let headings_f = schema_ref.get_field("headings")?;
+        let terms_f = schema_ref.get_field("important_terms")?;
+        let entities_f = schema_ref.get_field("entities")?;
+        Ok(LexicalIndex { index, reader, doc_id_f, content_f, headings_f, terms_f, entities_f })
     }
 
     fn lexical_bm25(&self, query: &str, top_k: usize) -> Result<HashMap<String, f32>> {
@@ -304,18 +850,32 @@ impl MemoryIndex {
         if q_terms.is_empty() {
             q_terms.push(q.clone());
         }
+        let expanded = expand_query_terms(&q_terms);
+        let expanded_terms = expanded.expanded_terms;
+        let bm25_query = if expanded_terms.is_empty() {
+            q.clone()
+        } else {
+            format!("{} {}", q, expanded_terms.join(" "))
+        };
 
-        let mut scores: HashMap<String, f32> = HashMap::new();
-        let mut breakdowns: HashMap<String, ScoreBreakdown> = HashMap::new();
-        let mut matched_entities: HashMap<String, Vec<String>> = HashMap::new();
-        let mut matched_terms: HashMap<String, Vec<String>> = HashMap::new();
+        let doc_count = self.doc_u32_to_id.len();
+        if doc_count == 0 {
+            return Vec::new();
+        }
+        let mut scores: Vec<f32> = vec![0.0; doc_count];
+        let mut breakdowns: Vec<ScoreBreakdown> = vec![ScoreBreakdown::default(); doc_count];
+        let mut matched_entities: Vec<Vec<String>> = vec![Vec::new(); doc_count];
+        let mut matched_terms: Vec<Vec<String>> = vec![Vec::new(); doc_count];
         let query_set: HashSet<String> = q_terms.iter().cloned().collect();
 
-        match self.lexical_bm25(&q, top_k.saturating_mul(5).max(20)) {
+        match self.lexical_bm25(&bm25_query, top_k.saturating_mul(5).max(20)) {
             Ok(lexical_hits) => {
                 for (doc_id, bm25_score) in lexical_hits {
-                    *scores.entry(doc_id.clone()).or_insert(0.0) += bm25_score;
-                    breakdowns.entry(doc_id).or_default().lexical_score += bm25_score;
+                    if let Some(&doc_u32) = self.doc_id_to_u32.get(&doc_id) {
+                        let idx = doc_u32 as usize;
+                        scores[idx] += bm25_score;
+                        breakdowns[idx].lexical_score += bm25_score;
+                    }
                 }
             }
             Err(err) => {
@@ -324,53 +884,93 @@ impl MemoryIndex {
         }
 
         // Full-query entity hit.
-        if let Some(postings) = self.entity_to_docs.get(&q) {
-            for post in postings {
-                let delta = 1.5 * post.score;
-                *scores.entry(post.doc_id.clone()).or_insert(0.0) += delta;
-                breakdowns
-                    .entry(post.doc_id.clone())
-                    .or_default()
-                    .entity_score += delta;
-                matched_entities
-                    .entry(post.doc_id.clone())
-                    .or_default()
-                    .push(q.clone());
+        if let Some(entity_u32) = self.entity_trie.get(&q) {
+            if let Some(postings) = self.entity_postings_chunk.get(entity_u32 as usize) {
+                for (chunk_u32, post_score) in postings {
+                    let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
+                    let idx = doc_u32 as usize;
+                    let delta = 1.5 * *post_score;
+                    scores[idx] += delta;
+                    breakdowns[idx].entity_score += delta;
+                    matched_entities[idx].push(q.clone());
+                }
             }
         }
 
         for term in &q_terms {
-            if let Some(postings) = self.entity_to_docs.get(term) {
-                for post in postings {
-                    let delta = 1.2 * post.score;
-                    *scores.entry(post.doc_id.clone()).or_insert(0.0) += delta;
-                    breakdowns
-                        .entry(post.doc_id.clone())
-                        .or_default()
-                        .entity_score += delta;
-                    matched_entities
-                        .entry(post.doc_id.clone())
-                        .or_default()
-                        .push(term.clone());
+            let mut entity_ids = Vec::new();
+            if let Some(entity_u32) = self.entity_trie.get(term) {
+                entity_ids.push((entity_u32, 1.0f32));
+            } else if term.len() >= 4 {
+                for entity_u32 in self.entity_trie.prefix_ids(term, 1) {
+                    entity_ids.push((entity_u32, 0.25));
                 }
             }
-            if let Some(postings) = self.term_to_docs.get(term) {
-                for post in postings {
-                    let delta = 0.8 * post.score;
-                    *scores.entry(post.doc_id.clone()).or_insert(0.0) += delta;
-                    breakdowns
-                        .entry(post.doc_id.clone())
-                        .or_default()
-                        .term_score += delta;
-                    matched_terms
-                        .entry(post.doc_id.clone())
-                        .or_default()
-                        .push(term.clone());
+            for (entity_u32, mult) in entity_ids {
+                if let Some(postings) = self.entity_postings_chunk.get(entity_u32 as usize) {
+                    for (chunk_u32, post_score) in postings {
+                        let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
+                        let idx = doc_u32 as usize;
+                        let delta = 1.2 * *post_score * mult;
+                        scores[idx] += delta;
+                        breakdowns[idx].entity_score += delta;
+                        matched_entities[idx].push(term.clone());
+                    }
+                }
+            }
+            let mut term_ids = Vec::new();
+            if let Some(term_u32) = self.term_trie.get(term) {
+                term_ids.push((term_u32, 1.0f32));
+            } else if term.len() >= 4 {
+                for term_u32 in self.term_trie.prefix_ids(term, 1) {
+                    term_ids.push((term_u32, 0.25));
+                }
+            }
+            for (term_u32, mult) in term_ids {
+                if let Some(postings) = self.term_postings_chunk.get(term_u32 as usize) {
+                    for (chunk_u32, post_score) in postings {
+                        let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
+                        let idx = doc_u32 as usize;
+                        let delta = 0.8 * *post_score * mult;
+                        scores[idx] += delta;
+                        breakdowns[idx].term_score += delta;
+                        matched_terms[idx].push(term.clone());
+                    }
+                }
+            }
+        }
+
+        // Expanded semantic terms are lower-weight than original terms.
+        for term in &expanded_terms {
+            if let Some(entity_u32) = self.entity_trie.get(term) {
+                if let Some(postings) = self.entity_postings_chunk.get(entity_u32 as usize) {
+                    for (chunk_u32, post_score) in postings {
+                        let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
+                        let idx = doc_u32 as usize;
+                        let delta = 0.45 * *post_score;
+                        scores[idx] += delta;
+                        breakdowns[idx].entity_score += delta;
+                    }
+                }
+            }
+            if let Some(term_u32) = self.term_trie.get(term) {
+                if let Some(postings) = self.term_postings_chunk.get(term_u32 as usize) {
+                    for (chunk_u32, post_score) in postings {
+                        let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
+                        let idx = doc_u32 as usize;
+                        let delta = 0.35 * *post_score;
+                        scores[idx] += delta;
+                        breakdowns[idx].term_score += delta;
+                    }
                 }
             }
         }
 
         for (doc_id, doc) in &self.docs {
+            let Some(&doc_u32) = self.doc_id_to_u32.get(doc_id) else {
+                continue;
+            };
+            let idx = doc_u32 as usize;
             if let Some(topic) = doc.probable_topic.as_ref() {
                 let topic_tokens = tokenize_query_terms(topic);
                 let overlap = topic_tokens
@@ -379,8 +979,8 @@ impl MemoryIndex {
                     .count();
                 if overlap > 0 {
                     let delta = 0.35 * overlap as f32;
-                    *scores.entry(doc_id.clone()).or_insert(0.0) += delta;
-                    breakdowns.entry(doc_id.clone()).or_default().topic_score += delta;
+                    scores[idx] += delta;
+                    breakdowns[idx].topic_score += delta;
                 }
             }
             if let Some(dt) = doc.doc_type_guess.as_ref() {
@@ -388,39 +988,92 @@ impl MemoryIndex {
                 let overlap = dt_tokens.iter().filter(|t| query_set.contains(*t)).count();
                 if overlap > 0 {
                     let delta = 0.25 * overlap as f32;
-                    *scores.entry(doc_id.clone()).or_insert(0.0) += delta;
-                    breakdowns.entry(doc_id.clone()).or_default().doc_type_score += delta;
+                    scores[idx] += delta;
+                    breakdowns[idx].doc_type_score += delta;
                 }
             }
             if doc.timestamp.is_some() {
                 let delta = 0.05;
-                *scores.entry(doc_id.clone()).or_insert(0.0) += delta;
-                breakdowns.entry(doc_id.clone()).or_default().recency_score += delta;
+                scores[idx] += delta;
+                breakdowns[idx].recency_score += delta;
             }
         }
 
-        let mut out: Vec<SearchResult> = scores
-            .into_iter()
-            .filter_map(|(doc_id, score)| {
-                let doc = self.docs.get(&doc_id)?;
-                Some(SearchResult {
-                    doc_id: doc_id.clone(),
-                    source: doc.source.clone(),
-                    score,
-                    score_breakdown: breakdowns.remove(&doc_id).unwrap_or_default(),
-                    matched_entities: matched_entities.remove(&doc_id).unwrap_or_default(),
-                    matched_terms: matched_terms.remove(&doc_id).unwrap_or_default(),
-                    probable_topic: doc.probable_topic.clone(),
-                    doc_type_guess: doc.doc_type_guess.clone(),
-                })
-            })
-            .collect();
-        out.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        out.truncate(top_k);
+        struct MaxSegTree {
+            n: usize,
+            tree: Vec<(f32, usize)>,
+        }
+        impl MaxSegTree {
+            fn build(values: &[f32]) -> Self {
+                let mut n = 1usize;
+                while n < values.len() {
+                    n <<= 1;
+                }
+                let mut tree = vec![(f32::NEG_INFINITY, usize::MAX); 2 * n];
+                for (i, &v) in values.iter().enumerate() {
+                    tree[n + i] = (v, i);
+                }
+                for i in (1..n).rev() {
+                    tree[i] = if tree[i << 1].0 >= tree[i << 1 | 1].0 {
+                        tree[i << 1]
+                    } else {
+                        tree[i << 1 | 1]
+                    };
+                }
+                Self { n, tree }
+            }
+            fn best(&self) -> (f32, usize) {
+                self.tree[1]
+            }
+            fn set(&mut self, idx: usize, value: f32) {
+                let mut p = self.n + idx;
+                self.tree[p] = (value, idx);
+                while p > 1 {
+                    p >>= 1;
+                    self.tree[p] = if self.tree[p << 1].0 >= self.tree[p << 1 | 1].0 {
+                        self.tree[p << 1]
+                    } else {
+                        self.tree[p << 1 | 1]
+                    };
+                }
+            }
+        }
+
+        let mut seg = MaxSegTree::build(&scores);
+        let mut out = Vec::new();
+        let limit = top_k.min(doc_count);
+        for _ in 0..limit {
+            let (best_score, idx) = seg.best();
+            if idx == usize::MAX || !best_score.is_finite() || best_score <= 0.0 {
+                break;
+            }
+            let doc_id = &self.doc_u32_to_id[idx];
+            let Some(doc) = self.docs.get(doc_id) else {
+                seg.set(idx, f32::NEG_INFINITY);
+                continue;
+            };
+            out.push(SearchResult {
+                doc_id: doc_id.clone(),
+                source: doc.source.clone(),
+                score: best_score,
+                score_breakdown: breakdowns[idx].clone(),
+                matched_entities: {
+                    let mut v = matched_entities[idx].clone();
+                    v.sort();
+                    v.dedup();
+                    v
+                },
+                matched_terms: {
+                    let mut v = matched_terms[idx].clone();
+                    v.sort();
+                    v.dedup();
+                    v
+                },
+                probable_topic: doc.probable_topic.clone(),
+                doc_type_guess: doc.doc_type_guess.clone(),
+            });
+            seg.set(idx, f32::NEG_INFINITY);
+        }
         out
     }
 
@@ -449,18 +1102,37 @@ impl MemoryIndex {
             doc_type_to_docs: self.doc_type_to_docs.clone(),
         }
     }
+
+    pub fn impacted_chunks_for_line_range(
+        &self,
+        doc_id: &str,
+        start_line: usize,
+        end_line: usize,
+    ) -> Vec<String> {
+        let Some(&doc_u32) = self.doc_id_to_u32.get(doc_id) else {
+            return Vec::new();
+        };
+        let Some(tree) = self.doc_interval_trees.get(doc_u32 as usize) else {
+            return Vec::new();
+        };
+        let mut chunk_ids = tree
+            .query(start_line.max(1), end_line.max(start_line))
+            .into_iter()
+            .filter_map(|chunk_u32| self.chunks.get(chunk_u32 as usize).map(|m| m.chunk_id.clone()))
+            .collect::<Vec<_>>();
+        chunk_ids.sort();
+        chunk_ids.dedup();
+        chunk_ids
+    }
 }
 
 fn tokenize_query_terms(input: &str) -> Vec<String> {
-    let token_re = Regex::new(r"[A-Za-z][A-Za-z0-9_-]{2,}").expect("valid regex");
+    static TOKEN_RE: OnceLock<Regex> = OnceLock::new();
+    let token_re = TOKEN_RE.get_or_init(|| Regex::new(r"[A-Za-z][A-Za-z0-9_-]{2,}").expect("valid regex"));
     token_re
         .find_iter(input)
         .map(|m| m.as_str().to_lowercase())
         .collect()
 }
 
-fn normalize_for_index(input: &str) -> String {
-    let lowered = deunicode(input).to_lowercase();
-    let tokens = tokenize_query_terms(&lowered);
-    tokens.join(" ")
-}
+// normalize_for_index moved to query_expansion.rs and reused here.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod engine;
 pub mod filters;
 pub mod graph;
 pub mod index;
+pub mod query_expansion;
 pub mod report;
 pub mod rules;
 pub mod tier1;

--- a/src/query_expansion.rs
+++ b/src/query_expansion.rs
@@ -1,0 +1,156 @@
+use deunicode::deunicode;
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone)]
+pub struct ExpandedQuery {
+    pub original_terms: Vec<String>,
+    pub expanded_terms: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Entry {
+    term: String,
+    related: Vec<Related>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Related {
+    term: String,
+    relation: String,
+    confidence: f32,
+}
+
+#[derive(Debug, Default)]
+struct LexicalStore {
+    by_term: HashMap<String, Vec<Related>>,
+}
+
+static WORDNET_DATA: &str = include_str!("../data/lexical/wordnet_subset.json");
+static CONCEPTNET_DATA: &str = include_str!("../data/lexical/conceptnet_subset.json");
+static STORE: OnceLock<Option<LexicalStore>> = OnceLock::new();
+
+const MAX_EXPANSIONS_PER_TERM: usize = 3;
+const CONCEPTNET_MIN_CONFIDENCE: f32 = 0.82;
+
+pub fn expand_query_terms(input_terms: &[String]) -> ExpandedQuery {
+    let original_terms = input_terms
+        .iter()
+        .map(|t| normalize_for_index(t))
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>();
+
+    let Some(store) = STORE.get_or_init(load_store).as_ref() else {
+        return ExpandedQuery {
+            original_terms,
+            expanded_terms: Vec::new(),
+        };
+    };
+
+    let original_set: HashSet<String> = original_terms.iter().cloned().collect();
+    let mut expanded = Vec::new();
+
+    for term in &original_terms {
+        if let Some(related) = store.by_term.get(term) {
+            let mut count = 0usize;
+            for rel in related {
+                if count >= MAX_EXPANSIONS_PER_TERM {
+                    break;
+                }
+                let candidate = normalize_for_index(&rel.term);
+                if candidate.is_empty() || original_set.contains(&candidate) || expanded.contains(&candidate) {
+                    continue;
+                }
+                expanded.push(candidate);
+                count += 1;
+            }
+        }
+    }
+
+    ExpandedQuery {
+        original_terms,
+        expanded_terms: expanded,
+    }
+}
+
+fn load_store() -> Option<LexicalStore> {
+    let mut store = LexicalStore::default();
+    let wn: Vec<Entry> = serde_json::from_str(WORDNET_DATA).ok()?;
+    let cn: Vec<Entry> = serde_json::from_str(CONCEPTNET_DATA).ok()?;
+
+    for e in wn {
+        let key = normalize_for_index(&e.term);
+        if key.is_empty() {
+            continue;
+        }
+        for rel in e.related {
+            if !matches!(rel.relation.as_str(), "Synonym" | "SimilarTo") {
+                continue;
+            }
+            store.by_term.entry(key.clone()).or_default().push(rel);
+        }
+    }
+
+    for e in cn {
+        let key = normalize_for_index(&e.term);
+        if key.is_empty() {
+            continue;
+        }
+        for rel in e.related {
+            if !matches!(rel.relation.as_str(), "Synonym" | "SimilarTo" | "RelatedTo") {
+                continue;
+            }
+            if rel.relation == "RelatedTo" && rel.confidence < CONCEPTNET_MIN_CONFIDENCE {
+                continue;
+            }
+            store.by_term.entry(key.clone()).or_default().push(rel);
+        }
+    }
+
+    for rels in store.by_term.values_mut() {
+        rels.sort_by(|a, b| b.confidence.partial_cmp(&a.confidence).unwrap_or(std::cmp::Ordering::Equal));
+    }
+    Some(store)
+}
+
+pub fn normalize_for_index(input: &str) -> String {
+    let lowered = deunicode(input).to_lowercase();
+    let token_re = regex::Regex::new(r"[A-Za-z][A-Za-z0-9_-]{2,}").expect("valid regex");
+    token_re
+        .find_iter(&lowered)
+        .map(|m| m.as_str())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_basic() {
+        assert_eq!(normalize_for_index("Virtual-Machine!"), "virtual-machine");
+        assert_eq!(normalize_for_index("Café"), "cafe");
+    }
+
+    #[test]
+    fn expansion_caps_and_dedups() {
+        let terms = vec!["install".to_string(), "setup".to_string()];
+        let out = expand_query_terms(&terms);
+        assert!(out.expanded_terms.len() <= terms.len() * MAX_EXPANSIONS_PER_TERM);
+        for t in &out.expanded_terms {
+            assert!(!out.original_terms.contains(t));
+        }
+    }
+
+    #[test]
+    fn install_expands_to_setup() {
+        let out = expand_query_terms(&["install".to_string()]);
+        assert!(
+            out.expanded_terms.iter().any(|t| t == "setup"),
+            "expected setup expansion, got {:?}",
+            out.expanded_terms
+        );
+    }
+}

--- a/src/tier1.rs
+++ b/src/tier1.rs
@@ -35,7 +35,7 @@ pub struct Tier1DocEntities {
     pub key_entities: Vec<Tier1Entity>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RankedTerm {
     pub term: String,
     pub score: f32,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,8 +1,10 @@
 use lint_ai::config::Config;
 use lint_ai::graph::Graph;
+use lint_ai::index::{DocRecord, MemoryIndex, Provenance};
 use lint_ai::report::Report;
 use lint_ai::rules::cross_refs::check_cross_refs;
 use lint_ai::rules::orphan_pages::check_orphans;
+use lint_ai::tier1::{RankedTerm, Tier1Entity};
 use std::fs;
 use std::path::PathBuf;
 
@@ -120,4 +122,82 @@ fn analyze_suggests_config() {
     assert!(output.contains("\"ignore_crossref_sections\""));
     assert!(output.contains("top concepts:"));
     assert!(output.contains("pages:"));
+}
+
+#[test]
+fn query_baseline_still_works_without_semantic_match() {
+    let index = MemoryIndex::from_records(vec![DocRecord {
+        doc_id: "d1".to_string(),
+        source: "d1.md".to_string(),
+        content: "docker install on linux".to_string(),
+        timestamp: None,
+        doc_length: 24,
+        author_agent: None,
+        probable_topic: Some("Install".to_string()),
+        doc_type_guess: None,
+        headings: vec!["Install".to_string()],
+        key_entities: vec![Tier1Entity {
+            text: "docker".to_string(),
+            label: "CONCEPT".to_string(),
+            start: 0,
+            end: 6,
+            score: Some(1.0),
+            source: "test".to_string(),
+        }],
+        important_terms: vec![RankedTerm {
+            term: "install".to_string(),
+            score: 2.0,
+            source: "test".to_string(),
+        }],
+        section_chunks: vec![],
+        embedding: None,
+        top_claims: vec![],
+        provenance: Provenance {
+            source: "d1.md".to_string(),
+            timestamp: None,
+            ner_provider: "heuristic".to_string(),
+            term_ranker: "test".to_string(),
+            index_version: "test".to_string(),
+        },
+    }]);
+
+    let results = index.query("docker", 10);
+    assert!(!results.is_empty());
+    assert_eq!(results[0].doc_id, "d1");
+}
+
+#[test]
+fn semantic_expansion_improves_recall_for_synonyms() {
+    let index = MemoryIndex::from_records(vec![DocRecord {
+        doc_id: "d2".to_string(),
+        source: "d2.md".to_string(),
+        content: "setup openclaw runtime".to_string(),
+        timestamp: None,
+        doc_length: 27,
+        author_agent: None,
+        probable_topic: Some("Bootstrap".to_string()),
+        doc_type_guess: None,
+        headings: vec!["Bootstrap".to_string()],
+        key_entities: vec![],
+        important_terms: vec![RankedTerm {
+            term: "setup".to_string(),
+            score: 3.0,
+            source: "test".to_string(),
+        }],
+        section_chunks: vec![],
+        embedding: None,
+        top_claims: vec![],
+        provenance: Provenance {
+            source: "d2.md".to_string(),
+            timestamp: None,
+            ner_provider: "heuristic".to_string(),
+            term_ranker: "test".to_string(),
+            index_version: "test".to_string(),
+        },
+    }]);
+
+    // "install" expands to "bootstrap" in bundled lexical subsets.
+    let results = index.query("install", 10);
+    assert!(!results.is_empty());
+    assert_eq!(results[0].doc_id, "d2");
 }


### PR DESCRIPTION
# Release Notes: v0.1.3

## Summary
This release improves query performance, chunk-aware indexing internals, and cache correctness for repeated query workflows.

## Highlights

### Query and Index Performance
- Added persistent Tantivy lexical index reuse across CLI runs.
- Added binary core snapshot cache for fast in-memory index restoration.
- Added dense `doc_u32` score accumulators and segment-tree top-k selection.
- Added trie-backed term/entity lookup with conservative prefix fallback.

### Chunking and Retrieval Structure
- Added section chunk metadata with line ranges (`start_line`, `end_line`).
- Added `hybrid` chunking strategy (line-stable + token-aware splitting).
- Added configurable chunk parameters:
  - `--chunk-strategy heading|line|hybrid`
  - `--chunk-lines`
  - `--chunk-overlap`
  - `--chunk-target-tokens`
  - `--chunk-max-tokens`

### Incremental/Change Awareness
- Added corpus fingerprint validation for cache reuse.
- Fingerprint now includes content hashing for robust change detection.
- Cache reload now rebuilds only when source corpus/settings fingerprints differ.

### Query Output and UX
- Query output now includes elapsed time metadata:
  - `elapsed_ms`
  - `result_count`
  - `results`
- Deduplicated `matched_entities` and `matched_terms` in query results.

### Internal Data Structures
- Added chunk-level postings and forward indexes.
- Added doc↔chunk adjacency mappings.
- Added interval-tree support for changed line-range to chunk impact mapping.

## Compatibility
- Existing CLI commands remain compatible.
- Query command remains:
  - `--query "..."`
- Index command remains:
  - `--index`
- JSON cache remains available for readability; binary cache is additive.
