### PR TITLE
Release 0.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lint-ai"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Semantic wiki and docs linting for contradictions, stale claims, orphan pages, and missing cross-references"
 license = "Apache-2.0"
@@ -34,6 +34,12 @@ bincode = "1.3"
 text2num = "2"
 thesaurus = "0.5"
 temps = { version = "3", features = ["chrono"] }
+fuzzydate = "0.4.1"
+console = { version = "0.16.3", features = ["std"] }
+
+[features]
+default = ["heuristic-query-semantics"]
+heuristic-query-semantics = []
 
 [dev-dependencies]
 lru = "0.16.3"

--- a/README.md
+++ b/README.md
@@ -1,287 +1,163 @@
-# Lint AI
+# Lint-AI
 
-Lint-AI is a system for analyzing and aligning large corpora of AI-generated documentation.
+Lint-AI is for teams building agent memory over large, fast-changing corpora: assistant sessions, task notes, traces, reports, decisions, and documentation that accumulate faster than any team can review manually.
 
-As AI systems produce increasing amounts of documentation--task records, traces, logs, decisions, and reports--these artifacts often become inconsistent, outdated, or misaligned with each other. Lint-AI addresses this by treating documentation as a network of facts, rather than isolated text.
+It is a good fit for people who maintain:
+- long-running agent memory over conversations, notes, and decisions
+- markdown knowledge bases with lots of cross-links
+- internal docs where terminology drifts over time
+- corpora where “what changed?” and “what is current?” matter as much as keyword search
 
-## How it works
+Use Lint-AI when plain search is not enough and memory recall needs evidence. It treats stored context as a network of facts, concepts, links, claims, and timestamps, then surfaces misalignment, missing context, and retrieval results suited for downstream review or LLM grounding.
 
-Lint-AI processes documentation in several stages:
+The problem it solves is **system-level consistency**: reading individual documents is not enough when terminology drifts, definitions conflict, or outdated claims persist across a growing corpus. Lint-AI analyzes documentation collectively, not in isolation, to catch these issues before they spread.
 
-### 1. Fact Extraction
-Extracts entities, concepts, and claims from each document.
+Why people use it:
+- to recover the right past session or note when an agent needs context
+- to catch contradictions before they spread
+- to detect terminology drift across documents
+- to find orphaned or weakly linked pages
+- to ask corpus-level questions over facts, entities, and time
+- to feed grounded context into an LLM instead of raw text blobs
 
-### 2. Concept & Entity Resolution
-Identifies when different documents refer to the same concept using different terms.
+## Benchmark
 
-### 3. Fact Graph Construction
-Builds a network of normalized facts with context such as:
-- source document
-- time
-- confidence
-- status (current, deprecated, proposed)
+Evaluated on **LongMemEval-S** (500 questions), a public benchmark for long-context agent memory retrieval over multi-session conversation corpora. The scoped variant is used: each query searches only the sessions attached to that question, matching the realistic setting where a system knows which sessions are candidates for a given user. No embedding vectors are used anywhere in the pipeline.
 
-### 4. Misalignment Detection
-Identifies potential issues such as:
-- contradictions
-- terminology drift
-- scope conflicts
-- unsupported claims
-- missing required context
+The section below shows both the rust-bert POS/NER branch result and the default heuristic release result.
 
-### 5. AI Review
-Routes suspicious cases to an AI reviewer that verifies and explains the issue with context.
+### Rust-BERT POS/NER Branch
 
-Instead of enforcing rigid templates, Lint-AI focuses on understanding and comparing what documents actually say, enabling systematic detection of misalignment at scale.
+**Aggregate (n=500):**
 
-The result is a continuous alignment layer that helps ensure AI-generated work remains consistent, interpretable, and trustworthy over time.
+| metric | value |
+|---|---|
+| recall@5 | 86.9% |
+| recall@10 | 93.8% |
+| recall@20 | 94.4% |
+| recall_any@5 | 94.8% |
+| recall_any@10 | 98.2% |
+| MRR | 87.1% |
+| NDCG@10 | 86.0% |
+| avg query latency | 5.1 ms |
 
-## Why Lint-AI?
+`recall@k` is fractional recall over all gold sessions. `recall_any@k` counts 1.0 if any gold session appears in the top k. Latency is measured on a single CPU core with no GPU.
 
-AI systems don't just produce outputs--they produce documentation about their work.
+**By question type:**
 
-Over time, this creates a growing body of:
-- task summaries
-- decision notes
-- traces and logs
-- generated reports
+| question type | n | recall@5 | recall@10 | recall_any@5 | MRR | NDCG@10 |
+|---|---|---|---|---|---|---|
+| single-session-assistant | 56 | 100.0% | 100.0% | 100.0% | 99.1% | 99.3% |
+| single-session-user | 70 | 97.1% | 98.6% | 97.1% | 86.8% | 89.8% |
+| knowledge-update | 78 | 96.8% | 98.7% | 100.0% | 95.2% | 94.4% |
+| single-session-preference | 30 | 80.0% | 96.7% | 80.0% | 64.7% | 72.3% |
+| temporal-reasoning | 133 | 81.1% | 92.0% | 91.7% | 84.1% | 82.3% |
+| multi-session | 133 | 77.7% | 87.1% | 94.7% | 85.3% | 80.2% |
 
-Without alignment:
-- terminology drifts
-- definitions conflict
-- outdated concepts persist
-- claims become unsupported or inconsistent
+Results file: `benchmark/data/lintai_longmemeval_scoped_results_0512.json`
 
-Reading individual documents is not enough. The problem is **system-level consistency**.
+### Heuristic Release Backend
 
-Lint-AI addresses this by analyzing documentation collectively, not in isolation.
+**Aggregate (n=500):**
 
-## Vision
+| metric | value |
+|---|---|
+| recall@5 | 83.7% |
+| recall@10 | 89.6% |
+| recall@20 | 91.1% |
+| recall_any@5 | 92.4% |
+| recall_any@10 | 95.6% |
+| recall_any@20 | 97.0% |
+| MRR | 84.3% |
+| NDCG@10 | 81.9% |
+| avg query latency | 6.1 ms |
 
-As AI systems perform more work, they will continuously generate documentation describing their actions, decisions, and outputs.
+`recall@k` is fractional recall over all gold sessions. `recall_any@k` counts 1.0 if any gold session appears in the top k. Latency is measured on a single CPU core with no GPU.
 
-Lint-AI aims to ensure that this growing body of AI-generated knowledge remains:
-- consistent
-- traceable
-- interpretable
-- aligned over time
+**By question type:**
 
-## Under the hood
+| question type | n | recall@5 | recall@10 | recall_any@5 | MRR | NDCG@10 |
+|---|---|---|---|---|---|---|
+| single-session-assistant | 56 | 100.0% | 100.0% | 100.0% | 98.2% | 98.7% |
+| single-session-user | 70 | 94.3% | 98.6% | 94.3% | 77.4% | 82.6% |
+| knowledge-update | 78 | 94.2% | 96.8% | 98.7% | 94.6% | 92.4% |
+| single-session-preference | 30 | 80.0% | 93.3% | 80.0% | 65.8% | 72.2% |
+| temporal-reasoning | 133 | 77.0% | 85.7% | 86.5% | 81.8% | 78.2% |
+| multi-session | 133 | 72.5% | 79.3% | 93.2% | 82.7% | 74.3% |
 
-Lint-AI builds on techniques such as:
-- concept extraction
-- corpus-wide matching
-- terminology analysis
+Results file: `benchmark/data/lintai_longmemeval_scoped_results.json`
 
-These are used as part of a larger system for fact extraction and alignment reasoning.
+## Quickstart
 
-## Usage
+See [docs/quickstart.md](docs/quickstart.md) for the shortest path to build, run, query, and use the crate from Rust.
 
-### How To Use
+## How It Works
 
-Run the linter against a docs directory:
+Lint-AI ingests sessions, notes, traces, and documents, builds a lexical index plus sparse entity/term tables, and overlays graph structure for links and co-occurrence. Queries are analyzed for intent, entities, and temporal hints, then scored with a blend of lexical, semantic, claim, topic, timestamp, and graph signals. The same corpus analysis also powers misalignment checks such as missing cross-refs, orphan pages, and low-confidence claims.
+
+If you want the deeper implementation view, see:
+- `docs/chunk-strategy.md`
+- `docs/lexical-data.md`
+- `docs/artifact-indexing.md`
+
+## How To Use
+
+Query semantics currently use the heuristic backend in the release build.
+The model-backed POS/NER path was used in the experimental rust-bert branch and is kept separate from the audited release graph.
+
+### CLI
+
+Lint a corpus:
 
 ```bash
 ./lint-ai /path/to/repo
 ```
 
-### Tier 0 and Tier 1 Outputs
-
-Show Tier 0 ingestion records:
+If you prefer `cargo run`:
 
 ```bash
-./lint-ai /path/to/repo --show-tier0
+cargo run --bin lint-ai -- /path/to/repo
 ```
 
-Write a Tier 0 index JSON:
-
-```bash
-./lint-ai /path/to/repo --tier0-index-out
-```
-
-Show Tier 1 key entities:
-
-```bash
-./lint-ai /path/to/repo --show-tier1-entities
-```
-
-Use spaCy for Tier 1 entities (falls back to heuristic if unavailable):
-
-```bash
-./lint-ai /path/to/repo --show-tier1-entities --tier1-ner-provider spacy --spacy-model en_core_web_sm
-```
-
-Show Tier 1 important terms:
-
-```bash
-./lint-ai /path/to/repo --show-tier1-terms --tier1-term-ranker yake
-```
-
-Available term rankers:
-- `yake`
-- `rake`
-- `cvalue`
-- `textrank`
-
-### Index and Query
-
-Build and print the in-memory hybrid index:
-
-```bash
-./lint-ai --index /path/to/repo/docs
-```
-
-Query the corpus (index is built automatically behind the scenes):
+Query the corpus:
 
 ```bash
 ./lint-ai --query "docker install linux" /path/to/repo/docs
 ```
 
-Generate LLM-ready retrieval context (same index/query engine, different output schema):
+Get LLM-ready retrieval context:
 
 ```bash
 ./lint-ai --llm-context "docker install linux" /path/to/repo/docs
-./lint-ai --llm-context "docker install linux" --result-count 10 /path/to/repo/docs
-./lint-ai --llm-context "docker install linux" --simplified /path/to/repo/docs
 ```
 
-`--llm-context` is chunk-focused output for LLM grounding (`top_chunks` + citation policy), while `--query` stays doc-focused.
-
-Chunk selection strategy for `--llm-context`:
+Inspect the derived inventory:
 
 ```bash
-./lint-ai --llm-context "docker install linux" --llm-chunk-strategy all /path/to/repo/docs
-./lint-ai --llm-context "docker install linux" --llm-chunk-strategy by-doc /path/to/repo/docs
+./lint-ai /path/to/repo/docs --show-concepts
+./lint-ai /path/to/repo/docs --show-headings
 ```
 
-Default is `all` (global chunk scoring).
-
-Export graph for visualization (Graphviz DOT):
+Show the main query-oriented modes:
 
 ```bash
-./lint-ai /path/to/repo/docs --export-graph dot --graph-out lint-ai-graph.dot
-dot -Tpng lint-ai-graph.dot -o lint-ai-graph.png
+./lint-ai --index /path/to/repo/docs
+./lint-ai --show-tier0 /path/to/repo
+./lint-ai --show-tier1-entities /path/to/repo
+./lint-ai --show-tier1-terms /path/to/repo --tier1-term-ranker yake
 ```
 
-Export chunk-level graph (DOT):
+Use spaCy for Tier 1 entities if available:
 
 ```bash
-./lint-ai /path/to/repo/docs --export-graph dot --graph-level chunk --graph-out lint-ai-chunk-graph.dot
-dot -Tpng lint-ai-chunk-graph.dot -o lint-ai-chunk-graph.png
+./lint-ai /path/to/repo --show-tier1-entities --tier1-ner-provider spacy --spacy-model en_core_web_sm
 ```
 
-Export entity-level graph (DOT):
+Common graph exports, chunking knobs, lexical subset regeneration, and artifact indexing details are documented in `docs/`.
 
-```bash
-./lint-ai /path/to/repo/docs --export-graph dot --graph-level entity --graph-out lint-ai-entity-graph.dot
-dot -Tpng lint-ai-entity-graph.dot -o lint-ai-entity-graph.png
-```
+### Rust Library
 
-Export graph as JSON (for D3/Cytoscape integration):
-
-```bash
-./lint-ai /path/to/repo/docs --export-graph json --graph-out lint-ai-graph.json
-./lint-ai /path/to/repo/docs --export-graph json --graph-level chunk --graph-out lint-ai-chunk-graph.json
-./lint-ai /path/to/repo/docs --export-graph json --graph-level entity --graph-out lint-ai-entity-graph.json
-```
-
-Export interactive Cytoscape.js HTML:
-
-```bash
-./lint-ai /path/to/repo/docs --export-graph cytoscape-html --graph-out lint-ai-graph.html
-./lint-ai /path/to/repo/docs --export-graph cytoscape-html --graph-level chunk --graph-out lint-ai-chunk-graph.html
-./lint-ai /path/to/repo/docs --export-graph cytoscape-html --graph-level entity --graph-out lint-ai-entity-graph.html
-```
-
-Note: Cytoscape HTML exports load `./cytoscape.min.js` from the same directory as the HTML file.
-
-Show chunk graph stats:
-
-```bash
-./lint-ai /path/to/repo/docs --show-chunk-graph-stats
-```
-
-Export seed entity ontology graph (JSON):
-
-```bash
-./lint-ai /path/to/repo/docs --export-ontology --ontology-out lint-ai-ontology.json
-```
-
-Query output includes:
-- `query`
-- `elapsed_ms`
-- `result_count`
-- `results`
-
-Chunking options:
-
-```bash
-./lint-ai --index /path/to/repo/docs --chunk-strategy hybrid --chunk-lines 40 --chunk-overlap 10 --chunk-target-tokens 450 --chunk-max-tokens 800
-```
-
-The query pipeline uses hybrid scoring with:
-- BM25 lexical scoring
-- key-entity overlap
-- important-term overlap
-- topic/doc-type boosts when available
-- score breakdown output for transparency
-
-Lexical expansion data is kept as small checked-in JSON subsets under
-`data/lexical/`. The upstream ConceptNet assertions dump is large, roughly
-hundreds of MB compressed and about 1.2 GB extracted, so the full raw file is
-not committed to this repo. WordNet is much smaller, typically tens of MB
-depending on the package.
-
-Download locations:
-- ConceptNet assertions: `https://s3.amazonaws.com/conceptnet/downloads/2019/edges/conceptnet-assertions-5.7.0.csv.gz`
-- ConceptNet download docs: `https://github.com/commonsense/conceptnet5/wiki/Downloads`
-- Princeton WordNet downloads: `https://wordnet.princeton.edu/`
-
-To regenerate the checked-in subsets from local upstream downloads:
-
-```bash
-python3 scripts/build_lexical_subsets.py \
-  --wordnet-dict /path/to/WordNet-3.0/dict \
-  --conceptnet-assertions /path/to/conceptnet-assertions-5.7.0.csv.gz
-```
-
-Seed terms live in `data/lexical/seed_terms.txt`. Edit that file to widen or
-narrow the lexical coverage, then rerun the generator. The script accepts
-either the WordNet `dict/` directory itself or the parent WordNet package
-directory that contains `dict/`.
-
-The generated JSON writes back to:
-
-- `data/lexical/wordnet_subset.json`
-- `data/lexical/conceptnet_subset.json`
-
-More detail is in `docs/lexical-data.md`.
-
-Chunk strategy details: `docs/chunk-strategy.md`
-
-Artifact indexing and update model: `docs/artifact-indexing.md`
-Temporal fact / assertion layer: `docs/artifact-indexing.md` (see "Temporal Fact / Assertion Layer")
-
-## Library Use
-
-`lint-ai` can also be used as a library for artifact-oriented indexing.
-
-The current public model is:
-
-- `IndexStore`
-  - mutable artifact-facing facade
-  - owns source documents, cached derived records, tombstones, internal Tantivy lexical state, and refresh lifecycle
-- `MemoryIndex`
-  - built immutable query structure
-  - optimized for semantic and hybrid search signals
-
-Typical flow:
-
-1. Normalize external content into `SourceDocument`
-2. Insert or update it inside `IndexStore`
-3. Call `query(...)`, which refreshes the semantic `MemoryIndex` when needed and merges it with Tantivy BM25 hits
-
-Example:
+Use `IndexStore` when you want mutable ingestion, `MemoryIndex` when you want an immutable query snapshot, and `SourceDocument` to add content.
 
 ```rust
 use lint_ai::{IndexStore, PipelineOptions, SourceDocument};
@@ -294,6 +170,7 @@ fn main() -> anyhow::Result<()> {
         source: "artifact://artifact-1".to_string(),
         content: "docker install guide for linux hosts".to_string(),
         concept: "docker install".to_string(),
+        group_id: None,
         headings: vec!["Overview".to_string()],
         links: vec![],
         timestamp: None,
@@ -316,8 +193,7 @@ use lint_ai::{IndexStore, PipelineOptions};
 let index = IndexStore::for_corpus(Path::new("/path/to/corpus"), PipelineOptions::default())?;
 ```
 
-If you already have fully prepared `DocRecord` values and want the built search
-structure directly, use `lint_ai::index::MemoryIndex`.
+If you already have prepared `DocRecord` values and want the built search structure directly, use `lint_ai::index::MemoryIndex`.
 
 ## Advanced
 
@@ -339,103 +215,17 @@ Limit total bytes read across the corpus:
 ./lint-ai /path/to/repo --max-total-bytes 100000000
 ```
 
-The tool will automatically scope to `/path/to/repo/docs/**` when that folder exists.
+The tool automatically scopes to `/path/to/repo/docs/**` when that folder exists.
 
-Example with a local repo:
+## Configuration
 
-```bash
-./lint-ai /path/to/openclaw
-```
-
-Show the inferred concept inventory:
+Analyze a corpus and emit a suggested `lint-ai.json` config:
 
 ```bash
-./lint-ai /path/to/openclaw/docs/channels --show-concepts
+./lint-ai /path/to/repo/docs --analyze
 ```
 
-Show Markdown headings per file (structure/architecture hints):
-
-```bash
-./lint-ai /path/to/openclaw/docs/channels --show-headings
-```
-
-Debug phrase matches (prints matched text fragments and concepts):
-
-```bash
-./lint-ai /path/to/openclaw/docs/channels --debug-matches
-```
-
-## Coordinator + Workers
-
-`lint-service` can run as a coordinator in front of multiple long-running `lint-client` workers.
-
-### Components
-
-- `lint-service`: gRPC coordinator + HTTP gateway/UI
-- `lint-client`: worker process that executes `lint-ai`
-- `lint-dispatch`: dispatch CLI that sends one request to coordinator and returns aggregated JSON
-
-### Start coordinator
-
-```bash
-cd /home/louis/sources/lint-service
-LINT_SERVICE_ADDR=127.0.0.1:50051 \
-LINT_HTTP_ADDR=127.0.0.1:8080 \
-cargo run --bin lint-service
-```
-
-### Start a worker
-
-```bash
-cd /home/louis/sources/lint-service
-LINT_AI_PATH=/home/louis/sources/lint-ai/target/debug/lint-ai \
-LINT_WORKER_ADDR=127.0.0.1:50052 \
-LINT_WORKER_ID=worker-1 \
-LINT_WORKER_PATH=/home/louis/sources/openclaw/docs \
-LINT_HTTP_ADDR=http://127.0.0.1:8080 \
-cargo run --bin lint-client
-```
-
-Workers send heartbeats to coordinator every 5s. Coordinator keeps a presence table and drops stale workers automatically.
-
-### Dispatch a query
-
-```bash
-cd /home/louis/sources/lint-service
-LINT_SERVICE_ADDR=http://127.0.0.1:50051 \
-cargo run --bin lint-dispatch -- --query "mac install"
-```
-
-### HTTP gateway and UI
-
-- `GET /`: web UI (workers + recent jobs + top results)
-- `GET /api/workers`: current worker presence
-- `GET /api/jobs`: recent dispatch jobs
-- `POST /api/dispatch`: run dispatch via HTTP
-- `POST /api/worker/heartbeat`: worker heartbeat endpoint
-
-`/api/dispatch` accepts:
-
-```json
-{
-  "args": ["--query", "mac install"],
-  "working_dir": "",
-  "timeout_ms": 120000
-}
-```
-
-Optional tenant routing header:
-- `x-tenant-id: <tenant>`
-
-If license is configured with a tenant, dispatch checks `x-tenant-id` before running.
-
-Analyze a corpus and emit a suggested `lint-ai.json`:
-
-```bash
-./lint-ai /path/to/openclaw/docs/channels --analyze
-```
-
-Example analysis output (Openclaw channels):
+Example output:
 
 ```
 Suggested config:
@@ -455,33 +245,15 @@ top concepts:
 - channel routing (22)
 - slack (11)
 - telegram (11)
-- signal (10)
-- whatsapp (10)
-- discord (9)
-- troubleshooting (9)
-- line (8)
-- imessage (7)
-- matrix (6)
-- zalo (4)
-- irc (3)
-- location (3)
 top sections:
 - configuration (41)
 - setup (35)
 - unscoped (31)
 - security (28)
 - related (22)
-- troubleshooting (22)
-- bundled plugin (14)
-- routing (14)
-- overview (10)
-- notes (4)
 ```
 
-## Configuration
-
-You can place a `lint-ai.json` file in the target root (or pass `--config /path/to/lint-ai.json`)
-to control filters.
+You can place a `lint-ai.json` file in the target root, or pass `--config /path/to/lint-ai.json`, to control filters.
 
 Use `--strict-config` to fail fast if the config is invalid.
 
@@ -491,17 +263,7 @@ Limit config size:
 ./lint-ai /path/to/repo --max-config-bytes 2000000
 ```
 
-```json
-{
-  "stopwords": ["workflow", "example"],
-  "ignore_sections": ["related", "unscoped"],
-  "ignore_crossref_sections": ["related", "unscoped"],
-  "ignore_paths": ["docs/reference/"]
-}
-```
-
-Example used for Openclaw channels (reduce false positives by skipping "Related" sections and
-ignoring generic terms):
+Example used for Openclaw channels:
 
 ```json
 {
@@ -514,91 +276,39 @@ ignoring generic terms):
 }
 ```
 
-Run it:
+Run it with `./lint-ai /path/to/openclaw/docs/channels --config /path/to/openclaw/lint-ai.json`.
 
-```bash
-./lint-ai /path/to/openclaw/docs/channels --config /path/to/openclaw/lint-ai.json
-```
+## Contributing
 
-## Development
-
-### Build
+If you want to contribute, the most useful workflow is:
 
 ```bash
 cargo build
-```
-
-### Test
-
-```bash
 cargo test
+cargo fmt --all
 ```
 
-### Contributing
+Please keep changes focused and include tests when behavior changes.
 
-1. Fork the repo and create a feature branch.
-2. Make changes with tests where appropriate.
-3. Run `cargo test`.
-4. Open a PR.
+Useful contribution rules:
 
-## Concept Examples
+- run `cargo test` before opening a PR
+- run `cargo fmt --all` for Rust code changes
+- update docs when CLI flags, benchmarks, or query behavior change
+- include benchmark notes when ranking or retrieval logic changes
+- prefer small PRs with a clear scope
 
-Concept inventory (derived from filenames in `docs/channels/**`):
-
-```
-discord
-slack
-telegram
-whatsapp
-group messages
-channel routing
-```
-
-Concepts grouped by section (aggregated across the corpus):
-
-```
-Section: setup
-- pairing (4)
-- signal (3)
-- feishu (2)
-- zalo (2)
-
-Section: configuration
-- pairing (7)
-- signal (6)
-- feishu (3)
-- groups (3)
-
-Section: related
-- channel routing (21)
-- groups (21)
-- pairing (21)
-```
-
-Surface forms (for matching text to a concept):
-
-```
-group messages
-group-messages
-group_messages
-groupmessages
-group message
-group messages
-```
+If the change affects query quality, mention the benchmark result it moves.
 
 ## Output Examples
 
-Sample findings now include severity tags and link‑debt signals:
+Running the linter emits findings tagged with severity and link-debt signals:
 
-```
+```text
 Missing cross-ref in docs/channels/discord.md -> [[signal]] (high)
 Low link density in docs/channels/location.md (outgoing 1, avg 4.2)
 Unreachable page: docs/channels/legacy.md
 Orphan page: docs/channels/unused.md
 ```
 
-Orphan detection example command:
-
-```bash
-./lint-ai /path/to/openclaw/docs/channels
-```
+Use `--show-concepts` when you need the derived concept inventory for tuning stopwords or allowlists in `lint-ai.json`.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,151 @@
+# Benchmark Suite
+
+This directory holds the retrieval benchmarks for `lint-ai`, including haystack-style corpora, LongMemEval-S runs, and the EverMemBench-Static setup.
+
+## Dataset format
+
+Provide a JSON file with this shape:
+
+```json
+{
+  "documents": [
+    {
+      "doc_id": "doc-1",
+      "source": "docs/alpha.md",
+      "content": "# Title\nDocument text...",
+      "concept": "optional-concept",
+      "headings": ["Title"],
+      "links": ["docs/beta.md"],
+      "timestamp": "2026-04-25T00:00:00Z",
+      "author_agent": "optional"
+    }
+  ],
+  "queries": [
+    {
+      "id": "q-1",
+      "query": "what does alpha say",
+      "relevant_doc_ids": ["doc-1"],
+      "relevant_chunk_ids": []
+    }
+  ]
+}
+```
+
+Notes:
+- `relevant_doc_ids` and `relevant_chunk_ids` are both optional arrays.
+- If only `relevant_chunk_ids` are provided, the benchmark resolves them to `doc_id` via indexed chunk metadata.
+
+## Haystack Run
+
+```bash
+cargo run --bin haystack_benchmark -- \
+  --dataset benchmark/sample_dataset.json \
+  --k 1 --k 3 --k 5 --k 10 \
+  --out benchmark/results.json
+```
+
+To run the academic LongMemEval-S corpus directly and index each session as turn-level chunks:
+
+```bash
+cargo run --bin haystack_benchmark -- \
+  --longmemeval benchmark/data/longmemeval_s_cleaned.json \
+  --limit 20 \
+  --k 5 --k 10 --k 20 \
+  --out benchmark/results.json
+```
+
+In LongMemEval mode, turn docs are grouped back to their parent session for scoring so you measure session retrieval quality while using finer-grained chunks for indexing.
+
+If you want the raw Hugging Face copy instead of the cleaned one, use:
+
+```bash
+cargo run --bin haystack_benchmark -- \
+  --longmemeval benchmark/data/longmemeval_s_raw.json \
+  --limit 20 \
+  --k 5 --k 10 --k 20 \
+  --out benchmark/results.json
+```
+
+If you want question-scoped haystack retrieval, where each query only searches the sessions attached to that question:
+
+```bash
+cargo run --bin haystack_scoped_benchmark -- \
+  --longmemeval benchmark/data/longmemeval_s_raw.json \
+  --limit 20 \
+  --k 5 --k 10 --k 20 \
+    --out benchmark/results.json
+```
+
+Scoped LongMemEval reporting includes both `recall@k` and `recall_any@k`. The any-hit metric matches the interpretation used by the current LongMemEval-S release notes and README.
+
+To prepare a reusable turn-based dataset file first, run:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+src = Path('benchmark/data/longmemeval_s_cleaned.json')
+out = Path('benchmark/data/longmemeval_turn_full_for_lintai.json')
+raw = json.loads(src.read_text())
+
+abst = {
+    'single-session-user_abs',
+    'multi-session_abs',
+    'knowledge-update_abs',
+    'temporal-reasoning_abs',
+}
+
+entries = [e for e in raw if e.get('question_type') not in abst]
+documents = []
+queries = []
+seen_docs = set()
+
+for entry in entries:
+    session_turns = {
+        sid: turns
+        for sid, turns in zip(
+            entry.get('haystack_session_ids', []),
+            entry.get('haystack_sessions', []),
+        )
+    }
+    for session_id, turns in session_turns.items():
+        for turn_idx, turn in enumerate(turns):
+            doc_id = f'{session_id}::turn{turn_idx}'
+            if doc_id in seen_docs:
+                continue
+            seen_docs.add(doc_id)
+            documents.append({
+                'doc_id': doc_id,
+                'source': f'longmemeval/session/{session_id}/turn/{turn_idx}',
+                'content': f"{turn.get('role', 'unknown')}: {turn.get('content', '')}",
+                'concept': 'longmemeval-turn',
+                'headings': [f'session:{session_id}'],
+                'links': [],
+                'timestamp': entry.get('question_date'),
+                'author_agent': None,
+            })
+
+    queries.append({
+        'id': entry['question_id'],
+        'query': entry['question'],
+        'relevant_doc_ids': entry.get('answer_session_ids', []),
+        'relevant_chunk_ids': [],
+    })
+
+with out.open('w') as f:
+    json.dump({'documents': documents, 'queries': queries}, f)
+
+print(f'wrote {out}')
+print(f'documents={len(documents)} queries={len(queries)}')
+PY
+```
+
+## Report Metrics
+
+- `recall_at_k`: average recall at each configured K.
+- `recall_any_at_k`: 1.0 when any gold session is in the top K, otherwise 0.0.
+- `mrr`: mean reciprocal rank.
+- `ndcg_at_10`: normalized DCG at 10.
+
+The output JSON includes both aggregate metrics and per-query details.

--- a/docs/cpp-code-adapter-design.md
+++ b/docs/cpp-code-adapter-design.md
@@ -1,0 +1,210 @@
+# C++ Code Adapter Design
+
+This document describes the intended design for supporting a C++ repository
+through the `lint-ai` adapter layer.
+
+The goal is to make C++ a first-class code source without changing the current
+Markdown pipeline or the downstream indexing model.
+
+## Goals
+
+- Support repository traversal for C++ source trees.
+- Extract code structure with Tree-sitter or a Tree-sitter-compatible parser.
+- Normalize code into `SourceDocument` records for the existing graph and
+  indexing pipeline.
+- Enable symbol-aware retrieval for classes, structs, functions, methods,
+  variables, namespaces, and includes.
+- Preserve compatibility with the current `Graph::build()` entry point.
+
+## Non-Goals
+
+- Do not rewrite the current Markdown adapter.
+- Do not replace the current graph or index layers.
+- Do not require all language support to live in this repo forever.
+- Do not make the first version depend on perfect C++ semantic analysis.
+
+## Proposed Layering
+
+```mermaid
+flowchart TD
+    A[C++ repository root] --> B[Discovery / adapter dispatch]
+    B --> C[C++ adapter]
+    C --> D[Tree-sitter parser layer]
+    D --> E[Symbol extraction]
+    E --> F[SourceDocument records]
+    F --> G[Graph build]
+    G --> H[Chunking / Tier 1 / IndexStore]
+    H --> I[Query and retrieval]
+```
+
+## Repository Split
+
+The recommended split is:
+
+- `lint-ai`
+  - adapter trait and registry
+  - generic ingestion shape
+  - graph construction
+  - chunking, Tier 1, indexing, and query flow
+- language parser package or repo
+  - C++ Tree-sitter parsing
+  - symbol extraction
+  - language-specific relationship detection
+
+The code adapter in `lint-ai` should remain thin and delegate to the language
+parser package.
+
+## Canonical Output Shape
+
+The adapter boundary should emit `SourceDocument` directly.
+
+For C++, a `SourceDocument` should represent one of the following:
+
+- file-level document
+- namespace-level document
+- class or struct document
+- function or method document
+- optionally, variable or member-focused documents if needed
+
+Recommended fields:
+
+- `doc_id`
+  - stable and deterministic
+- `source`
+  - file path plus symbol scope when applicable
+- `content`
+  - source text or scoped source text
+- `concept`
+  - canonical symbol name or file subject
+- `group_id`
+  - logical grouping for all symbols in one file or module
+- `headings`
+  - structural labels such as `class Foo`, `namespace bar`
+- `links`
+  - referenced symbols, includes, base classes, or member references
+- `timestamp`
+  - file modification timestamp when available
+- `doc_length`
+  - text length in bytes
+- `author_agent`
+  - usually unused for code, but preserved for compatibility
+
+## C++ Parsing Strategy
+
+Use Tree-sitter to parse source files and build a symbol inventory.
+
+Initial file set:
+
+- `.cpp`
+- `.cc`
+- `.cxx`
+- `.hpp`
+- `.hh`
+- `.h`
+- `.hxx`
+
+Initial extraction targets:
+
+- namespaces
+- classes
+- structs
+- enums
+- functions
+- methods
+- fields and variables
+- `#include` directives
+- base-class declarations
+- identifier references inside symbol bodies
+
+The first version does not need full semantic resolution from a compiler.
+Tree-sitter structure is enough to produce useful retrieval records.
+
+## Document Granularity
+
+The adapter should not force every file into a single document.
+For C++, retrieval is better when the adapter emits multiple symbol-scoped
+documents per file.
+
+Example from one file:
+
+- file document
+- namespace document
+- class document
+- method document
+
+This allows a query like `className` to return:
+
+- the class definition
+- methods defined in the class
+- references to the class
+- related types in the same file or namespace
+
+## Relationship Model
+
+The adapter should preserve lightweight edges as symbol links:
+
+- class -> base class
+- class -> member field
+- class -> method
+- method -> referenced type
+- file -> included header
+- namespace -> contained symbols
+
+These links should be flattened into `SourceDocument.links` when possible so the
+current graph and retrieval layers can continue to operate unchanged.
+
+## Query Expectations
+
+For a query like `className`, expected retrieval should include:
+
+- the file that defines `className`
+- the class document for `className`
+- subclasses or derived classes if known
+- methods and fields inside that class
+- references to `className` from other files
+
+For a query like `variableName`, expected retrieval should include:
+
+- the variable declaration
+- the enclosing function or class
+- references where the variable is used
+
+## Adapter Contract
+
+The `SourceAdapter` trait in `lint-ai` should remain simple:
+
+```rust
+pub trait SourceAdapter {
+    fn name(&self) -> &'static str;
+    fn supports(&self, path: &std::path::Path) -> bool;
+    fn ingest(
+        &self,
+        input: &AdapterInput<'_>,
+    ) -> anyhow::Result<Vec<lint_ai::SourceDocument>>;
+}
+```
+
+The C++ adapter should be responsible for:
+
+- recognizing supported file extensions
+- invoking the language parser
+- transforming parser output into `SourceDocument`
+- attaching stable identifiers and symbol-scoped metadata
+
+## Suggested Next Step
+
+Before implementation, define the C++ parser output contract in a separate
+document or crate:
+
+- symbol kind
+- symbol name
+- fully qualified name
+- file path
+- byte range
+- parent symbol
+- references
+- base types
+- includes
+
+That contract should be stable enough for both `lint-ai` and any future
+language-specific repo.

--- a/docs/ingestion-architecture.md
+++ b/docs/ingestion-architecture.md
@@ -1,0 +1,79 @@
+# Ingestion Architecture
+
+This diagram shows the ingestion shape the repo should support once non-Markdown
+sources are added. It keeps the current retrieval/indexing layers intact and
+splits source handling into file-type-specific adapters.
+
+```mermaid
+flowchart TD
+    A[Corpus root] --> B[Discovery / traversal]
+    B --> C{File type}
+
+    C -->|Markdown| D[Markdown adapter]
+    C -->|Code| E[Code adapter]
+    C -->|Text / other| F[Generic adapter]
+
+    D --> G[Canonical SourceDocument]
+    E --> G
+    F --> G
+
+    G --> H[Tier 0 ingestion records]
+    G --> I[Chunking]
+    G --> J[Tier 1 signals]
+
+    I --> K[DocRecord / SectionChunk]
+    J --> K
+    H --> K
+
+    K --> L[MemoryIndex / IndexStore]
+    L --> M[Lexical retrieval]
+    L --> N[Entity / term ranking]
+    L --> O[Query + LLM context]
+
+    P[Config + corpus limits] -. controls .-> B
+    P -. controls .-> D
+    P -. controls .-> E
+    P -. controls .-> F
+    P -. controls .-> I
+    P -. controls .-> J
+```
+
+## File ownership map
+
+- [`src/graph.rs`](/home/louis/sources/Lint-AI/src/graph.rs): corpus traversal, page discovery, Tier 0 record generation
+- [`src/source.rs`](/home/louis/sources/Lint-AI/src/source.rs): canonical source document shape
+- [`src/chunking.rs`](/home/louis/sources/Lint-AI/src/chunking.rs): chunk boundaries and chunk enrichment
+- [`src/tier1.rs`](/home/louis/sources/Lint-AI/src/tier1.rs): entity and important-term extraction
+- [`src/pipeline.rs`](/home/louis/sources/Lint-AI/src/pipeline.rs): ingestion-to-index pipeline and store assembly
+- [`src/index.rs`](/home/louis/sources/Lint-AI/src/index.rs): persistent query structures and retrieval state
+- [`src/engine.rs`](/home/louis/sources/Lint-AI/src/engine.rs): CLI orchestration, cache handling, query flow
+
+## Adapter design
+
+The adapter boundary should return `SourceDocument` directly. We do not need a
+separate intermediate `AdaptedDocument` shape yet.
+
+Recommended trait shape:
+
+```rust
+pub struct AdapterInput<'a> {
+    pub root: &'a std::path::Path,
+    pub max_bytes: usize,
+    pub max_files: usize,
+    pub max_depth: usize,
+    pub max_total_bytes: usize,
+}
+
+pub trait SourceAdapter {
+    fn name(&self) -> &'static str;
+    fn supports(&self, path: &std::path::Path) -> bool;
+    fn ingest(
+        &self,
+        input: &AdapterInput<'_>,
+    ) -> anyhow::Result<Vec<lint_ai::SourceDocument>>;
+}
+```
+
+The main change needed for code support is to replace the single Markdown-only
+discovery path with a dispatcher that chooses an adapter by extension or file
+kind, then normalizes every source into `SourceDocument`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,105 @@
+# Quickstart
+
+This guide gives you the shortest path to try Lint-AI on an agent memory corpus, local repository, or note base.
+
+## 1. Build the binary
+
+```bash
+cargo build
+```
+
+If you want to run it without installing a binary, use:
+
+```bash
+cargo run --bin lint-ai -- --help
+```
+
+Query semantics use the heuristic backend in this release.
+The rust-bert POS/NER path is experimental and not part of the audited release dependency graph.
+
+## 2. Lint a corpus
+
+Point Lint-AI at a repository or memory corpus directory:
+
+```bash
+./lint-ai /path/to/repo
+```
+
+If the repository has a `docs/` folder, the tool will usually scope itself there automatically.
+
+## 3. Inspect the corpus
+
+Show the derived inventory:
+
+```bash
+./lint-ai /path/to/repo/docs --show-concepts
+./lint-ai /path/to/repo/docs --show-headings
+```
+
+Show the entity and term views:
+
+```bash
+./lint-ai /path/to/repo --show-tier0
+./lint-ai /path/to/repo --show-tier1-entities
+./lint-ai /path/to/repo --show-tier1-terms --tier1-term-ranker yake
+```
+
+If you want spaCy-based entity extraction:
+
+```bash
+./lint-ai /path/to/repo --show-tier1-entities --tier1-ner-provider spacy --spacy-model en_core_web_sm
+```
+
+## 4. Query the corpus
+
+Ask a simple memory retrieval question:
+
+```bash
+./lint-ai --query "docker install linux" /path/to/repo/docs
+```
+
+Ask for LLM-ready retrieval context:
+
+```bash
+./lint-ai --llm-context "docker install linux" /path/to/repo/docs
+```
+
+## 5. Use it as a library
+
+If you are integrating Lint-AI into a Rust app, start with `IndexStore` and `SourceDocument`.
+
+```rust
+use lint_ai::{IndexStore, PipelineOptions, SourceDocument};
+
+fn main() -> anyhow::Result<()> {
+    let mut index = IndexStore::in_memory(PipelineOptions::default());
+
+    index.upsert(SourceDocument {
+        doc_id: "artifact-1".to_string(),
+        source: "artifact://artifact-1".to_string(),
+        content: "docker install guide for linux hosts".to_string(),
+        concept: "docker install".to_string(),
+        group_id: None,
+        headings: vec!["Overview".to_string()],
+        links: vec![],
+        timestamp: None,
+        doc_length: 36,
+        author_agent: None,
+    });
+
+    let results = index.query("docker install", 5)?;
+    println!("{}", serde_json::to_string_pretty(&results)?);
+    Ok(())
+}
+```
+
+For corpus-local persistence under `.lint-ai/`, use:
+
+```rust
+use std::path::Path;
+use lint_ai::{IndexStore, PipelineOptions};
+
+let index = IndexStore::for_corpus(Path::new("/path/to/corpus"), PipelineOptions::default())?;
+```
+
+If you already have `DocRecord` values, use `lint_ai::index::MemoryIndex` for the built search structure.

--- a/docs/releases/0.1.6.md
+++ b/docs/releases/0.1.6.md
@@ -1,0 +1,48 @@
+# Release Notes: v0.1.6
+
+Date: 2026-05-12
+
+This release bumps the crate version to `0.1.6`.
+
+## Highlights
+
+- Bumped crate version from `0.1.5` to `0.1.6`.
+
+## Post-Release Snapshot
+
+Date: 2026-05-15
+
+This section captures the current main-branch work after the `0.1.6` release. The crate is still on `0.1.6`; these notes reflect post-release work that should be visible in the docs and benchmark outputs.
+
+### Highlights
+
+- Added early query routing intent detection for count, sum, and sequence questions.
+- Added routed evidence-first reranking signals for numerical and sequence questions.
+- Added `recall_any@k` to the scoped LongMemEval benchmark so multi-session reporting matches the benchmark's any-hit interpretation.
+- Added fine-grained query timing fields, including:
+  - `evidence_ms`
+  - `group_build_ms`
+  - `group_sort_ms`
+  - `lexical_merge_ms`
+  - `posting_scoring_ms`
+  - `routing_seed_ms`
+- Optimized routing seeding by removing repeated per-doc text parsing and token-set construction.
+- Reduced query latency substantially on routed benchmark cases after the sparse scoring path was tightened.
+- Hardened persistence paths and the spaCy subprocess script path.
+- Refreshed the README and Tier 1 docs to match the current live query path and the latest benchmark results.
+- Gated POS-derived time hints so they only affect ranking when the query has an explicit temporal phrase.
+- Stopped applying recency bias from verb tense alone to non-temporal queries.
+- Improved the benchmark stability slightly by reducing accidental temporal boosting.
+
+### Query Path Notes
+
+- Query analysis now exposes routing intent for numerical and sequence questions.
+- Routed queries use evidence scoring inside the rerank path.
+- The benchmark and live query paths now both expose richer timing breakdowns for profiling.
+- The current live pipeline remains lexical + sparse + graph based.
+- POS-based time hints remain analysis metadata unless the query is explicitly temporal.
+
+### Benchmark Notes
+
+- Scoped LongMemEval reporting now includes both `recall@k` and `recall_any@k`.
+- The current benchmark report used by the README is `benchmark/data/lintai_longmemeval_scoped_results.json`.

--- a/docs/tier1-hybrid-indexing-and-retrieval.md
+++ b/docs/tier1-hybrid-indexing-and-retrieval.md
@@ -12,7 +12,7 @@ Required now:
 
 Planned fields:
 - `doc_type_guess`
-- `embedding`
+- `embedding` (reserved for future vector workflows)
 - `top_claims`
 
 Provenance fields (required):
@@ -43,8 +43,7 @@ Build multiple in-memory indexes from Tier 1 records.
 - doc-type facet: `doc_type_guess -> doc_ids` (when available)
 
 ### 2.4 Vector Index
-- in-memory embedding table: `doc_id -> embedding`
-- used for vector similarity retrieval when embeddings are available
+- not part of the current live query path
 
 ## 3. Search / Retrieval Strategy
 Use hybrid retrieval, then re-rank.
@@ -52,7 +51,7 @@ Use hybrid retrieval, then re-rank.
 ### 3.1 Candidate Retrieval
 - lexical retrieval (BM25/keyword style on content + important terms)
 - entity retrieval (entity overlap boost)
-- vector retrieval (when embeddings exist)
+- no vector retrieval in the current live pipeline
 
 ### 3.2 Candidate Merge
 - union candidate sets by `doc_id`
@@ -76,9 +75,8 @@ Return ranked docs with transparent reasons:
 ## 4. Query Flow
 1. Parse query into entities and terms.
 2. Retrieve top N from lexical and entity indexes.
-3. Merge with vector top N (if available).
-4. Re-rank using Tier 1 features.
-5. Return results with `why_matched` evidence.
+3. Re-rank using Tier 1 features.
+4. Return results with `why_matched` evidence.
 
 ## 5. Claim-Hint Extension (Later)
 When `top_claims` is available, use claim overlap/conflict hints to:
@@ -90,3 +88,4 @@ When `top_claims` is available, use claim overlap/conflict hints to:
 - Keep indexing deterministic and reproducible via provenance/version fields.
 - Rebuild index whenever ranker/provider/version changes.
 - Keep index structures plain memory objects for algorithm-first iteration.
+- Leave vector retrieval as a future extension, not a current dependency.

--- a/docs/tier1-indexing-and-search.md
+++ b/docs/tier1-indexing-and-search.md
@@ -7,16 +7,15 @@ Store one Tier 1 record per `doc_id` with:
 - `probable_topic`
 - `key_entities` (text, label, score)
 - `important_terms` (term, score, ranker source)
-- `doc_type_guess` (when added)
-- `embedding` (when added)
-- `top_claims` (when added)
+- `doc_type_guess`
+- `embedding` (reserved for future vector workflows; not used by the live query path)
+- `top_claims`
 
 ## Indexing Strategy
 Build multiple indexes from Tier 1 outputs:
 - lexical inverted index on `important_terms` and headings
 - entity index (`entity -> doc_ids`)
 - topic and document-type facets
-- vector index for embeddings
 
 Keep provenance fields (`source`, timestamps, ranker version) to support reindexing and reproducibility.
 
@@ -24,7 +23,7 @@ Keep provenance fields (`source`, timestamps, ranker version) to support reindex
 Use hybrid retrieval:
 - BM25 or keyword retrieval on content and important terms
 - entity-match boost from key-entity overlap
-- vector similarity search (when embeddings exist)
+- no vector similarity search in the current live pipeline
 
 Re-rank candidates with Tier 1 signals:
 - entity score overlap
@@ -37,12 +36,12 @@ Use claim hints (when available) to select comparison candidates for contradicti
 ## Query Flow
 1. Parse query into entities and terms.
 2. Retrieve top N from lexical and entity indexes.
-3. Merge with vector top N.
-4. Re-rank using Tier 1 features.
-5. Return documents with transparent match reasons (matched entities and terms).
+3. Re-rank using Tier 1 features.
+4. Return documents with transparent match reasons (matched entities and terms).
 
 ## Expected Outcomes
-- improved clustering quality (entity + term + vector signals)
+- improved clustering quality from entity, term, topic, and claim signals
 - faster comparison-candidate generation
 - terminology drift detection over time
 - prioritization using salience, confidence, recency, and conflict likelihood
+- vector retrieval can be added later without changing the Tier 1 record shape

--- a/docs/tier1-light-understanding.md
+++ b/docs/tier1-light-understanding.md
@@ -8,7 +8,7 @@ For every document, extract a cheap fingerprint.
 - key entities/concepts
 - important terms
 - document type guess
-- summary embedding
+- optional embedding placeholder for future vector workflows
 - a few top claims
 
 ## What This Enables
@@ -90,7 +90,7 @@ Use heading patterns and lexical cues.
 2-4 sentence cheap summary (extractive first, abstractive optional).
 
 ### 6. Embedding
-One document embedding over cleaned text (or title + headings + lead paragraph for cost cap).
+Embedding is currently stored as an optional field, but the live pipeline does not use vector retrieval.
 
 ### 7. Top Claims
 Extract 3-8 claim tuples:
@@ -134,7 +134,7 @@ CLI examples:
 
 Behavior:
 - default provider is `heuristic`
-- `spacy` provider calls `scripts/spacy_ner.py` via `python3`
+- `spacy` provider calls `scripts/spacy_ner.py` via a crate-relative path resolved from `CARGO_MANIFEST_DIR`
 - if spaCy is unavailable, the pipeline falls back to heuristic entities
 
 ## Important Terms Rankers

--- a/scripts/build_lexical_subsets.py
+++ b/scripts/build_lexical_subsets.py
@@ -20,7 +20,7 @@ import json
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import DefaultDict, Iterable
+from typing import DefaultDict
 
 
 WORDNET_FILES = ("data.noun", "data.verb", "data.adj", "data.adv")

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use std::path::Path;
+
+use crate::source::SourceDocument;
+
+#[derive(Debug, Clone)]
+pub struct AdapterInput<'a> {
+    pub root: &'a Path,
+    pub max_bytes: usize,
+    pub max_files: usize,
+    pub max_depth: usize,
+    pub max_total_bytes: usize,
+}
+
+pub trait SourceAdapter {
+    fn name(&self) -> &'static str;
+    fn supports(&self, path: &Path) -> bool;
+    fn ingest(&self, input: &AdapterInput<'_>) -> Result<Vec<SourceDocument>>;
+}
+
+pub mod markdown;
+
+pub fn default_source_adapters() -> Vec<Box<dyn SourceAdapter>> {
+    vec![Box::new(markdown::MarkdownAdapter)]
+}

--- a/src/adapters/markdown.rs
+++ b/src/adapters/markdown.rs
@@ -1,0 +1,282 @@
+use anyhow::Result;
+use comrak::{nodes::NodeValue, parse_document, Arena, ComrakOptions};
+use regex::Regex;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+use walkdir::WalkDir;
+
+use crate::adapters::{AdapterInput, SourceAdapter};
+use crate::graph::{concept_from_link_target, normalize_concept, rel_path, Tier0Record};
+use crate::source::SourceDocument;
+
+#[derive(Debug, Clone)]
+pub struct SourcePage {
+    pub path: String,
+    pub rel_path: String,
+    pub concept: String,
+    pub raw_concept: String,
+    pub content: String,
+    pub links: std::collections::HashSet<String>,
+    pub headings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MarkdownCorpus {
+    pub pages: Vec<SourcePage>,
+    pub tier0_records: Vec<Tier0Record>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MarkdownAdapter;
+
+impl SourceAdapter for MarkdownAdapter {
+    fn name(&self) -> &'static str {
+        "markdown"
+    }
+
+    fn supports(&self, path: &Path) -> bool {
+        path.extension()
+            .and_then(|s| s.to_str())
+            .map(|ext| ext.eq_ignore_ascii_case("md"))
+            .unwrap_or(false)
+    }
+
+    fn ingest(&self, input: &AdapterInput<'_>) -> Result<Vec<SourceDocument>> {
+        let corpus = build_markdown_corpus(
+            input.root,
+            input.max_bytes,
+            input.max_files,
+            input.max_depth,
+            input.max_total_bytes,
+        )?;
+        Ok(corpus
+            .pages
+            .into_iter()
+            .map(|page| {
+                let doc_length = page.content.len();
+                SourceDocument {
+                    doc_id: page.rel_path.clone(),
+                    source: page.rel_path,
+                    content: page.content,
+                    concept: page.raw_concept,
+                    group_id: None,
+                    headings: page.headings,
+                    links: page.links.into_iter().collect(),
+                    timestamp: None,
+                    doc_length,
+                    author_agent: None,
+                }
+            })
+            .collect())
+    }
+}
+
+pub fn build_markdown_corpus(
+    root: &Path,
+    max_bytes: usize,
+    max_files: usize,
+    max_depth: usize,
+    max_total_bytes: usize,
+) -> Result<MarkdownCorpus> {
+    let base = docs_dir(root);
+    let base_walk = base.clone();
+    let single_file = if root.is_file() {
+        Some(root.to_path_buf())
+    } else {
+        None
+    };
+    let rel_root = if root.is_file() { base.as_path() } else { root };
+
+    let wiki_link_re = Regex::new(r"\[\[(.*?)\]\]")?;
+    let md_link_re = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)")?;
+    let md_heading_re = Regex::new(r"(?m)^#{1,6}\s+(.*)$")?;
+
+    let mut pages = Vec::new();
+    let mut tier0_records = Vec::new();
+    let mut files_seen = 0usize;
+    let mut total_bytes = 0usize;
+
+    for entry in WalkDir::new(base_walk).max_depth(max_depth) {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if let Some(ref only) = single_file {
+            if entry.path() != only {
+                continue;
+            }
+        }
+
+        let ext = entry
+            .path()
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        if ext != "md" {
+            continue;
+        }
+
+        files_seen += 1;
+        if files_seen > max_files {
+            break;
+        }
+
+        let metadata = entry.metadata()?;
+        if metadata.len() as usize > max_bytes {
+            continue;
+        }
+        total_bytes = total_bytes.saturating_add(metadata.len() as usize);
+        if total_bytes > max_total_bytes {
+            break;
+        }
+
+        let content = fs::read_to_string(entry.path())?;
+        let raw_concept = entry
+            .path()
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        let concept = normalize_concept(&raw_concept);
+
+        let mut links = std::collections::HashSet::new();
+        let mut headings = Vec::new();
+
+        for cap in wiki_link_re.captures_iter(&content) {
+            if let Some(concept) = concept_from_link_target(cap[1].trim()) {
+                links.insert(concept);
+            }
+        }
+
+        for cap in md_link_re.captures_iter(&content) {
+            let target = cap.get(2).map(|m| m.as_str()).unwrap_or("");
+            if let Some(concept) = concept_from_link_target(target) {
+                links.insert(concept);
+            }
+        }
+
+        for cap in md_heading_re.captures_iter(&content) {
+            let heading = cap[1].trim();
+            if !heading.is_empty() {
+                headings.push(heading.to_string());
+            }
+        }
+
+        if headings.is_empty() {
+            let arena = Arena::new();
+            let ast = parse_document(&arena, &content, &ComrakOptions::default());
+            let mut stack = vec![ast];
+            while let Some(node) = stack.pop() {
+                for child in node.children() {
+                    stack.push(child);
+                }
+                if let NodeValue::Heading(ref heading) = node.data.borrow().value {
+                    let mut text = String::new();
+                    for child in node.children() {
+                        if let NodeValue::Text(ref t) = child.data.borrow().value {
+                            text.push_str(t);
+                        }
+                    }
+                    if !text.is_empty() {
+                        headings.push(text);
+                    } else if heading.level > 0 {
+                        headings.push(format!("(heading level {})", heading.level));
+                    }
+                }
+            }
+        }
+
+        let page = SourcePage {
+            path: entry.path().display().to_string(),
+            rel_path: rel_path(rel_root, entry.path()),
+            concept,
+            raw_concept,
+            content,
+            links,
+            headings,
+        };
+
+        let mut basic_metadata: HashMap<String, String> = HashMap::new();
+        basic_metadata.insert("concept".to_string(), page.concept.clone());
+        basic_metadata.insert("raw_concept".to_string(), page.raw_concept.clone());
+        basic_metadata.insert("file_ext".to_string(), "md".to_string());
+        basic_metadata.insert("heading_count".to_string(), page.headings.len().to_string());
+        basic_metadata.insert(
+            "outbound_link_count".to_string(),
+            page.links.len().to_string(),
+        );
+        basic_metadata.insert("path".to_string(), page.path.clone());
+
+        let file_size = metadata.len() as usize;
+        let timestamp = metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs().to_string());
+        let frontmatter = parse_frontmatter_kv(&page.content);
+        let author_agent = frontmatter
+            .get("author")
+            .cloned()
+            .or_else(|| frontmatter.get("agent").cloned())
+            .or_else(|| frontmatter.get("author_agent").cloned())
+            .or_else(|| frontmatter.get("created_by").cloned());
+        if frontmatter.contains_key("author") {
+            basic_metadata.insert("frontmatter_author".to_string(), "true".to_string());
+        }
+        if frontmatter.contains_key("agent") {
+            basic_metadata.insert("frontmatter_agent".to_string(), "true".to_string());
+        }
+        basic_metadata.insert("file_size_bytes".to_string(), file_size.to_string());
+
+        tier0_records.push(Tier0Record {
+            id: page.rel_path.clone(),
+            source: page.rel_path.clone(),
+            timestamp,
+            author_agent,
+            doc_length: file_size,
+            metadata: basic_metadata,
+        });
+        pages.push(page);
+    }
+
+    Ok(MarkdownCorpus {
+        pages,
+        tier0_records,
+    })
+}
+
+fn docs_dir(root: &Path) -> PathBuf {
+    if root.is_file() {
+        return root.parent().unwrap_or(root).to_path_buf();
+    }
+    let docs = root.join("docs");
+    if docs.is_dir() {
+        docs
+    } else {
+        root.to_path_buf()
+    }
+}
+
+pub(crate) fn parse_frontmatter_kv(content: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let mut lines = content.lines();
+    if lines.next() != Some("---") {
+        return out;
+    }
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            break;
+        }
+        if let Some((k, v)) = trimmed.split_once(':') {
+            let key = k.trim().to_lowercase();
+            let value = v.trim().trim_matches('"').trim_matches('\'').to_string();
+            if !key.is_empty() && !value.is_empty() {
+                out.insert(key, value);
+            }
+        }
+    }
+    out
+}

--- a/src/bin/haystack_scoped_benchmark.rs
+++ b/src/bin/haystack_scoped_benchmark.rs
@@ -1,0 +1,587 @@
+use anyhow::{Context, Result};
+use clap::{ArgAction, Parser};
+use lint_ai::index::TemporalQueryHint;
+use lint_ai::{
+    aggregation::{build_aggregate_output, AggregateOutput},
+    build_query_snapshot_from_source_documents,
+    query_semantics::{analyze_query, QueryTimeHint},
+    ChunkStrategy, QueryDiagnostics, QueryTimings, SearchResult, SourceDocument,
+    TemporalQueryContext, Tier1NerProvider, Tier1TermRankerKind,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+#[derive(Debug, Parser)]
+#[command(name = "haystack-scoped-benchmark")]
+#[command(about = "Run a question-scoped LongMemEval haystack benchmark against Lint-AI")]
+struct Args {
+    /// Path to the raw LongMemEval-S dataset.
+    #[arg(long)]
+    longmemeval: PathBuf,
+
+    /// Top-K values to evaluate. Repeat the flag to add multiple K values.
+    #[arg(long = "k", default_values_t = vec![1usize, 3, 5, 10])]
+    ks: Vec<usize>,
+
+    /// Limit the number of queries to evaluate.
+    #[arg(long)]
+    limit: Option<usize>,
+
+    /// Only evaluate one question type, for example `multi-session`.
+    #[arg(long)]
+    question_type: Option<String>,
+
+    /// Optional output path for JSON results.
+    #[arg(long)]
+    out: Option<PathBuf>,
+
+    /// Enable n-gram text reranking on the top rerank window.
+    #[arg(long, action = ArgAction::SetTrue)]
+    text_rerank_ngram: bool,
+
+    /// Enable LCS text reranking on the top rerank window.
+    #[arg(long, action = ArgAction::SetTrue)]
+    text_rerank_lcs: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LongMemEvalEntry {
+    question_id: String,
+    question_type: String,
+    question: String,
+    question_date: String,
+    #[serde(default)]
+    answer_session_ids: Vec<String>,
+    #[serde(default)]
+    haystack_session_ids: Vec<String>,
+    #[serde(default)]
+    haystack_dates: Vec<String>,
+    #[serde(default)]
+    haystack_sessions: Vec<Vec<LongMemEvalTurn>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LongMemEvalTurn {
+    role: String,
+    content: String,
+    #[serde(default)]
+    _has_answer: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryMetrics {
+    id: String,
+    query: String,
+    question_type: Option<String>,
+    question_date: Option<String>,
+    analysis_ms: f64,
+    candidate_session_ids: Vec<String>,
+    retrieved_session_ids: Vec<String>,
+    aggregation: Option<AggregateOutput>,
+    recall_at_k: HashMap<usize, f64>,
+    recall_any_at_k: HashMap<usize, f64>,
+    mrr: f64,
+    ndcg_at_10: f64,
+    timings: QueryTimings,
+    diagnostics: QueryDiagnostics,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AggregateMetrics {
+    query_count: usize,
+    analysis_ms: f64,
+    recall_at_k: HashMap<usize, f64>,
+    recall_any_at_k: HashMap<usize, f64>,
+    mrr: f64,
+    ndcg_at_10: f64,
+    timings: QueryTimings,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TypeMetrics {
+    query_count: usize,
+    analysis_ms: f64,
+    recall_at_k: HashMap<usize, f64>,
+    recall_any_at_k: HashMap<usize, f64>,
+    mrr: f64,
+    ndcg_at_10: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BenchmarkReport {
+    aggregate: AggregateMetrics,
+    by_question_type: HashMap<String, TypeMetrics>,
+    per_query: Vec<QueryMetrics>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let mut ks = args
+        .ks
+        .into_iter()
+        .filter(|k| *k > 0)
+        .collect::<Vec<usize>>();
+    ks.sort_unstable();
+    ks.dedup();
+    if ks.is_empty() {
+        anyhow::bail!("at least one positive --k value is required");
+    }
+
+    eprintln!("loading raw LongMemEval data...");
+    let data = fs::read_to_string(&args.longmemeval)
+        .with_context(|| format!("failed to read {}", args.longmemeval.display()))?;
+    let raw: Vec<LongMemEvalEntry> =
+        serde_json::from_str(&data).context("failed to parse raw LongMemEval JSON")?;
+
+    let report = run_scoped_benchmark(
+        raw,
+        args.limit,
+        args.question_type.as_deref(),
+        &ks,
+        args.text_rerank_ngram,
+        args.text_rerank_lcs,
+    )?;
+    let json = serde_json::to_string_pretty(&report)?;
+
+    if let Some(out) = args.out {
+        fs::write(&out, &json)
+            .with_context(|| format!("failed to write benchmark report to {}", out.display()))?;
+        println!("wrote benchmark report to {}", out.display());
+    } else {
+        println!("{}", json);
+    }
+
+    Ok(())
+}
+
+fn run_scoped_benchmark(
+    raw: Vec<LongMemEvalEntry>,
+    limit: Option<usize>,
+    question_type: Option<&str>,
+    ks: &[usize],
+    text_rerank_ngram: bool,
+    text_rerank_lcs: bool,
+) -> Result<BenchmarkReport> {
+    let abstention_types = HashSet::from([
+        "single-session-user_abs".to_string(),
+        "multi-session_abs".to_string(),
+        "knowledge-update_abs".to_string(),
+        "temporal-reasoning_abs".to_string(),
+    ]);
+
+    let entries = raw
+        .into_iter()
+        .filter(|entry| !abstention_types.contains(&entry.question_type))
+        .filter(|entry| question_type.is_none_or(|wanted| entry.question_type == wanted))
+        .take(limit.unwrap_or(usize::MAX))
+        .collect::<Vec<_>>();
+
+    if let Some(question_type) = question_type {
+        eprintln!(
+            "running {} scoped questions for question_type={}...",
+            entries.len(),
+            question_type
+        );
+    } else {
+        eprintln!("running {} scoped questions...", entries.len());
+    }
+    let max_k = ks.iter().copied().max().unwrap_or(10).max(10);
+    let mut per_query = Vec::with_capacity(entries.len());
+
+    for (idx, entry) in entries.into_iter().enumerate() {
+        let analysis_start = Instant::now();
+        let analysis = analyze_query(&entry.question);
+        let analysis_ms = analysis_start.elapsed().as_secs_f64() * 1000.0;
+        let query_text = analysis.augmented_query.clone();
+        let candidate_session_ids = entry.haystack_session_ids.clone();
+        let source_docs = build_scoped_source_docs(&entry);
+        let index = build_query_snapshot_from_source_documents(
+            &source_docs,
+            &Tier1NerProvider::Heuristic,
+            "en_core_web_sm",
+            &Tier1TermRankerKind::Yake,
+            &ChunkStrategy::Heading,
+            40,
+            10,
+            450,
+            800,
+            text_rerank_ngram,
+            text_rerank_lcs,
+        )?;
+        let temporal = TemporalQueryContext {
+            starts_from: None,
+            ends_at: Some(entry.question_date.as_str()),
+            window_days: 7,
+            hard_filter: false,
+            time_hint: analysis
+                .time_hint
+                .filter(|_| analysis.temporal.is_some())
+                .map(|hint| match hint {
+                    QueryTimeHint::Past => TemporalQueryHint::Past,
+                    QueryTimeHint::Present => TemporalQueryHint::Present,
+                    QueryTimeHint::Ongoing => TemporalQueryHint::Ongoing,
+                    QueryTimeHint::Mixed => TemporalQueryHint::Mixed,
+                }),
+            allowed_doc_ids: None,
+            query_routing_intent: analysis.query_routing_intent,
+            has_explicit_temporal: analysis.temporal.is_some(),
+        };
+        let (results, timings, diagnostics) =
+            index.query_with_temporal_context(&query_text, max_k, temporal);
+        let aggregation = build_aggregate_output(&index, &entry.question, &results, max_k);
+        assert_group_diversity(&results, 2, &entry.question_id);
+        let retrieved_session_ids = results
+            .into_iter()
+            .map(|r| evaluation_group_id(&r.doc_id))
+            .collect::<Vec<_>>();
+        let retrieved_session_ids = dedupe_preserve_order(retrieved_session_ids);
+        let relevant = candidate_session_ids
+            .iter()
+            .filter(|session_id| entry.answer_session_ids.contains(session_id))
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        let mut recall_at_k = HashMap::new();
+        let mut recall_any_at_k = HashMap::new();
+        for k in ks {
+            recall_at_k.insert(*k, recall_at_k_fn(&retrieved_session_ids, &relevant, *k));
+            recall_any_at_k.insert(
+                *k,
+                recall_any_at_k_fn(&retrieved_session_ids, &relevant, *k),
+            );
+        }
+
+        let mrr = reciprocal_rank(&retrieved_session_ids, &relevant);
+        let ndcg_at_10 = ndcg_at_k(&retrieved_session_ids, &relevant, 10);
+
+        per_query.push(QueryMetrics {
+            id: entry.question_id,
+            query: entry.question,
+            question_type: Some(entry.question_type),
+            question_date: Some(entry.question_date),
+            analysis_ms,
+            candidate_session_ids,
+            retrieved_session_ids,
+            aggregation,
+            recall_at_k,
+            recall_any_at_k,
+            mrr,
+            ndcg_at_10,
+            timings,
+            diagnostics,
+        });
+
+        let last = per_query.last().expect("query metrics should exist");
+        eprintln!(
+            "[{}/{}] {} candidates={} q={} analysis={:.2}ms total={:.2}ms snapshot={:.2}ms rerank={:.2}ms sparse={:.2}ms lex_merge={:.2}ms post={:.2}ms routing={:.2}ms seq_rerank={:.2}ms evidence={:.2}ms group_build={:.2}ms group_sort={:.2}ms",
+            idx + 1,
+            per_query.len(),
+            last.id,
+            last.candidate_session_ids.len(),
+            last.diagnostics.query_terms,
+            last.analysis_ms,
+            last.timings.total_ms,
+            last.timings.snapshot_query_ms,
+            last.timings.rerank_ms,
+            last.timings.sparse_scoring_ms,
+            last.timings.lexical_merge_ms,
+            last.timings.posting_scoring_ms,
+            last.timings.routing_seed_ms,
+            last.timings.sequence_rerank_ms,
+            last.timings.evidence_ms,
+            last.timings.group_build_ms,
+            last.timings.group_sort_ms,
+        );
+    }
+
+    Ok(BenchmarkReport {
+        aggregate: aggregate_metrics(&per_query, ks),
+        by_question_type: aggregate_by_question_type(&per_query, ks),
+        per_query,
+    })
+}
+
+fn build_scoped_source_docs(entry: &LongMemEvalEntry) -> Vec<SourceDocument> {
+    let mut docs = Vec::new();
+    for (idx, (session_id, turns)) in entry
+        .haystack_session_ids
+        .iter()
+        .cloned()
+        .zip(entry.haystack_sessions.iter())
+        .enumerate()
+    {
+        let session_date = entry
+            .haystack_dates
+            .get(idx)
+            .cloned()
+            .unwrap_or_else(|| entry.question_date.clone());
+        for (turn_idx, turn) in turns.iter().enumerate() {
+            let doc_id = format!("{}::turn{}", session_id, turn_idx);
+            docs.push(SourceDocument {
+                doc_id,
+                source: format!("longmemeval/session/{session_id}/turn/{turn_idx}"),
+                content: format!("{}: {}", turn.role, turn.content),
+                concept: "longmemeval-turn".to_string(),
+                group_id: Some(session_id.clone()),
+                headings: vec![format!("session:{session_id}")],
+                links: vec![],
+                timestamp: Some(session_date.clone()),
+                doc_length: turn.content.len(),
+                author_agent: None,
+            });
+        }
+    }
+    docs
+}
+
+fn evaluation_group_id(doc_id: &str) -> String {
+    doc_id.split("::turn").next().unwrap_or(doc_id).to_string()
+}
+
+fn dedupe_preserve_order(items: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for item in items {
+        if seen.insert(item.clone()) {
+            out.push(item);
+        }
+    }
+    out
+}
+
+fn recall_at_k_fn(retrieved: &[String], relevant: &HashSet<String>, k: usize) -> f64 {
+    if relevant.is_empty() {
+        return 0.0;
+    }
+    let limit = k.min(retrieved.len());
+    let hits = retrieved
+        .iter()
+        .take(limit)
+        .filter(|doc_id| relevant.contains(*doc_id))
+        .count();
+    hits as f64 / relevant.len() as f64
+}
+
+fn recall_any_at_k_fn(retrieved: &[String], relevant: &HashSet<String>, k: usize) -> f64 {
+    if relevant.is_empty() {
+        return 0.0;
+    }
+    let limit = k.min(retrieved.len());
+    if retrieved
+        .iter()
+        .take(limit)
+        .any(|doc_id| relevant.contains(doc_id))
+    {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+fn reciprocal_rank(retrieved: &[String], relevant: &HashSet<String>) -> f64 {
+    for (idx, doc_id) in retrieved.iter().enumerate() {
+        if relevant.contains(doc_id) {
+            return 1.0 / (idx as f64 + 1.0);
+        }
+    }
+    0.0
+}
+
+fn ndcg_at_k(retrieved: &[String], relevant: &HashSet<String>, k: usize) -> f64 {
+    let mut dcg = 0.0;
+    for (idx, doc_id) in retrieved.iter().take(k).enumerate() {
+        if relevant.contains(doc_id) {
+            dcg += 1.0 / ((idx as f64 + 2.0).log2());
+        }
+    }
+    let ideal = relevant.len().min(k);
+    let idcg = (0..ideal)
+        .map(|idx| 1.0 / ((idx as f64 + 2.0).log2()))
+        .sum::<f64>();
+    if idcg == 0.0 {
+        0.0
+    } else {
+        dcg / idcg
+    }
+}
+
+fn assert_group_diversity(results: &[SearchResult], cap: usize, query_id: &str) {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for result in results {
+        if let Some(group_id) = result.group_id.as_ref() {
+            *counts.entry(group_id.clone()).or_default() += 1;
+        }
+    }
+    let max_count = counts.values().copied().max().unwrap_or(0);
+    eprintln!("{} group_counts={:?}", query_id, counts);
+    assert!(
+        max_count <= cap,
+        "query {} exceeded group cap {} with counts {:?}",
+        query_id,
+        cap,
+        counts
+    );
+}
+
+fn aggregate_metrics(per_query: &[QueryMetrics], ks: &[usize]) -> AggregateMetrics {
+    let n = per_query.len();
+    if n == 0 {
+        return AggregateMetrics {
+            query_count: 0,
+            analysis_ms: 0.0,
+            recall_at_k: ks.iter().copied().map(|k| (k, 0.0)).collect(),
+            recall_any_at_k: ks.iter().copied().map(|k| (k, 0.0)).collect(),
+            mrr: 0.0,
+            ndcg_at_10: 0.0,
+            timings: QueryTimings::default(),
+        };
+    }
+
+    let mut recall_at_k = HashMap::new();
+    let mut recall_any_at_k = HashMap::new();
+    for k in ks {
+        let avg = per_query
+            .iter()
+            .map(|q| q.recall_at_k.get(k).copied().unwrap_or(0.0))
+            .sum::<f64>()
+            / n as f64;
+        recall_at_k.insert(*k, avg);
+        let avg_any = per_query
+            .iter()
+            .map(|q| q.recall_any_at_k.get(k).copied().unwrap_or(0.0))
+            .sum::<f64>()
+            / n as f64;
+        recall_any_at_k.insert(*k, avg_any);
+    }
+
+    let timings = QueryTimings {
+        total_ms: per_query.iter().map(|q| q.timings.total_ms).sum::<f64>() / n as f64,
+        refresh_ms: per_query.iter().map(|q| q.timings.refresh_ms).sum::<f64>() / n as f64,
+        lexical_bm25_ms: per_query
+            .iter()
+            .map(|q| q.timings.lexical_bm25_ms)
+            .sum::<f64>()
+            / n as f64,
+        snapshot_query_ms: per_query
+            .iter()
+            .map(|q| q.timings.snapshot_query_ms)
+            .sum::<f64>()
+            / n as f64,
+        rerank_ms: per_query.iter().map(|q| q.timings.rerank_ms).sum::<f64>() / n as f64,
+        parse_ms: per_query.iter().map(|q| q.timings.parse_ms).sum::<f64>() / n as f64,
+        sparse_scoring_ms: per_query
+            .iter()
+            .map(|q| q.timings.sparse_scoring_ms)
+            .sum::<f64>()
+            / n as f64,
+        lexical_merge_ms: per_query
+            .iter()
+            .map(|q| q.timings.lexical_merge_ms)
+            .sum::<f64>()
+            / n as f64,
+        posting_scoring_ms: per_query
+            .iter()
+            .map(|q| q.timings.posting_scoring_ms)
+            .sum::<f64>()
+            / n as f64,
+        routing_seed_ms: per_query
+            .iter()
+            .map(|q| q.timings.routing_seed_ms)
+            .sum::<f64>()
+            / n as f64,
+        candidate_accumulation_ms: per_query
+            .iter()
+            .map(|q| q.timings.candidate_accumulation_ms)
+            .sum::<f64>()
+            / n as f64,
+        candidate_rank_ms: per_query
+            .iter()
+            .map(|q| q.timings.candidate_rank_ms)
+            .sum::<f64>()
+            / n as f64,
+        metadata_ms: per_query.iter().map(|q| q.timings.metadata_ms).sum::<f64>() / n as f64,
+        graph_ms: per_query.iter().map(|q| q.timings.graph_ms).sum::<f64>() / n as f64,
+        entity_graph_ms: per_query
+            .iter()
+            .map(|q| q.timings.entity_graph_ms)
+            .sum::<f64>()
+            / n as f64,
+        sequence_rerank_ms: per_query
+            .iter()
+            .map(|q| q.timings.sequence_rerank_ms)
+            .sum::<f64>()
+            / n as f64,
+        evidence_ms: per_query.iter().map(|q| q.timings.evidence_ms).sum::<f64>() / n as f64,
+        group_build_ms: per_query
+            .iter()
+            .map(|q| q.timings.group_build_ms)
+            .sum::<f64>()
+            / n as f64,
+        group_sort_ms: per_query
+            .iter()
+            .map(|q| q.timings.group_sort_ms)
+            .sum::<f64>()
+            / n as f64,
+        ranking_ms: per_query.iter().map(|q| q.timings.ranking_ms).sum::<f64>() / n as f64,
+    };
+
+    AggregateMetrics {
+        query_count: n,
+        analysis_ms: per_query.iter().map(|q| q.analysis_ms).sum::<f64>() / n as f64,
+        recall_at_k,
+        recall_any_at_k,
+        mrr: per_query.iter().map(|q| q.mrr).sum::<f64>() / n as f64,
+        ndcg_at_10: per_query.iter().map(|q| q.ndcg_at_10).sum::<f64>() / n as f64,
+        timings,
+    }
+}
+
+fn aggregate_by_question_type(
+    per_query: &[QueryMetrics],
+    ks: &[usize],
+) -> HashMap<String, TypeMetrics> {
+    let mut buckets: HashMap<String, Vec<&QueryMetrics>> = HashMap::new();
+    for q in per_query {
+        let key = q
+            .question_type
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string());
+        buckets.entry(key).or_default().push(q);
+    }
+
+    let mut out = HashMap::new();
+    for (question_type, items) in buckets {
+        let n = items.len();
+        let mut recall_at_k = HashMap::new();
+        let mut recall_any_at_k = HashMap::new();
+        for k in ks {
+            let avg = items
+                .iter()
+                .map(|q| q.recall_at_k.get(k).copied().unwrap_or(0.0))
+                .sum::<f64>()
+                / n as f64;
+            recall_at_k.insert(*k, avg);
+            let avg_any = items
+                .iter()
+                .map(|q| q.recall_any_at_k.get(k).copied().unwrap_or(0.0))
+                .sum::<f64>()
+                / n as f64;
+            recall_any_at_k.insert(*k, avg_any);
+        }
+        out.insert(
+            question_type,
+            TypeMetrics {
+                query_count: n,
+                analysis_ms: items.iter().map(|q| q.analysis_ms).sum::<f64>() / n as f64,
+                recall_at_k,
+                recall_any_at_k,
+                mrr: items.iter().map(|q| q.mrr).sum::<f64>() / n as f64,
+                ndcg_at_10: items.iter().map(|q| q.ndcg_at_10).sum::<f64>() / n as f64,
+            },
+        );
+    }
+    out
+}

--- a/src/claim_extractor.rs
+++ b/src/claim_extractor.rs
@@ -48,11 +48,12 @@ impl ClaimExtractor for ConservativeClaimExtractor {
 fn chunk_claims(record: &DocRecord, chunk: &SectionChunk) -> Vec<Claim> {
     let mut out = Vec::new();
 
-    if let Some(topic) = record.probable_topic.as_ref().filter(|s| !s.trim().is_empty()) {
-        if chunk
-            .heading
-            .to_lowercase()
-            .contains(&topic.to_lowercase())
+    if let Some(topic) = record
+        .probable_topic
+        .as_ref()
+        .filter(|s| !s.trim().is_empty())
+    {
+        if chunk.heading.to_lowercase().contains(&topic.to_lowercase())
             || chunk.content.to_lowercase().contains(&topic.to_lowercase())
         {
             out.push(Claim {
@@ -110,7 +111,11 @@ fn dedupe_claims(claims: &mut Vec<Claim>) {
             .cmp(&b.subject)
             .then_with(|| a.predicate.cmp(&b.predicate))
             .then_with(|| a.object.cmp(&b.object))
-            .then_with(|| a.confidence.partial_cmp(&b.confidence).unwrap_or(std::cmp::Ordering::Equal))
+            .then_with(|| {
+                a.confidence
+                    .partial_cmp(&b.confidence)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
     });
     claims.dedup_by(|a, b| {
         a.subject == b.subject && a.predicate == b.predicate && a.object == b.object

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,17 +3,18 @@ use crate::cli::{GraphExportFormat, GraphLevel, LlmChunkStrategy};
 use crate::config::{load_config, normalize_list, Config};
 use crate::filters::is_noise_concept;
 use crate::graph::{normalize_concept, Graph, Tier0Record};
-use crate::index::{DocRecord, MemoryIndex, SectionChunk};
+use crate::index::{DocRecord, MemoryIndex, SectionChunk, TemporalQueryContext, TemporalQueryHint};
 use crate::pipeline::{
     source_documents_to_tier1_inputs, ChunkStrategy, Tier1NerProvider, Tier1TermRankerKind,
 };
+use crate::query_semantics::{analyze_query, QueryAnalysis, QueryTimeHint};
 use crate::report::Report;
 use crate::rules::cross_refs::check_cross_refs;
 use crate::rules::orphan_pages::check_orphans;
 use crate::source::SourceDocument;
 use crate::tier1::{
-    HeuristicKeyEntityRanker, ImportantTermRanker, KeyEntityRanker, SpacyKeyEntityRanker,
-    Tier1DocEntities, Tier1DocInput, Tier1DocTerms,
+    default_spacy_script_path, HeuristicKeyEntityRanker, ImportantTermRanker, KeyEntityRanker,
+    SpacyKeyEntityRanker, Tier1DocEntities, Tier1DocInput, Tier1DocTerms,
 };
 use aho_corasick::AhoCorasick;
 use anyhow::Result;
@@ -67,6 +68,33 @@ fn graph_to_source_documents(graph: &Graph) -> Vec<SourceDocument> {
             }
         })
         .collect()
+}
+
+fn query_temporal_context(analysis: &QueryAnalysis) -> TemporalQueryContext<'_> {
+    TemporalQueryContext {
+        starts_from: None,
+        ends_at: None,
+        window_days: match analysis.time_hint {
+            Some(QueryTimeHint::Past) => 365,
+            Some(QueryTimeHint::Present) => 30,
+            Some(QueryTimeHint::Ongoing) => 14,
+            Some(QueryTimeHint::Mixed) => 30,
+            None => 7,
+        },
+        hard_filter: false,
+        time_hint: analysis
+            .time_hint
+            .map(|hint| match hint {
+                QueryTimeHint::Past => TemporalQueryHint::Past,
+                QueryTimeHint::Present => TemporalQueryHint::Present,
+                QueryTimeHint::Ongoing => TemporalQueryHint::Ongoing,
+                QueryTimeHint::Mixed => TemporalQueryHint::Mixed,
+            })
+            .filter(|_| analysis.temporal.is_some()),
+        query_routing_intent: analysis.query_routing_intent,
+        has_explicit_temporal: analysis.temporal.is_some(),
+        allowed_doc_ids: None,
+    }
 }
 
 fn surface_forms(raw: &str) -> Vec<String> {
@@ -527,7 +555,7 @@ fn show_tier1_entities(
         Tier1NerProvider::Spacy => {
             let spacy = SpacyKeyEntityRanker {
                 model: spacy_model.to_string(),
-                script_path: "scripts/spacy_ner.py".to_string(),
+                script_path: default_spacy_script_path().display().to_string(),
             };
             match spacy.rank_docs(&docs) {
                 Ok(out) => out,
@@ -809,8 +837,7 @@ fn load_cached_query_index(s: &CacheSettings<'_>, corpus_fingerprint: &str) -> O
         &core_file,
         Some(&lexical_dir),
         false,
-    )
-    {
+    ) {
         Ok(index) => return Some(index),
         Err(err) => {
             eprintln!(
@@ -852,9 +879,88 @@ fn save_cached_query_index(
         corpus_fingerprint: corpus_fingerprint.to_string(),
         records,
     };
-    fs::write(cache_file, serde_json::to_string(&payload)?)?;
+    safe_write_text_file(
+        &cache_file.display().to_string(),
+        &serde_json::to_string(&payload)?,
+    )?;
     let core_file = query_cache_core_file(s);
-    index.save_binary_core(&core_file)?;
+    save_binary_core_atomic(index, &core_file)?;
+    Ok(())
+}
+
+fn ensure_safe_output_path(path: &Path) -> Result<()> {
+    if path.is_dir() {
+        anyhow::bail!("refusing to write: output path is a directory");
+    }
+    if let Ok(meta) = fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            anyhow::bail!("refusing to write: output path is a symlink");
+        }
+    }
+    if let Some(parent) = path.parent() {
+        let mut cur = if parent.is_absolute() {
+            PathBuf::from("/")
+        } else {
+            std::env::current_dir()?
+        };
+        for comp in parent.components() {
+            use std::path::Component;
+            match comp {
+                Component::RootDir | Component::CurDir => continue,
+                Component::ParentDir => {
+                    anyhow::bail!("refusing to write: parent traversal is not allowed")
+                }
+                Component::Normal(seg) => {
+                    cur.push(seg);
+                    if let Ok(meta) = fs::symlink_metadata(&cur) {
+                        if meta.file_type().is_symlink() {
+                            anyhow::bail!(
+                                "refusing to write: parent path component is a symlink ({})",
+                                cur.display()
+                            );
+                        }
+                    }
+                }
+                Component::Prefix(_) => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn atomic_temp_path(path: &Path) -> Result<PathBuf> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let stem = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("output");
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    for attempt in 0..1000u32 {
+        let candidate = parent.join(format!(".{}.{}.{}.tmp", stem, pid, nanos + attempt as u128));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    anyhow::bail!(
+        "unable to allocate temporary file path for {}",
+        path.display()
+    )
+}
+
+fn save_binary_core_atomic(index: &MemoryIndex, path: &Path) -> Result<()> {
+    ensure_safe_output_path(path)?;
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let temp_path = atomic_temp_path(path)?;
+    index.save_binary_core(&temp_path)?;
+    fs::rename(&temp_path, path)?;
     Ok(())
 }
 
@@ -872,6 +978,7 @@ struct QueryOutput {
     query: String,
     elapsed_ms: u128,
     result_count: usize,
+    analysis: QueryAnalysis,
     results: Vec<crate::index::SearchResult>,
     aggregation: Option<crate::aggregation::AggregateOutput>,
 }
@@ -1950,10 +2057,15 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         let query_value = args.llm_context.as_deref().or(args.query.as_deref());
         if let Some(query) = query_value {
             let started = Instant::now();
+            let analysis = analyze_query(query);
+            let search_query = analysis.augmented_query.clone();
+            let temporal_context = query_temporal_context(&analysis);
             if args.llm_context.is_some() {
                 let requested = args.result_count.clamp(1, MAX_RESULT_COUNT);
                 let candidate_top_k = requested.max(LLM_CONTEXT_CANDIDATE_TOP_K);
-                let candidate_results = index.query(query, candidate_top_k);
+                let candidate_results = index
+                    .query_with_temporal_context(&search_query, candidate_top_k, temporal_context)
+                    .0;
                 let elapsed_ms = started.elapsed().as_millis();
                 let payload = build_llm_context_output(
                     &index,
@@ -1979,7 +2091,13 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
                     println!("{}", serde_json::to_string_pretty(&payload)?);
                 }
             } else {
-                let results = index.query(query, DEFAULT_QUERY_TOP_K);
+                let results = index
+                    .query_with_temporal_context(
+                        &search_query,
+                        DEFAULT_QUERY_TOP_K,
+                        temporal_context,
+                    )
+                    .0;
                 let elapsed_ms = started.elapsed().as_millis();
                 let aggregation =
                     build_aggregate_output(&index, query, &results, DEFAULT_QUERY_TOP_K);
@@ -1987,6 +2105,7 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
                     query: query.to_string(),
                     elapsed_ms,
                     result_count: results.len(),
+                    analysis,
                     results,
                     aggregation,
                 };

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,15 +1,12 @@
+use crate::adapters::markdown::build_markdown_corpus;
 use anyhow::Result;
-use comrak::{nodes::NodeValue, parse_document, Arena, ComrakOptions};
 use deunicode::deunicode;
 use petgraph::graph::{DiGraph, NodeIndex};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::UNIX_EPOCH;
+use std::path::Path;
 use unicode_normalization::UnicodeNormalization;
-use walkdir::WalkDir;
 
 #[derive(Debug, Clone)]
 pub struct Page {
@@ -103,7 +100,7 @@ pub struct Tier0Record {
 }
 
 /// Normalize a concept string for matching (unicode + deunicode + case fold).
-pub fn normalize_concept(s: &str) -> String {
+pub(crate) fn normalize_concept(s: &str) -> String {
     let normalized: String = s
         .nfc()
         .collect::<String>()
@@ -114,11 +111,11 @@ pub fn normalize_concept(s: &str) -> String {
     deunicode(&normalized).to_lowercase()
 }
 
-fn strip_anchor(target: &str) -> &str {
+pub(crate) fn strip_anchor(target: &str) -> &str {
     target.split('#').next().unwrap_or(target)
 }
 
-fn concept_from_link_target(target: &str) -> Option<String> {
+pub(crate) fn concept_from_link_target(target: &str) -> Option<String> {
     let target = strip_anchor(target).trim();
     if target.is_empty() || target.starts_with("http://") || target.starts_with("https://") {
         return None;
@@ -139,45 +136,11 @@ fn concept_from_link_target(target: &str) -> Option<String> {
     Some(normalize_concept(stem))
 }
 
-fn rel_path(root: &Path, path: &Path) -> String {
+pub(crate) fn rel_path(root: &Path, path: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
         .display()
         .to_string()
-}
-
-fn docs_dir(root: &Path) -> PathBuf {
-    if root.is_file() {
-        return root.parent().unwrap_or(root).to_path_buf();
-    }
-    let docs = root.join("docs");
-    if docs.is_dir() {
-        docs
-    } else {
-        root.to_path_buf()
-    }
-}
-
-fn parse_frontmatter_kv(content: &str) -> HashMap<String, String> {
-    let mut out = HashMap::new();
-    let mut lines = content.lines();
-    if lines.next() != Some("---") {
-        return out;
-    }
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed == "---" {
-            break;
-        }
-        if let Some((k, v)) = trimmed.split_once(':') {
-            let key = k.trim().to_lowercase();
-            let value = v.trim().trim_matches('"').trim_matches('\'').to_string();
-            if !key.is_empty() && !value.is_empty() {
-                out.insert(key, value);
-            }
-        }
-    }
-    out
 }
 
 fn chunk_page_sections(content: &str, rel_path: &str) -> Vec<ChunkNode> {
@@ -287,167 +250,21 @@ impl Graph {
         max_total_bytes: usize,
     ) -> Result<Self> {
         let root = Path::new(path);
-        let base = docs_dir(root);
-        let base_walk = base.clone();
-        let single_file = if root.is_file() {
-            Some(root.to_path_buf())
-        } else {
-            None
-        };
-        let rel_root = if root.is_file() { base.as_path() } else { root };
-
-        let wiki_link_re = Regex::new(r"\[\[(.*?)\]\]")?;
-        let md_link_re = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)")?;
-        let md_heading_re = Regex::new(r"(?m)^#{1,6}\s+(.*)$")?;
-
-        let mut pages = Vec::new();
-        let mut tier0_records = Vec::new();
-
-        let mut files_seen = 0usize;
-        let mut total_bytes = 0usize;
-        for entry in WalkDir::new(base_walk).max_depth(max_depth) {
-            let entry = entry?;
-            if !entry.file_type().is_file() {
-                continue;
-            }
-            if let Some(ref only) = single_file {
-                if entry.path() != only {
-                    continue;
-                }
-            }
-
-            let ext = entry
-                .path()
-                .extension()
-                .and_then(|s| s.to_str())
-                .unwrap_or("");
-            if ext != "md" {
-                continue;
-            }
-
-            files_seen += 1;
-            if files_seen > max_files {
-                break;
-            }
-
-            let metadata = entry.metadata()?;
-            if metadata.len() as usize > max_bytes {
-                continue;
-            }
-            total_bytes = total_bytes.saturating_add(metadata.len() as usize);
-            if total_bytes > max_total_bytes {
-                break;
-            }
-            let content = fs::read_to_string(entry.path())?;
-            let raw_concept = entry
-                .path()
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("")
-                .to_string();
-            let concept = normalize_concept(&raw_concept);
-
-            let mut links = HashSet::new();
-            let mut headings = Vec::new();
-
-            for cap in wiki_link_re.captures_iter(&content) {
-                let target = cap[1].trim();
-                if let Some(concept) = concept_from_link_target(target) {
-                    links.insert(concept);
-                }
-            }
-
-            for cap in md_link_re.captures_iter(&content) {
-                let target = cap.get(2).map(|m| m.as_str()).unwrap_or("");
-                if let Some(concept) = concept_from_link_target(target) {
-                    links.insert(concept);
-                }
-            }
-
-            for cap in md_heading_re.captures_iter(&content) {
-                let heading = cap[1].trim();
-                if !heading.is_empty() {
-                    headings.push(heading.to_string());
-                }
-            }
-
-            if headings.is_empty() {
-                let arena = Arena::new();
-                let ast = parse_document(&arena, &content, &ComrakOptions::default());
-                let mut stack = vec![ast];
-                while let Some(node) = stack.pop() {
-                    for child in node.children() {
-                        stack.push(child);
-                    }
-                    if let NodeValue::Heading(ref heading) = node.data.borrow().value {
-                        let mut text = String::new();
-                        for child in node.children() {
-                            if let NodeValue::Text(ref t) = child.data.borrow().value {
-                                text.push_str(t);
-                            }
-                        }
-                        if !text.is_empty() {
-                            headings.push(text);
-                        } else if heading.level > 0 {
-                            // Fallback to keep a placeholder for structure.
-                            headings.push(format!("(heading level {})", heading.level));
-                        }
-                    }
-                }
-            }
-
-            let page = Page {
-                path: entry.path().display().to_string(),
-                rel_path: rel_path(rel_root, entry.path()),
-                concept,
-                raw_concept,
-                content,
-                links,
-                headings,
-            };
-
-            let mut basic_metadata: HashMap<String, String> = HashMap::new();
-            basic_metadata.insert("concept".to_string(), page.concept.clone());
-            basic_metadata.insert("raw_concept".to_string(), page.raw_concept.clone());
-            basic_metadata.insert("file_ext".to_string(), "md".to_string());
-            basic_metadata.insert("heading_count".to_string(), page.headings.len().to_string());
-            basic_metadata.insert(
-                "outbound_link_count".to_string(),
-                page.links.len().to_string(),
-            );
-            basic_metadata.insert("path".to_string(), page.path.clone());
-
-            let file_size = metadata.len() as usize;
-            let timestamp = metadata
-                .modified()
-                .ok()
-                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                .map(|d| d.as_secs().to_string());
-            let frontmatter = parse_frontmatter_kv(&page.content);
-            let author_agent = frontmatter
-                .get("author")
-                .cloned()
-                .or_else(|| frontmatter.get("agent").cloned())
-                .or_else(|| frontmatter.get("author_agent").cloned())
-                .or_else(|| frontmatter.get("created_by").cloned());
-            if frontmatter.contains_key("author") {
-                basic_metadata.insert("frontmatter_author".to_string(), "true".to_string());
-            }
-            if frontmatter.contains_key("agent") {
-                basic_metadata.insert("frontmatter_agent".to_string(), "true".to_string());
-            }
-            basic_metadata.insert("file_size_bytes".to_string(), file_size.to_string());
-
-            tier0_records.push(Tier0Record {
-                id: page.rel_path.clone(),
-                source: page.rel_path.clone(),
-                timestamp,
-                author_agent,
-                doc_length: file_size,
-                metadata: basic_metadata,
-            });
-            pages.push(page);
-        }
+        let corpus = build_markdown_corpus(root, max_bytes, max_files, max_depth, max_total_bytes)?;
+        let pages: Vec<Page> = corpus
+            .pages
+            .into_iter()
+            .map(|page| Page {
+                path: page.path,
+                rel_path: page.rel_path,
+                concept: page.concept,
+                raw_concept: page.raw_concept,
+                content: page.content,
+                links: page.links,
+                headings: page.headings,
+            })
+            .collect();
+        let tier0_records = corpus.tier0_records;
 
         let mut graph = DiGraph::<String, ()>::new();
         let mut index: HashMap<String, NodeIndex> = HashMap::new();
@@ -589,6 +406,7 @@ impl Graph {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adapters::markdown::parse_frontmatter_kv;
 
     #[test]
     fn normalize_concept_basic() {

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,9 +1,10 @@
 use crate::ids::stable_chunk_id;
 use crate::query_expansion::{expand_query_terms, normalize_for_index};
+use crate::query_semantics::QueryRoutingIntent;
 use crate::temporal::{parse_temporal_date, resolve_temporal_target};
 use crate::tier1::{RankedTerm, Tier1Entity};
 use anyhow::Result;
-use chrono::NaiveDate;
+use chrono::{DateTime, NaiveDate, Utc};
 use deunicode::deunicode;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -11,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 use std::sync::OnceLock;
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
 use tantivy::schema::document::TantivyDocument;
@@ -39,6 +40,7 @@ const GRAPH_MAX_BOOST: f32 = 0.6;
 const ENTITY_GRAPH_WEIGHT: f32 = 0.08;
 const ENTITY_GRAPH_MAX_CANDIDATES: usize = 100;
 const FINAL_RERANK_WINDOW: usize = 200;
+const MAX_DOC_POSTINGS: usize = 500;
 const MAX_RESULTS_PER_GROUP: usize = 2;
 const TEXT_RERANK_WEIGHT: f32 = 0.08;
 const TEXT_RERANK_NGRAM_WEIGHT: f32 = 0.08;
@@ -347,6 +349,10 @@ pub struct MemoryIndex {
     #[serde(skip_serializing)]
     entity_postings_chunk: Vec<Vec<(u32, f32)>>,
     #[serde(skip_serializing)]
+    entity_postings_doc: Vec<Vec<(u32, f32)>>,
+    #[serde(skip_serializing)]
+    term_postings_doc: Vec<Vec<(u32, f32)>>,
+    #[serde(skip_serializing)]
     #[allow(dead_code)]
     chunk_terms: Vec<Vec<u32>>,
     #[serde(skip_serializing)]
@@ -360,6 +366,12 @@ pub struct MemoryIndex {
     doc_interval_trees: Vec<IntervalTree>,
     #[serde(skip_serializing)]
     doc_key_entities: Vec<Vec<String>>,
+    #[serde(skip_serializing)]
+    doc_rerank_texts: Vec<String>,
+    #[serde(skip_serializing)]
+    doc_rerank_tokens: Vec<Vec<String>>,
+    #[serde(skip_serializing)]
+    doc_has_number: Vec<bool>,
     #[serde(skip_serializing)]
     claim_scoring: bool,
     #[serde(skip_serializing)]
@@ -385,6 +397,7 @@ pub struct ScoreBreakdown {
     pub entity_score: f32,
     pub term_score: f32,
     pub claim_score: f32,
+    pub semantic_score: f32,
     pub topic_score: f32,
     pub doc_type_score: f32,
     pub recency_score: f32,
@@ -415,12 +428,18 @@ pub struct QueryTimings {
     pub rerank_ms: f64,
     pub parse_ms: f64,
     pub sparse_scoring_ms: f64,
+    pub lexical_merge_ms: f64,
+    pub posting_scoring_ms: f64,
+    pub routing_seed_ms: f64,
     pub candidate_accumulation_ms: f64,
     pub candidate_rank_ms: f64,
     pub metadata_ms: f64,
     pub graph_ms: f64,
     pub entity_graph_ms: f64,
     pub sequence_rerank_ms: f64,
+    pub evidence_ms: f64,
+    pub group_build_ms: f64,
+    pub group_sort_ms: f64,
     pub ranking_ms: f64,
 }
 
@@ -432,12 +451,16 @@ pub struct QueryDiagnostics {
     pub candidates: usize,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TemporalQueryContext<'a> {
     pub starts_from: Option<&'a str>,
     pub ends_at: Option<&'a str>,
     pub window_days: i64,
     pub hard_filter: bool,
+    pub time_hint: Option<TemporalQueryHint>,
+    pub query_routing_intent: Option<QueryRoutingIntent>,
+    pub has_explicit_temporal: bool,
+    pub allowed_doc_ids: Option<&'a HashSet<String>>,
 }
 
 impl<'a> Default for TemporalQueryContext<'a> {
@@ -447,6 +470,10 @@ impl<'a> Default for TemporalQueryContext<'a> {
             ends_at: None,
             window_days: 7,
             hard_filter: false,
+            time_hint: None,
+            query_routing_intent: None,
+            has_explicit_temporal: false,
+            allowed_doc_ids: None,
         }
     }
 }
@@ -457,6 +484,18 @@ struct CandidateState {
     breakdown: ScoreBreakdown,
     matched_entities: Vec<String>,
     matched_terms: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct EvidenceFeatures {
+    score: f32,
+    matched_terms: usize,
+    has_number: bool,
+    has_unit: bool,
+    has_date: bool,
+    has_temporal_terms: bool,
+    predicate_signal: bool,
+    distractor_penalty: f32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -476,6 +515,14 @@ pub struct RedactedMemoryIndex {
     pub docs: HashMap<String, RedactedDocRecord>,
     pub topic_to_docs: HashMap<String, Vec<String>>,
     pub doc_type_to_docs: HashMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TemporalQueryHint {
+    Past,
+    Present,
+    Ongoing,
+    Mixed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -564,6 +611,9 @@ impl MemoryIndex {
         let mut chunk_terms: Vec<Vec<u32>> = Vec::new();
         let mut chunk_entities: Vec<Vec<u32>> = Vec::new();
         let mut doc_key_entities: Vec<Vec<String>> = Vec::new();
+        let mut doc_rerank_texts: Vec<String> = Vec::new();
+        let mut doc_rerank_tokens: Vec<Vec<String>> = Vec::new();
+        let mut doc_has_number: Vec<bool> = Vec::new();
 
         for mut record in records {
             let doc_id = record.doc_id.clone();
@@ -572,6 +622,10 @@ impl MemoryIndex {
             doc_u32_to_id.push(doc_id.clone());
             doc_to_chunks.push(Vec::new());
             doc_key_entities.push(normalized_entity_keys(&record.key_entities));
+            let (rerank_text, rerank_tokens) = build_doc_rerank_cache(&record);
+            doc_has_number.push(contains_number_like(&rerank_text));
+            doc_rerank_texts.push(rerank_text);
+            doc_rerank_tokens.push(rerank_tokens);
             if record.section_chunks.is_empty() {
                 record.section_chunks.push(SectionChunk {
                     chunk_id: stable_chunk_id(
@@ -685,13 +739,10 @@ impl MemoryIndex {
             if claim_scoring {
                 for claim in &record.top_claims {
                     for token in claim_tokens(claim) {
-                        claim_to_docs
-                            .entry(token)
-                            .or_default()
-                            .push(TermPosting {
-                                doc_id: doc_id.clone(),
-                                score: claim.confidence.max(0.1),
-                            });
+                        claim_to_docs.entry(token).or_default().push(TermPosting {
+                            doc_id: doc_id.clone(),
+                            score: claim.confidence.max(0.1),
+                        });
                     }
                 }
             }
@@ -784,7 +835,7 @@ impl MemoryIndex {
                         .push(TermPosting {
                             doc_id: doc_id.clone(),
                             score: *score,
-                    });
+                        });
                 }
             }
             for (entity_u32, postings) in entity_postings_chunk.iter().enumerate() {
@@ -819,6 +870,11 @@ impl MemoryIndex {
             &chunks,
             doc_u32_to_id.len(),
         );
+
+        let entity_postings_doc =
+            derive_doc_postings(&entity_postings_chunk, &chunks, MAX_DOC_POSTINGS);
+        let term_postings_doc =
+            derive_doc_postings(&term_postings_chunk, &chunks, MAX_DOC_POSTINGS);
 
         for postings in entity_to_docs.values_mut() {
             postings.sort_by(|a, b| {
@@ -860,12 +916,17 @@ impl MemoryIndex {
             entity_lexicon,
             term_postings_chunk,
             entity_postings_chunk,
+            entity_postings_doc,
+            term_postings_doc,
             chunk_terms,
             chunk_entities,
             term_trie,
             entity_trie,
             doc_interval_trees,
             doc_key_entities,
+            doc_rerank_texts,
+            doc_rerank_tokens,
+            doc_has_number,
             claim_scoring,
             text_rerank_ngram,
             text_rerank_lcs,
@@ -971,9 +1032,20 @@ impl MemoryIndex {
             core.doc_u32_to_id.len(),
         );
         let mut doc_key_entities = vec![Vec::new(); core.doc_u32_to_id.len()];
+        let mut doc_rerank_texts = vec![String::new(); core.doc_u32_to_id.len()];
+        let mut doc_rerank_tokens = vec![Vec::new(); core.doc_u32_to_id.len()];
+        let entity_postings_doc =
+            derive_doc_postings(&core.entity_postings_chunk, &core.chunks, MAX_DOC_POSTINGS);
+        let term_postings_doc =
+            derive_doc_postings(&core.term_postings_chunk, &core.chunks, MAX_DOC_POSTINGS);
+        let mut doc_has_number = vec![false; core.doc_u32_to_id.len()];
         for (doc_id, record) in &docs {
             if let Some(&doc_u32) = core.doc_id_to_u32.get(doc_id) {
                 doc_key_entities[doc_u32 as usize] = normalized_entity_keys(&record.key_entities);
+                let (rerank_text, rerank_tokens) = build_doc_rerank_cache(record);
+                doc_has_number[doc_u32 as usize] = contains_number_like(&rerank_text);
+                doc_rerank_texts[doc_u32 as usize] = rerank_text;
+                doc_rerank_tokens[doc_u32 as usize] = rerank_tokens;
             }
         }
         Ok(Self {
@@ -997,12 +1069,17 @@ impl MemoryIndex {
             entity_lexicon: core.entity_lexicon,
             term_postings_chunk: core.term_postings_chunk,
             entity_postings_chunk: core.entity_postings_chunk,
+            entity_postings_doc,
+            term_postings_doc,
             chunk_terms: core.chunk_terms,
             chunk_entities: core.chunk_entities,
             term_trie,
             entity_trie,
             doc_interval_trees,
             doc_key_entities,
+            doc_rerank_texts,
+            doc_rerank_tokens,
+            doc_has_number,
             claim_scoring,
             text_rerank_ngram: false,
             text_rerank_lcs: false,
@@ -1099,7 +1176,7 @@ impl MemoryIndex {
             }
         } else {
             let ram = Index::create_in_ram(schema);
-            let mut writer = ram.writer(50_000_000)?;
+            let mut writer = ram.writer(15_000_001)?;
             for doc in docs.values() {
                 let headings_text = doc
                     .section_chunks
@@ -1216,9 +1293,13 @@ impl MemoryIndex {
         top_k: usize,
         temporal: TemporalQueryContext<'_>,
     ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
-        let search_k = top_k.saturating_mul(5).max(20);
+        let search_k = match temporal.query_routing_intent {
+            Some(_) => top_k.saturating_mul(10).max(25),
+            None => top_k.saturating_mul(5).max(20),
+        };
         let total_start = Instant::now();
-        let (mut results, mut timings, diagnostics) = self.query_timed(query, search_k);
+        let (mut results, mut timings, diagnostics) =
+            self.query_timed_with_context(query, search_k, temporal);
         let (temporal_start, temporal_end) =
             normalize_temporal_bounds(temporal.starts_from, temporal.ends_at);
         let relative_anchor = temporal_start
@@ -1228,7 +1309,11 @@ impl MemoryIndex {
             .or(temporal.starts_from)
             .or(temporal.ends_at);
         let target = resolve_temporal_target(query, relative_anchor);
-        if target.is_none() && temporal_start.is_none() && temporal_end.is_none() {
+        if target.is_none()
+            && temporal_start.is_none()
+            && temporal_end.is_none()
+            && temporal.time_hint.is_none()
+        {
             timings.total_ms = total_start.elapsed().as_secs_f64() * 1000.0;
             results.truncate(top_k);
             return (results, timings, diagnostics);
@@ -1236,6 +1321,8 @@ impl MemoryIndex {
 
         let window_days = temporal.window_days.max(1);
         let hard_filter = temporal.hard_filter;
+        let time_hint = temporal.time_hint;
+        let now_date = DateTime::<Utc>::from(SystemTime::now()).date_naive();
         let mut rescored = Vec::with_capacity(results.len());
         for mut result in results.drain(..) {
             let Some(doc) = self.docs.get(&result.doc_id) else {
@@ -1280,6 +1367,52 @@ impl MemoryIndex {
                     result.score_breakdown.recency_score += boost;
                 }
             }
+            if temporal.has_explicit_temporal
+                && target.is_none()
+                && temporal_start.is_none()
+                && temporal_end.is_none()
+            {
+                if let Some(hint) = time_hint {
+                    let delta_days = (doc_date.signed_duration_since(now_date).num_days()).abs();
+                    let boost = match hint {
+                        TemporalQueryHint::Past => {
+                            if doc_date <= now_date {
+                                0.03
+                            } else {
+                                0.0
+                            }
+                        }
+                        TemporalQueryHint::Present => {
+                            if delta_days <= 30 {
+                                let proximity = 1.0 - (delta_days as f32 / 30.0);
+                                proximity.clamp(0.0, 1.0) * 0.25
+                            } else {
+                                0.0
+                            }
+                        }
+                        TemporalQueryHint::Ongoing => {
+                            if delta_days <= 14 {
+                                let proximity = 1.0 - (delta_days as f32 / 14.0);
+                                proximity.clamp(0.0, 1.0) * 0.3
+                            } else {
+                                0.0
+                            }
+                        }
+                        TemporalQueryHint::Mixed => {
+                            if delta_days <= 30 {
+                                let proximity = 1.0 - (delta_days as f32 / 30.0);
+                                proximity.clamp(0.0, 1.0) * 0.15
+                            } else {
+                                0.0
+                            }
+                        }
+                    };
+                    if boost > 0.0 {
+                        result.score += boost;
+                        result.score_breakdown.recency_score += boost;
+                    }
+                }
+            }
             rescored.push(result);
         }
         rescored.sort_by(|a, b| {
@@ -1297,6 +1430,15 @@ impl MemoryIndex {
         query: &str,
         top_k: usize,
     ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
+        self.query_timed_with_context(query, top_k, TemporalQueryContext::default())
+    }
+
+    fn query_timed_with_context(
+        &self,
+        query: &str,
+        top_k: usize,
+        temporal: TemporalQueryContext<'_>,
+    ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
         let total_start = Instant::now();
         let lexical_start = Instant::now();
         let lexical_hits = match self.lexical_bm25(query, top_k.saturating_mul(5).max(20)) {
@@ -1308,8 +1450,14 @@ impl MemoryIndex {
         };
         let lexical_bm25_ms = lexical_start.elapsed().as_secs_f64() * 1000.0;
         let snapshot_start = Instant::now();
-        let (results, mut timings, diagnostics) =
-            self.query_with_lexical_hits_timed(query, top_k, lexical_hits.as_ref());
+        let (results, mut timings, diagnostics) = self.query_with_lexical_hits_timed(
+            query,
+            top_k,
+            lexical_hits.as_ref(),
+            temporal.query_routing_intent,
+            temporal.has_explicit_temporal,
+            temporal.allowed_doc_ids,
+        );
         let snapshot_query_ms = snapshot_start.elapsed().as_secs_f64() * 1000.0;
         let total_ms = total_start.elapsed().as_secs_f64() * 1000.0;
         timings.snapshot_query_ms = snapshot_query_ms;
@@ -1324,7 +1472,7 @@ impl MemoryIndex {
         top_k: usize,
         lexical_hits: Option<&HashMap<String, f32>>,
     ) -> Vec<SearchResult> {
-        self.query_with_lexical_hits_timed(query, top_k, lexical_hits)
+        self.query_with_lexical_hits_timed(query, top_k, lexical_hits, None, false, None)
             .0
     }
 
@@ -1333,6 +1481,9 @@ impl MemoryIndex {
         query: &str,
         top_k: usize,
         lexical_hits: Option<&HashMap<String, f32>>,
+        query_routing_intent: Option<QueryRoutingIntent>,
+        has_explicit_temporal: bool,
+        allowed_doc_ids: Option<&HashSet<String>>,
     ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
         const MAX_QUERY_CHARS: usize = 4096;
         const MAX_QUERY_TOKENS: usize = 128;
@@ -1368,6 +1519,15 @@ impl MemoryIndex {
         }
         let expanded = expand_query_terms(&q_terms);
         let expanded_terms = expanded.expanded_terms;
+        let mut query_entities: HashSet<String> = HashSet::new();
+        if self.entity_trie.get(&q).is_some() {
+            query_entities.insert(q.clone());
+        }
+        for term in &q_terms {
+            if self.entity_trie.get(term).is_some() {
+                query_entities.insert(term.clone());
+            }
+        }
         if self.doc_u32_to_id.is_empty() {
             return (
                 Vec::new(),
@@ -1379,40 +1539,71 @@ impl MemoryIndex {
         let sparse_start = Instant::now();
         let mut candidates: HashMap<usize, CandidateState> = HashMap::new();
         let query_set: HashSet<String> = q_terms.iter().cloned().collect();
+        let allowed_doc_u32s: Option<HashSet<usize>> = allowed_doc_ids.map(|allowed| {
+            allowed
+                .iter()
+                .filter_map(|doc_id| self.doc_id_to_u32.get(doc_id).copied())
+                .map(|doc_u32| doc_u32 as usize)
+                .collect()
+        });
 
         fn score_doc<F>(
             candidates: &mut HashMap<usize, CandidateState>,
             doc_u32: usize,
             delta: f32,
+            allowed_doc_u32s: Option<&HashSet<usize>>,
             apply: F,
         ) where
             F: FnOnce(&mut CandidateState),
         {
+            if let Some(allowed_doc_u32s) = allowed_doc_u32s {
+                if !allowed_doc_u32s.contains(&doc_u32) {
+                    return;
+                }
+            }
             let entry = candidates.entry(doc_u32).or_default();
             entry.score += delta;
             apply(entry);
         }
 
+        let lexical_merge_start = Instant::now();
         if let Some(lexical_hits) = lexical_hits {
             for (doc_id, bm25_score) in lexical_hits {
                 if let Some(&doc_u32) = self.doc_id_to_u32.get(doc_id) {
-                    score_doc(&mut candidates, doc_u32 as usize, *bm25_score, |entry| {
-                        entry.breakdown.lexical_score += *bm25_score;
-                        });
+                    score_doc(
+                        &mut candidates,
+                        doc_u32 as usize,
+                        *bm25_score,
+                        allowed_doc_u32s.as_ref(),
+                        |entry| {
+                            entry.breakdown.lexical_score += *bm25_score;
+                        },
+                    );
                 }
             }
         }
+        let lexical_merge_ms = lexical_merge_start.elapsed().as_secs_f64() * 1000.0;
+
+        let posting_scoring_start = Instant::now();
 
         // Full-query entity hit.
         if let Some(entity_u32) = self.entity_trie.get(&q) {
-            if let Some(postings) = self.entity_postings_chunk.get(entity_u32 as usize) {
-                for (chunk_u32, post_score) in postings {
-                    let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
-                    let delta = FULL_QUERY_ENTITY_WEIGHT * *post_score;
-                    score_doc(&mut candidates, doc_u32 as usize, delta, |entry| {
-                        entry.breakdown.entity_score += delta;
-                        entry.matched_entities.push(q.clone());
-                    });
+            if let Some(postings) = self.entity_postings_doc.get(entity_u32 as usize) {
+                for &(doc_u32, post_score) in postings {
+                    let mut delta = FULL_QUERY_ENTITY_WEIGHT * post_score;
+                    if !query_entities.is_empty() {
+                        delta *= 1.25;
+                    }
+                    score_doc(
+                        &mut candidates,
+                        doc_u32 as usize,
+                        delta,
+                        allowed_doc_u32s.as_ref(),
+                        |entry| {
+                            entry.breakdown.entity_score += delta;
+                            entry.matched_entities.push(q.clone());
+                        },
+                    );
                 }
             }
         }
@@ -1427,14 +1618,23 @@ impl MemoryIndex {
                 }
             }
             for (entity_u32, mult) in entity_ids {
-                if let Some(postings) = self.entity_postings_chunk.get(entity_u32 as usize) {
-                    for (chunk_u32, post_score) in postings {
-                        let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
-                        let delta = ENTITY_TERM_WEIGHT * *post_score * mult;
-                        score_doc(&mut candidates, doc_u32 as usize, delta, |entry| {
-                            entry.breakdown.entity_score += delta;
-                            entry.matched_entities.push(term.clone());
-                        });
+                if let Some(postings) = self.entity_postings_doc.get(entity_u32 as usize) {
+                    for &(doc_u32, post_score) in postings {
+                        let exact_entity_match = query_entities.contains(term);
+                        let mut delta = ENTITY_TERM_WEIGHT * post_score * mult;
+                        if exact_entity_match {
+                            delta *= 1.4;
+                        }
+                        score_doc(
+                            &mut candidates,
+                            doc_u32 as usize,
+                            delta,
+                            allowed_doc_u32s.as_ref(),
+                            |entry| {
+                                entry.breakdown.entity_score += delta;
+                                entry.matched_entities.push(term.clone());
+                            },
+                        );
                     }
                 }
             }
@@ -1447,14 +1647,19 @@ impl MemoryIndex {
                 }
             }
             for (term_u32, mult) in term_ids {
-                if let Some(postings) = self.term_postings_chunk.get(term_u32 as usize) {
-                    for (chunk_u32, post_score) in postings {
-                        let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
-                        let delta = IMPORTANT_TERM_WEIGHT * *post_score * mult;
-                        score_doc(&mut candidates, doc_u32 as usize, delta, |entry| {
-                            entry.breakdown.term_score += delta;
-                            entry.matched_terms.push(term.clone());
-                        });
+                if let Some(postings) = self.term_postings_doc.get(term_u32 as usize) {
+                    for &(doc_u32, post_score) in postings {
+                        let delta = IMPORTANT_TERM_WEIGHT * post_score * mult;
+                        score_doc(
+                            &mut candidates,
+                            doc_u32 as usize,
+                            delta,
+                            allowed_doc_u32s.as_ref(),
+                            |entry| {
+                                entry.breakdown.term_score += delta;
+                                entry.matched_terms.push(term.clone());
+                            },
+                        );
                     }
                 }
             }
@@ -1463,10 +1668,16 @@ impl MemoryIndex {
                     for posting in postings {
                         if let Some(&doc_u32) = self.doc_id_to_u32.get(&posting.doc_id) {
                             let delta = 0.7 * posting.score;
-                            score_doc(&mut candidates, doc_u32 as usize, delta, |entry| {
-                                entry.breakdown.claim_score += delta;
-                                entry.matched_terms.push(term.clone());
-                            });
+                            score_doc(
+                                &mut candidates,
+                                doc_u32 as usize,
+                                delta,
+                                allowed_doc_u32s.as_ref(),
+                                |entry| {
+                                    entry.breakdown.claim_score += delta;
+                                    entry.matched_terms.push(term.clone());
+                                },
+                            );
                         }
                     }
                 }
@@ -1476,24 +1687,37 @@ impl MemoryIndex {
         // Expanded semantic terms are lower-weight than original terms.
         for term in &expanded_terms {
             if let Some(entity_u32) = self.entity_trie.get(term) {
-                if let Some(postings) = self.entity_postings_chunk.get(entity_u32 as usize) {
-                    for (chunk_u32, post_score) in postings {
-                        let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
-                        let delta = EXPANDED_ENTITY_WEIGHT * *post_score;
-                        score_doc(&mut candidates, doc_u32 as usize, delta, |entry| {
-                            entry.breakdown.entity_score += delta;
-                        });
+                if let Some(postings) = self.entity_postings_doc.get(entity_u32 as usize) {
+                    for &(doc_u32, post_score) in postings {
+                        let mut delta = EXPANDED_ENTITY_WEIGHT * post_score;
+                        if query_entities.contains(term) {
+                            delta *= 1.2;
+                        }
+                        score_doc(
+                            &mut candidates,
+                            doc_u32 as usize,
+                            delta,
+                            allowed_doc_u32s.as_ref(),
+                            |entry| {
+                                entry.breakdown.entity_score += delta;
+                            },
+                        );
                     }
                 }
             }
             if let Some(term_u32) = self.term_trie.get(term) {
-                if let Some(postings) = self.term_postings_chunk.get(term_u32 as usize) {
-                    for (chunk_u32, post_score) in postings {
-                        let doc_u32 = self.chunks[*chunk_u32 as usize].doc_u32;
-                        let delta = EXPANDED_TERM_WEIGHT * *post_score;
-                        score_doc(&mut candidates, doc_u32 as usize, delta, |entry| {
-                            entry.breakdown.term_score += delta;
-                        });
+                if let Some(postings) = self.term_postings_doc.get(term_u32 as usize) {
+                    for &(doc_u32, post_score) in postings {
+                        let delta = EXPANDED_TERM_WEIGHT * post_score;
+                        score_doc(
+                            &mut candidates,
+                            doc_u32 as usize,
+                            delta,
+                            allowed_doc_u32s.as_ref(),
+                            |entry| {
+                                entry.breakdown.term_score += delta;
+                            },
+                        );
                     }
                 }
             }
@@ -1502,14 +1726,35 @@ impl MemoryIndex {
                     for posting in postings {
                         if let Some(&doc_u32) = self.doc_id_to_u32.get(&posting.doc_id) {
                             let delta = 0.7 * 0.6 * posting.score;
-                            score_doc(&mut candidates, doc_u32 as usize, delta, |entry| {
-                                entry.breakdown.claim_score += delta;
-                            });
+                            score_doc(
+                                &mut candidates,
+                                doc_u32 as usize,
+                                delta,
+                                allowed_doc_u32s.as_ref(),
+                                |entry| {
+                                    entry.breakdown.claim_score += delta;
+                                },
+                            );
                         }
                     }
                 }
             }
         }
+        let posting_scoring_ms = posting_scoring_start.elapsed().as_secs_f64() * 1000.0;
+
+        let routing_seed_start = Instant::now();
+        if let Some(intent) = query_routing_intent {
+            let candidate_doc_ids = candidates.keys().copied().collect::<Vec<_>>();
+            seed_routing_candidates(
+                self,
+                &mut candidates,
+                &candidate_doc_ids,
+                &q_terms,
+                &query_entities,
+                intent,
+            );
+        }
+        let routing_seed_ms = routing_seed_start.elapsed().as_secs_f64() * 1000.0;
         let sparse_scoring_ms = sparse_start.elapsed().as_secs_f64() * 1000.0;
 
         let candidate_accumulation_start = Instant::now();
@@ -1592,69 +1837,81 @@ impl MemoryIndex {
 
         // Graph-aware rerank features with bounded contribution.
         // Use current hybrid score as base so graph signals cannot dominate.
-        let graph_start = Instant::now();
-        let anchors = ranked_docs.iter().take(5).cloned().collect::<Vec<_>>();
+        let disable_followup_boosts = matches!(
+            query_routing_intent,
+            Some(QueryRoutingIntent::Count) | Some(QueryRoutingIntent::Sum)
+        );
 
-        // 1-hop doc-link proximity boost.
-        for (anchor_idx, anchor_score) in &anchors {
-            let anchor_doc_id = &self.doc_u32_to_id[*anchor_idx];
-            let Some(anchor_doc) = self.docs.get(anchor_doc_id) else {
-                continue;
-            };
-            let anchor_weight = (*anchor_score / (1.0 + *anchor_score)).clamp(0.0, 1.0);
-            for linked in &anchor_doc.doc_links {
-                if let Some(&doc_u32) = self.doc_id_to_u32.get(linked) {
-                    let Some(entry) = candidates.get_mut(&(doc_u32 as usize)) else {
+        let graph_ms;
+        let entity_graph_ms;
+        if disable_followup_boosts {
+            graph_ms = 0.0;
+            entity_graph_ms = 0.0;
+        } else {
+            let graph_start = Instant::now();
+            let anchors = ranked_docs.iter().take(5).cloned().collect::<Vec<_>>();
+
+            // 1-hop doc-link proximity boost.
+            for (anchor_idx, anchor_score) in &anchors {
+                let anchor_doc_id = &self.doc_u32_to_id[*anchor_idx];
+                let Some(anchor_doc) = self.docs.get(anchor_doc_id) else {
+                    continue;
+                };
+                let anchor_weight = (*anchor_score / (1.0 + *anchor_score)).clamp(0.0, 1.0);
+                for linked in &anchor_doc.doc_links {
+                    if let Some(&doc_u32) = self.doc_id_to_u32.get(linked) {
+                        let Some(entry) = candidates.get_mut(&(doc_u32 as usize)) else {
+                            continue;
+                        };
+                        let delta = (DOC_LINK_GRAPH_WEIGHT * anchor_weight)
+                            .min(GRAPH_MAX_BOOST - entry.breakdown.graph_link_score);
+                        if delta > 0.0 {
+                            entry.score += delta;
+                            entry.breakdown.graph_link_score += delta;
+                        }
+                    }
+                }
+            }
+            graph_ms = graph_start.elapsed().as_secs_f64() * 1000.0;
+
+            let entity_graph_start = Instant::now();
+            // Entity-graph proximity boost: overlap against anchor-entity set.
+            let mut anchor_entities: HashSet<String> = HashSet::new();
+            for (doc_u32, _) in &anchors {
+                if let Some(keys) = self.doc_key_entities.get(*doc_u32) {
+                    for key in keys {
+                        if !key.is_empty() {
+                            anchor_entities.insert(key.clone());
+                        }
+                    }
+                }
+            }
+            if !anchor_entities.is_empty() {
+                let candidate_doc_ids = ranked_docs
+                    .iter()
+                    .take(ENTITY_GRAPH_MAX_CANDIDATES)
+                    .map(|(doc_u32, _)| *doc_u32)
+                    .collect::<Vec<_>>();
+                for doc_u32 in candidate_doc_ids {
+                    let Some(entry) = candidates.get_mut(&doc_u32) else {
                         continue;
                     };
-                    let delta = (DOC_LINK_GRAPH_WEIGHT * anchor_weight)
-                        .min(GRAPH_MAX_BOOST - entry.breakdown.graph_link_score);
-                    if delta > 0.0 {
-                        entry.score += delta;
-                        entry.breakdown.graph_link_score += delta;
+                    let Some(keys) = self.doc_key_entities.get(doc_u32) else {
+                        continue;
+                    };
+                    let overlap = keys.iter().filter(|k| anchor_entities.contains(*k)).count();
+                    if overlap > 0 {
+                        let delta = (ENTITY_GRAPH_WEIGHT * overlap as f32)
+                            .min(GRAPH_MAX_BOOST - entry.breakdown.entity_graph_score);
+                        if delta > 0.0 {
+                            entry.score += delta;
+                            entry.breakdown.entity_graph_score += delta;
+                        }
                     }
                 }
             }
+            entity_graph_ms = entity_graph_start.elapsed().as_secs_f64() * 1000.0;
         }
-        let graph_ms = graph_start.elapsed().as_secs_f64() * 1000.0;
-
-        let entity_graph_start = Instant::now();
-        // Entity-graph proximity boost: overlap against anchor-entity set.
-        let mut anchor_entities: HashSet<String> = HashSet::new();
-        for (doc_u32, _) in &anchors {
-            if let Some(keys) = self.doc_key_entities.get(*doc_u32) {
-                for key in keys {
-                    if !key.is_empty() {
-                        anchor_entities.insert(key.clone());
-                    }
-                }
-            }
-        }
-        if !anchor_entities.is_empty() {
-            let candidate_doc_ids = ranked_docs
-                .iter()
-                .take(ENTITY_GRAPH_MAX_CANDIDATES)
-                .map(|(doc_u32, _)| *doc_u32)
-                .collect::<Vec<_>>();
-            for doc_u32 in candidate_doc_ids {
-                let Some(entry) = candidates.get_mut(&doc_u32) else {
-                    continue;
-                };
-                let Some(keys) = self.doc_key_entities.get(doc_u32) else {
-                    continue;
-                };
-                let overlap = keys.iter().filter(|k| anchor_entities.contains(*k)).count();
-                if overlap > 0 {
-                    let delta = (ENTITY_GRAPH_WEIGHT * overlap as f32)
-                        .min(GRAPH_MAX_BOOST - entry.breakdown.entity_graph_score);
-                    if delta > 0.0 {
-                        entry.score += delta;
-                        entry.breakdown.entity_graph_score += delta;
-                    }
-                }
-            }
-        }
-        let entity_graph_ms = entity_graph_start.elapsed().as_secs_f64() * 1000.0;
 
         let sequence_rerank_start = Instant::now();
         let rerank_window = ranked_docs
@@ -1662,28 +1919,53 @@ impl MemoryIndex {
             .take(TEXT_RERANK_WINDOW.min(FINAL_RERANK_WINDOW))
             .map(|(doc_u32, _)| *doc_u32)
             .collect::<Vec<_>>();
-        if !q_terms.is_empty() {
+        let skip_sequence_rerank = query_routing_intent.is_some() && !has_explicit_temporal;
+        if !skip_sequence_rerank && !q_terms.is_empty() {
             for doc_u32 in rerank_window {
-                let Some(doc_id) = self.doc_u32_to_id.get(doc_u32) else {
+                let Some(candidate_tokens) = cached_doc_rerank_tokens(self, doc_u32) else {
+                    let Some(doc_id) = self.doc_u32_to_id.get(doc_u32) else {
+                        continue;
+                    };
+                    let Some(doc) = self.docs.get(doc_id) else {
+                        continue;
+                    };
+                    let fallback_text = normalize_for_index(&candidate_rerank_text(doc));
+                    let owned_tokens = tokenize_query_terms(&fallback_text);
+                    if owned_tokens.is_empty() {
+                        continue;
+                    }
+                    let token_overlap = token_overlap_ratio(&q_terms, &owned_tokens);
+                    let mut delta = TEXT_RERANK_WEIGHT * token_overlap;
+                    if self.text_rerank_ngram {
+                        let ngram_overlap =
+                            ngram_overlap_ratio(&q_terms, &owned_tokens, TEXT_RERANK_NGRAM_SIZE);
+                        delta += TEXT_RERANK_NGRAM_WEIGHT * ngram_overlap;
+                    }
+                    if self.text_rerank_lcs {
+                        let lcs_overlap = lcs_ratio(&q_terms, &owned_tokens);
+                        delta += TEXT_RERANK_LCS_WEIGHT * lcs_overlap;
+                    }
+                    if delta <= 0.0 {
+                        continue;
+                    }
+                    if let Some(entry) = candidates.get_mut(&doc_u32) {
+                        entry.score += delta;
+                        entry.breakdown.sequence_rerank_score += delta;
+                    }
                     continue;
                 };
-                let Some(doc) = self.docs.get(doc_id) else {
-                    continue;
-                };
-                let candidate_text = candidate_rerank_text(doc);
-                let candidate_tokens = tokenize_query_terms(&normalize_for_index(&candidate_text));
                 if candidate_tokens.is_empty() {
                     continue;
                 }
-                let token_overlap = token_overlap_ratio(&q_terms, &candidate_tokens);
+                let token_overlap = token_overlap_ratio(&q_terms, candidate_tokens);
                 let mut delta = TEXT_RERANK_WEIGHT * token_overlap;
                 if self.text_rerank_ngram {
                     let ngram_overlap =
-                        ngram_overlap_ratio(&q_terms, &candidate_tokens, TEXT_RERANK_NGRAM_SIZE);
+                        ngram_overlap_ratio(&q_terms, candidate_tokens, TEXT_RERANK_NGRAM_SIZE);
                     delta += TEXT_RERANK_NGRAM_WEIGHT * ngram_overlap;
                 }
                 if self.text_rerank_lcs {
-                    let lcs_overlap = lcs_ratio(&q_terms, &candidate_tokens);
+                    let lcs_overlap = lcs_ratio(&q_terms, candidate_tokens);
                     delta += TEXT_RERANK_LCS_WEIGHT * lcs_overlap;
                 }
                 if delta <= 0.0 {
@@ -1697,6 +1979,16 @@ impl MemoryIndex {
         }
         let sequence_rerank_ms = sequence_rerank_start.elapsed().as_secs_f64() * 1000.0;
 
+        let count_query = {
+            let lower = query.to_lowercase();
+            lower.starts_with("how many")
+                || lower.starts_with("count ")
+                || lower.contains(" number of ")
+                || lower.contains(" number of")
+                || lower.contains("count the ")
+                || lower.contains("times did i")
+        };
+        let group_build_start = Instant::now();
         let mut ranked_docs: Vec<(usize, f32)> = candidates
             .iter()
             .filter_map(|(doc_u32, state)| {
@@ -1734,16 +2026,142 @@ impl MemoryIndex {
                 .entry(group_key)
                 .or_insert_with(|| (doc.group_id.clone(), doc.source.clone()));
         }
+        let group_build_ms = group_build_start.elapsed().as_secs_f64() * 1000.0;
 
         let mut ranked_groups: Vec<(String, f32, Vec<(usize, f32)>)> = grouped_ranked_docs
             .into_iter()
             .map(|(group_key, mut items)| {
                 items.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-                let score = aggregate_group_score(&items);
+                let mut unique_entities: HashSet<String> = HashSet::new();
+                let mut unique_terms: HashSet<String> = HashSet::new();
+                let mut dates: Vec<NaiveDate> = Vec::new();
+                let support_threshold = (items[0].1 * 0.35).max(0.15);
+                let mut supporting_docs = 0usize;
+
+                for (doc_u32, score) in &items {
+                    if let Some(state) = candidates.get(doc_u32) {
+                        if *score >= support_threshold {
+                            supporting_docs += 1;
+                        }
+                        for entity in &state.matched_entities {
+                            if !entity.is_empty() {
+                                unique_entities.insert(entity.clone());
+                            }
+                        }
+                        for term in &state.matched_terms {
+                            if !term.is_empty() {
+                                unique_terms.insert(term.clone());
+                            }
+                        }
+                    }
+                    if let Some(doc_id) = self.doc_u32_to_id.get(*doc_u32) {
+                        if let Some(doc) = self.docs.get(doc_id) {
+                            if let Some(date) = doc_temporal_date(doc) {
+                                dates.push(date);
+                            }
+                        }
+                    }
+                }
+
+                let mut score = aggregate_group_score(&items, count_query);
+                if !query_entities.is_empty() {
+                    let exact_entity_matches = items
+                        .iter()
+                        .filter(|(doc_u32, _)| {
+                            candidates
+                                .get(doc_u32)
+                                .map(|state| {
+                                    state
+                                        .matched_entities
+                                        .iter()
+                                        .any(|entity| query_entities.contains(entity.as_str()))
+                                })
+                                .unwrap_or(false)
+                        })
+                        .count();
+                    score += (exact_entity_matches.min(3) as f32) * 0.10;
+                    score += (unique_entities
+                        .iter()
+                        .filter(|entity| query_entities.contains(*entity))
+                        .count()
+                        .min(3) as f32)
+                        * 0.08;
+                }
+                score += (unique_entities.len().min(4) as f32) * 0.04;
+                score += (unique_terms.len().min(6) as f32) * 0.015;
+                score += (supporting_docs.min(4) as f32) * if count_query { 0.06 } else { 0.03 };
+                if dates.len() >= 2 {
+                    dates.sort();
+                    let span_days = dates
+                        .last()
+                        .zip(dates.first())
+                        .map(|(end, start)| end.signed_duration_since(*start).num_days().abs())
+                        .unwrap_or(0);
+                    if span_days <= 7 {
+                        score += if count_query { 0.12 } else { 0.08 };
+                    } else if span_days <= 30 {
+                        score += if count_query { 0.06 } else { 0.04 };
+                    }
+                }
                 (group_key, score, items)
             })
             .collect();
+        let mut group_sort_ms = 0.0;
+        let group_sort_start = Instant::now();
         ranked_groups.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        group_sort_ms += group_sort_start.elapsed().as_secs_f64() * 1000.0;
+        let evidence_start = Instant::now();
+        if let Some(intent) = query_routing_intent {
+            let evidence_terms = routing_content_terms(&q_terms);
+            let unit_terms = routing_unit_terms(&q_terms);
+            for (_group_key, score, items) in ranked_groups.iter_mut() {
+                let mut evidence_supporting_docs = 0usize;
+                let mut evidence_score = 0.0f32;
+                let mut evidence_term_matches = 0usize;
+                let mut evidence_numbers = 0usize;
+                let mut evidence_units = 0usize;
+                let mut evidence_dates = 0usize;
+                let mut evidence_predicates = 0usize;
+                let mut evidence_penalty = 0.0f32;
+                for (doc_u32, _) in items.iter() {
+                    if let Some(features) = self.evidence_features_for_doc(
+                        *doc_u32,
+                        &evidence_terms,
+                        &unit_terms,
+                        intent,
+                    ) {
+                        if features.score > 0.0 {
+                            evidence_supporting_docs += 1;
+                            evidence_score += features.score;
+                            evidence_term_matches += features.matched_terms;
+                            evidence_numbers += usize::from(features.has_number);
+                            evidence_units += usize::from(features.has_unit);
+                            evidence_dates +=
+                                usize::from(features.has_date || features.has_temporal_terms);
+                            evidence_predicates += usize::from(features.predicate_signal);
+                            evidence_penalty += features.distractor_penalty;
+                        }
+                    }
+                }
+                let evidence_boost = group_evidence_boost(
+                    intent,
+                    evidence_supporting_docs,
+                    evidence_score,
+                    evidence_term_matches,
+                    evidence_numbers,
+                    evidence_units,
+                    evidence_dates,
+                    evidence_predicates,
+                    evidence_penalty,
+                );
+                *score = *score * 0.80 + evidence_boost;
+            }
+            let group_sort_start = Instant::now();
+            ranked_groups
+                .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            group_sort_ms += group_sort_start.elapsed().as_secs_f64() * 1000.0;
+        }
+        let evidence_ms = evidence_start.elapsed().as_secs_f64() * 1000.0;
 
         let mut per_group_counts: HashMap<String, usize> = HashMap::new();
         let mut results = Vec::new();
@@ -1812,12 +2230,18 @@ impl MemoryIndex {
                 rerank_ms,
                 parse_ms,
                 sparse_scoring_ms,
+                lexical_merge_ms,
+                posting_scoring_ms,
+                routing_seed_ms,
                 candidate_accumulation_ms,
                 candidate_rank_ms,
                 metadata_ms,
                 graph_ms,
                 entity_graph_ms,
                 sequence_rerank_ms,
+                evidence_ms,
+                group_build_ms,
+                group_sort_ms,
                 ranking_ms,
             },
             QueryDiagnostics {
@@ -2157,7 +2581,8 @@ impl SemanticAggregate {
         for postings in self.claim_to_docs.values_mut() {
             postings.retain(|posting| posting.doc_id != doc_id);
         }
-        self.claim_to_docs.retain(|_, postings| !postings.is_empty());
+        self.claim_to_docs
+            .retain(|_, postings| !postings.is_empty());
         for docs in self.topic_to_docs.values_mut() {
             docs.retain(|id| id != doc_id);
         }
@@ -2245,6 +2670,48 @@ fn candidate_rerank_text(doc: &DocRecord) -> String {
     parts.join(" ")
 }
 
+fn derive_doc_postings(
+    chunk_postings: &[Vec<(u32, f32)>],
+    chunks: &[ChunkMeta],
+    cap: usize,
+) -> Vec<Vec<(u32, f32)>> {
+    chunk_postings
+        .iter()
+        .map(|postings| {
+            let mut doc_scores: HashMap<u32, f32> = HashMap::new();
+            for &(chunk_u32, score) in postings {
+                let doc_u32 = chunks[chunk_u32 as usize].doc_u32;
+                doc_scores
+                    .entry(doc_u32)
+                    .and_modify(|s| *s = s.max(score))
+                    .or_insert(score);
+            }
+            let mut out: Vec<(u32, f32)> = doc_scores.into_iter().collect();
+            out.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            out.truncate(cap);
+            out
+        })
+        .collect()
+}
+
+fn build_doc_rerank_cache(doc: &DocRecord) -> (String, Vec<String>) {
+    let rerank_text = candidate_rerank_text(doc);
+    let normalized = normalize_for_index(&rerank_text);
+    let tokens = tokenize_query_terms(&normalized);
+    (normalized, tokens)
+}
+
+fn cached_doc_rerank_text<'a>(index: &'a MemoryIndex, doc_u32: usize) -> Option<&'a str> {
+    index.doc_rerank_texts.get(doc_u32).map(|s| s.as_str())
+}
+
+fn cached_doc_rerank_tokens<'a>(index: &'a MemoryIndex, doc_u32: usize) -> Option<&'a [String]> {
+    index
+        .doc_rerank_tokens
+        .get(doc_u32)
+        .map(|tokens| tokens.as_slice())
+}
+
 fn doc_has_timestamped_chunk(doc: &DocRecord) -> bool {
     doc.section_chunks
         .iter()
@@ -2273,7 +2740,422 @@ fn normalize_temporal_bounds(
     }
 }
 
-fn aggregate_group_score(items: &[(usize, f32)]) -> f32 {
+fn seed_routing_candidates(
+    index: &MemoryIndex,
+    candidates: &mut HashMap<usize, CandidateState>,
+    candidate_doc_ids: &[usize],
+    q_terms: &[String],
+    query_entities: &HashSet<String>,
+    intent: QueryRoutingIntent,
+) {
+    if candidate_doc_ids.is_empty() {
+        return;
+    }
+
+    let content_terms = routing_content_terms(q_terms);
+    let unit_terms = routing_unit_terms(q_terms);
+
+    for doc_u32 in candidate_doc_ids.iter().copied() {
+        let Some(doc_id) = index.doc_u32_to_id.get(doc_u32) else {
+            continue;
+        };
+        let Some(doc) = index.docs.get(doc_id) else {
+            continue;
+        };
+        let Some(doc_terms) = cached_doc_rerank_tokens(index, doc_u32) else {
+            continue;
+        };
+        if doc_terms.is_empty() {
+            continue;
+        }
+        let matched_terms = content_terms
+            .iter()
+            .filter(|term| doc_terms.iter().any(|tok| tok == *term))
+            .count() as f32;
+        let doc_entities = index
+            .doc_key_entities
+            .get(doc_u32)
+            .map(|keys| keys.as_slice())
+            .unwrap_or(&[]);
+        let matched_entities = doc_entities
+            .iter()
+            .filter(|entity| query_entities.contains(entity.as_str()))
+            .count() as f32;
+        let has_number = index.doc_has_number.get(doc_u32).copied().unwrap_or(false);
+        let has_unit = !unit_terms.is_empty()
+            && unit_terms
+                .iter()
+                .any(|unit| doc_terms.iter().any(|tok| tok == unit));
+        let has_date = doc_temporal_date(doc).is_some();
+        let has_temporal_terms = !doc.temporal_terms.is_empty();
+
+        let mut score = match intent {
+            QueryRoutingIntent::Count => {
+                matched_terms * 0.24
+                    + matched_entities * 0.35
+                    + if has_date { 0.05 } else { 0.0 }
+                    + if has_temporal_terms { 0.04 } else { 0.0 }
+            }
+            QueryRoutingIntent::Sum => {
+                matched_terms * 0.20
+                    + matched_entities * 0.12
+                    + if has_number { 0.30 } else { 0.0 }
+                    + if has_unit { 0.18 } else { 0.0 }
+                    + if has_date { 0.04 } else { 0.0 }
+            }
+            QueryRoutingIntent::Sequence => {
+                matched_terms * 0.20
+                    + matched_entities * 0.12
+                    + if has_date { 0.28 } else { 0.0 }
+                    + if has_temporal_terms { 0.14 } else { 0.0 }
+                    + if has_number { 0.08 } else { 0.0 }
+            }
+        };
+
+        if score <= 0.0 {
+            continue;
+        }
+        if matches!(intent, QueryRoutingIntent::Sequence) && !has_date && !has_temporal_terms {
+            continue;
+        }
+        if matches!(intent, QueryRoutingIntent::Sum) && !has_number && !has_unit {
+            continue;
+        }
+
+        score = score.min(0.85);
+        let entry = candidates.entry(doc_u32).or_default();
+        entry.score += score;
+        entry.breakdown.semantic_score += score;
+    }
+}
+
+impl MemoryIndex {
+    fn evidence_features_for_doc(
+        &self,
+        doc_u32: usize,
+        content_terms: &[String],
+        unit_terms: &[String],
+        intent: QueryRoutingIntent,
+    ) -> Option<EvidenceFeatures> {
+        let doc_id = self.doc_u32_to_id.get(doc_u32)?;
+        let doc = self.docs.get(doc_id)?;
+        let normalized = cached_doc_rerank_text(self, doc_u32)?;
+        if normalized.is_empty() {
+            return None;
+        }
+
+        let doc_terms: HashSet<String> = cached_doc_rerank_tokens(self, doc_u32)
+            .map(|tokens| tokens.iter().cloned().collect())
+            .unwrap_or_else(|| tokenize_query_terms(normalized).into_iter().collect());
+        let matched_terms = content_terms
+            .iter()
+            .filter(|term| doc_terms.contains(term.as_str()))
+            .count();
+        let has_number = self
+            .doc_has_number
+            .get(doc_u32)
+            .copied()
+            .unwrap_or_else(|| contains_number_like(normalized));
+        let has_unit = !unit_terms.is_empty()
+            && unit_terms
+                .iter()
+                .any(|unit| doc_terms.contains(unit.as_str()));
+        if matched_terms == 0 && !has_number && !has_unit {
+            return None;
+        }
+        let has_date = doc_temporal_date(doc).is_some();
+        let has_temporal_terms = !doc.temporal_terms.is_empty();
+        let predicate_signal = has_predicate_signal(&normalized, intent);
+        let distractor_penalty = routing_distractor_penalty(&normalized, intent);
+
+        let mut score = matched_terms.min(6) as f32 * 0.18;
+        if predicate_signal {
+            score += 0.55;
+        }
+        if has_date || has_temporal_terms {
+            score += match intent {
+                QueryRoutingIntent::Sequence => 0.45,
+                _ => 0.12,
+            };
+        }
+        if has_number {
+            score += match intent {
+                QueryRoutingIntent::Sum => 0.45,
+                QueryRoutingIntent::Sequence => 0.12,
+                QueryRoutingIntent::Count => 0.08,
+            };
+        }
+        if has_unit {
+            score += match intent {
+                QueryRoutingIntent::Sum => 0.30,
+                QueryRoutingIntent::Sequence => 0.16,
+                QueryRoutingIntent::Count => 0.06,
+            };
+        }
+        score -= distractor_penalty;
+
+        if !predicate_signal && matched_terms < 2 {
+            score *= 0.25;
+        }
+
+        Some(EvidenceFeatures {
+            score: score.max(0.0),
+            matched_terms,
+            has_number,
+            has_unit,
+            has_date,
+            has_temporal_terms,
+            predicate_signal,
+            distractor_penalty,
+        })
+    }
+}
+
+fn group_evidence_boost(
+    intent: QueryRoutingIntent,
+    supporting_docs: usize,
+    evidence_score: f32,
+    evidence_terms: usize,
+    evidence_numbers: usize,
+    evidence_units: usize,
+    evidence_dates: usize,
+    evidence_predicates: usize,
+    evidence_penalty: f32,
+) -> f32 {
+    if supporting_docs == 0 {
+        return 0.0;
+    }
+
+    let mut boost = evidence_score.min(4.0);
+    boost += supporting_docs.min(4) as f32 * 0.22;
+    boost += evidence_terms.min(8) as f32 * 0.04;
+    boost += evidence_predicates.min(3) as f32 * 0.24;
+
+    match intent {
+        QueryRoutingIntent::Count => {
+            boost += supporting_docs.saturating_sub(1).min(3) as f32 * 0.22;
+        }
+        QueryRoutingIntent::Sum => {
+            boost += evidence_numbers.min(3) as f32 * 0.30;
+            boost += evidence_units.min(3) as f32 * 0.18;
+        }
+        QueryRoutingIntent::Sequence => {
+            boost += evidence_dates.min(4) as f32 * 0.30;
+            boost += evidence_numbers.min(2) as f32 * 0.12;
+        }
+    }
+
+    (boost - evidence_penalty.min(1.5)).max(0.0)
+}
+
+fn routing_content_terms(q_terms: &[String]) -> Vec<String> {
+    let stop = routing_stopwords();
+    let mut seen = HashSet::new();
+    q_terms
+        .iter()
+        .filter(|term| term.len() >= 3)
+        .filter(|term| !stop.contains(term.as_str()))
+        .filter(|term| seen.insert((*term).clone()))
+        .take(16)
+        .cloned()
+        .collect()
+}
+
+fn routing_stopwords() -> &'static HashSet<&'static str> {
+    static STOP: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    STOP.get_or_init(|| {
+        [
+            "how",
+            "many",
+            "much",
+            "what",
+            "which",
+            "who",
+            "when",
+            "where",
+            "why",
+            "did",
+            "does",
+            "have",
+            "has",
+            "had",
+            "been",
+            "being",
+            "was",
+            "were",
+            "are",
+            "the",
+            "and",
+            "or",
+            "for",
+            "from",
+            "with",
+            "that",
+            "this",
+            "these",
+            "those",
+            "currently",
+            "recently",
+            "past",
+            "last",
+            "next",
+            "into",
+            "onto",
+            "about",
+            "after",
+            "before",
+            "over",
+            "under",
+            "between",
+            "during",
+            "i",
+            "you",
+            "we",
+            "they",
+        ]
+        .into_iter()
+        .collect()
+    })
+}
+
+fn routing_unit_terms(query: &[String]) -> Vec<String> {
+    let units = [
+        "mile",
+        "miles",
+        "km",
+        "kilometer",
+        "kilometers",
+        "meter",
+        "meters",
+        "hour",
+        "hours",
+        "minute",
+        "minutes",
+        "day",
+        "days",
+        "week",
+        "weeks",
+        "month",
+        "months",
+        "dollar",
+        "dollars",
+        "usd",
+        "pound",
+        "pounds",
+        "kg",
+        "kilogram",
+        "kilograms",
+        "screen",
+        "time",
+    ];
+    let unit_set: HashSet<&str> = units.into_iter().collect();
+    query
+        .iter()
+        .filter(|term| unit_set.contains(term.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn contains_number_like(text: &str) -> bool {
+    static NUMBER_RE: OnceLock<Regex> = OnceLock::new();
+    let re = NUMBER_RE.get_or_init(|| {
+        Regex::new(
+            r"\b(?:\d+(?:\.\d+)?|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b",
+        )
+        .expect("valid number regex")
+    });
+    re.is_match(text)
+}
+
+fn has_predicate_signal(text: &str, intent: QueryRoutingIntent) -> bool {
+    let terms = match intent {
+        QueryRoutingIntent::Count => [
+            "led",
+            "lead",
+            "leading",
+            "visited",
+            "attended",
+            "bought",
+            "purchased",
+            "baked",
+            "cooked",
+            "tried",
+            "used",
+            "played",
+            "learned",
+            "presented",
+            "participated",
+            "sibling",
+            "brother",
+            "sister",
+            "doctor",
+            "project",
+        ]
+        .as_slice(),
+        QueryRoutingIntent::Sum => [
+            "total",
+            "distance",
+            "cost",
+            "spent",
+            "paid",
+            "miles",
+            "kilometers",
+            "hours",
+            "days",
+        ]
+        .as_slice(),
+        QueryRoutingIntent::Sequence => [
+            "consecutive",
+            "before",
+            "after",
+            "weekend",
+            "days",
+            "weeks",
+            "earliest",
+            "latest",
+            "first",
+            "last",
+        ]
+        .as_slice(),
+    };
+    terms.iter().any(|term| text.contains(term))
+}
+
+fn routing_distractor_penalty(text: &str, intent: QueryRoutingIntent) -> f32 {
+    let generic_markers = [
+        "write a story",
+        "fiction",
+        "character",
+        "captain america",
+        "area of",
+        "formula",
+        "table showing",
+        "census",
+        "survey",
+        "article",
+        "research studies",
+        "here are some",
+        "resources",
+    ];
+    let mut penalty = generic_markers
+        .iter()
+        .filter(|marker| text.contains(**marker))
+        .count() as f32
+        * 0.35;
+
+    if matches!(intent, QueryRoutingIntent::Count) {
+        if text.contains("how many") && text.contains("here are") {
+            penalty += 0.25;
+        }
+        if text.contains("formula") || text.contains("approximately") {
+            penalty += 0.35;
+        }
+    }
+
+    penalty.min(1.4)
+}
+
+fn aggregate_group_score(items: &[(usize, f32)], count_query: bool) -> f32 {
     if items.is_empty() {
         return 0.0;
     }
@@ -2281,11 +3163,38 @@ fn aggregate_group_score(items: &[(usize, f32)]) -> f32 {
     let support = items
         .iter()
         .skip(1)
-        .take(2)
-        .map(|(_, score)| *score)
+        .take(4)
+        .enumerate()
+        .map(|(idx, (_, score))| {
+            let decay = if count_query {
+                match idx {
+                    0 => 0.45,
+                    1 => 0.28,
+                    2 => 0.16,
+                    _ => 0.08,
+                }
+            } else {
+                match idx {
+                    0 => 0.30,
+                    1 => 0.18,
+                    2 => 0.10,
+                    _ => 0.05,
+                }
+            };
+            decay * *score
+        })
         .sum::<f32>();
-    let coverage = items.len().saturating_sub(1).min(3) as f32;
-    base + 0.16 * support + 0.03 * coverage
+    let supporting_docs = items
+        .iter()
+        .skip(1)
+        .filter(|(_, score)| *score >= (items[0].1 * 0.35).max(0.15))
+        .count();
+    let coverage = supporting_docs.min(4) as f32 * if count_query { 0.08 } else { 0.05 };
+    if count_query {
+        base * 0.75 + support + coverage
+    } else {
+        base + support + coverage
+    }
 }
 
 fn normalized_entity_keys(entities: &[Tier1Entity]) -> Vec<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,10 @@
 //! check_cross_refs(&graph, &mut report, &cfg);
 //! ```
 
+pub mod adapters;
 pub mod aggregation;
 pub mod chunking;
+pub mod claim_extractor;
 pub mod cli;
 pub mod config;
 pub mod engine;
@@ -29,14 +31,15 @@ pub mod ids;
 pub mod index;
 pub mod pipeline;
 pub mod query_expansion;
+pub mod query_semantics;
 pub mod report;
 pub mod rules;
-pub mod claim_extractor;
 pub mod source;
 pub mod temporal;
 pub mod temporal_fact;
 pub mod tier1;
 
+pub use crate::claim_extractor::{ClaimExtractor, ConservativeClaimExtractor, ExtractedClaims};
 pub use crate::ids::{stable_chunk_id, stable_doc_id_from_source};
 pub use crate::index::{
     MemoryIndex, QueryDiagnostics, QueryTimings, SearchResult, TemporalQueryContext,
@@ -46,8 +49,5 @@ pub use crate::pipeline::{
     resolve_store_paths, ChunkStrategy, IndexLocation, IndexStore, PipelineOptions, StorePaths,
     Tier1NerProvider, Tier1TermRankerKind,
 };
-pub use crate::claim_extractor::{ClaimExtractor, ConservativeClaimExtractor, ExtractedClaims};
 pub use crate::source::SourceDocument;
-pub use crate::temporal_fact::{
-    TemporalFact, TemporalFactStore, TimelineEvent, TimelinePair,
-};
+pub use crate::temporal_fact::{TemporalFact, TemporalFactStore, TimelineEvent, TimelinePair};

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -10,15 +10,17 @@ use crate::source::SourceDocument;
 use crate::temporal::extract_temporal_terms;
 use crate::temporal_fact::TemporalFactStore;
 use crate::tier1::{
-    CValueStyleTermRanker, HeuristicKeyEntityRanker, ImportantTermRanker, KeyEntityRanker,
-    RakeStyleTermRanker, SpacyKeyEntityRanker, TextRankStyleTermRanker, Tier1DocInput,
-    YakeStyleTermRanker,
+    default_spacy_script_path, CValueStyleTermRanker, HeuristicKeyEntityRanker,
+    ImportantTermRanker, KeyEntityRanker, RakeStyleTermRanker, SpacyKeyEntityRanker,
+    TextRankStyleTermRanker, Tier1DocInput, YakeStyleTermRanker,
 };
 use anyhow::Result;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::thread;
@@ -508,7 +510,8 @@ impl IndexStore {
         before: usize,
         after: usize,
     ) -> Vec<crate::temporal_fact::TimelineEvent<'_>> {
-        self.temporal_facts.timeline_window_around(anchor, before, after)
+        self.temporal_facts
+            .timeline_window_around(anchor, before, after)
     }
 
     pub fn temporal_events_between(
@@ -844,17 +847,8 @@ fn persist_store_metadata(store_paths: &StorePaths, options: &PipelineOptions) -
     let Some(metadata_path) = store_paths.metadata_path.as_ref() else {
         return Ok(());
     };
-    if let Some(parent) = metadata_path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    if let Some(root) = store_paths.root.as_ref() {
-        fs::create_dir_all(root)?;
-    }
-    if let Some(semantic_dir) = store_paths.semantic_dir.as_ref() {
-        fs::create_dir_all(semantic_dir)?;
-    }
     let metadata = current_store_metadata(options);
-    fs::write(metadata_path, serde_json::to_string_pretty(&metadata)?)?;
+    write_text_file_atomic(metadata_path, &serde_json::to_string_pretty(&metadata)?)?;
     Ok(())
 }
 
@@ -993,12 +987,8 @@ fn load_semantic_state(
         .into_iter()
         .map(Into::into)
         .collect::<Vec<DocRecord>>();
-    let snapshot = MemoryIndex::load_with_binary_core(
-        restored_records.clone(),
-        &core_path,
-        None,
-        false,
-    )?;
+    let snapshot =
+        MemoryIndex::load_with_binary_core(restored_records.clone(), &core_path, None, false)?;
     let mut source_docs = HashMap::new();
     let mut records = HashMap::new();
     for record in restored_records {
@@ -1031,9 +1021,9 @@ fn load_semantic_state(
         }
     } else if let Some(chunk_lifecycle_path) = chunk_lifecycle_path(store_paths) {
         if !chunk_lifecycle_path.exists() {
-            fs::write(
-                chunk_lifecycle_path,
-                serde_json::to_string_pretty(
+            write_text_file_atomic(
+                &chunk_lifecycle_path,
+                &serde_json::to_string_pretty(
                     &chunk_lifecycle.values().cloned().collect::<Vec<_>>(),
                 )?,
             )?;
@@ -1067,16 +1057,112 @@ fn persist_semantic_state(
             .cloned()
             .collect::<Vec<ChunkLifecycleMeta>>(),
     };
-    fs::write(records_path, serde_json::to_string_pretty(&payload)?)?;
+    write_text_file_atomic(&records_path, &serde_json::to_string_pretty(&payload)?)?;
     if let Some(lifecycle_path) = chunk_lifecycle_path(store_paths) {
         let mut lifecycle = chunk_lifecycle_map
             .values()
             .cloned()
             .collect::<Vec<ChunkLifecycleMeta>>();
         lifecycle.sort_by(|a, b| a.chunk_id.cmp(&b.chunk_id));
-        fs::write(lifecycle_path, serde_json::to_string_pretty(&lifecycle)?)?;
+        write_text_file_atomic(&lifecycle_path, &serde_json::to_string_pretty(&lifecycle)?)?;
     }
-    snapshot.save_binary_core(&core_path)?;
+    save_binary_core_atomic(snapshot, &core_path)?;
+    Ok(())
+}
+
+fn ensure_safe_output_path(path: &Path) -> Result<()> {
+    if path.is_dir() {
+        anyhow::bail!("refusing to write: output path is a directory");
+    }
+    if let Ok(meta) = fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            anyhow::bail!("refusing to write: output path is a symlink");
+        }
+    }
+    if let Some(parent) = path.parent() {
+        let mut cur = if parent.is_absolute() {
+            PathBuf::from("/")
+        } else {
+            std::env::current_dir()?
+        };
+        for comp in parent.components() {
+            use std::path::Component;
+            match comp {
+                Component::RootDir | Component::CurDir => continue,
+                Component::ParentDir => {
+                    anyhow::bail!("refusing to write: parent traversal is not allowed")
+                }
+                Component::Normal(seg) => {
+                    cur.push(seg);
+                    if let Ok(meta) = fs::symlink_metadata(&cur) {
+                        if meta.file_type().is_symlink() {
+                            anyhow::bail!(
+                                "refusing to write: parent path component is a symlink ({})",
+                                cur.display()
+                            );
+                        }
+                    }
+                }
+                Component::Prefix(_) => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn atomic_temp_path(path: &Path) -> Result<PathBuf> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let stem = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("output");
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    for attempt in 0..1000u32 {
+        let candidate = parent.join(format!(".{}.{}.{}.tmp", stem, pid, nanos + attempt as u128));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    anyhow::bail!(
+        "unable to allocate temporary file path for {}",
+        path.display()
+    )
+}
+
+fn write_text_file_atomic(path: &Path, content: &str) -> Result<()> {
+    ensure_safe_output_path(path)?;
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let temp_path = atomic_temp_path(path)?;
+    {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp_path)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all().ok();
+    }
+    fs::rename(&temp_path, path)?;
+    Ok(())
+}
+
+fn save_binary_core_atomic(snapshot: &MemoryIndex, path: &Path) -> Result<()> {
+    ensure_safe_output_path(path)?;
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    let temp_path = atomic_temp_path(path)?;
+    snapshot.save_binary_core(&temp_path)?;
+    fs::rename(&temp_path, path)?;
     Ok(())
 }
 
@@ -1276,7 +1362,7 @@ fn build_doc_records(
         Tier1NerProvider::Spacy => {
             let spacy = SpacyKeyEntityRanker {
                 model: options.spacy_model.clone(),
-                script_path: "scripts/spacy_ner.py".to_string(),
+                script_path: default_spacy_script_path().display().to_string(),
             };
             match spacy.rank_docs(&docs) {
                 Ok(out) => out,
@@ -1342,7 +1428,7 @@ fn build_doc_record(source_doc: &SourceDocument, options: &PipelineOptions) -> R
         Tier1NerProvider::Spacy => {
             let spacy = SpacyKeyEntityRanker {
                 model: options.spacy_model.clone(),
-                script_path: "scripts/spacy_ner.py".to_string(),
+                script_path: default_spacy_script_path().display().to_string(),
             };
             match spacy.rank_docs(std::slice::from_ref(&doc)) {
                 Ok(mut out) => out.remove(&doc.id).unwrap_or_default(),
@@ -1790,7 +1876,7 @@ mod tests {
         fs::create_dir_all(&index_root).expect("index root should be creatable");
         fs::write(
             index_root.join("metadata.json"),
-            r#"{"schema_version":999,"layout_version":"index-store-v1","crate_version":"0.1.5","index_location":"explicit"}"#,
+            r#"{"schema_version":999,"layout_version":"index-store-v1","crate_version":"0.1.6","index_location":"explicit"}"#,
         )
         .expect("metadata file should be writable");
 

--- a/src/query_semantics.rs
+++ b/src/query_semantics.rs
@@ -1,0 +1,1239 @@
+#![allow(unexpected_cfgs)]
+
+use chrono::NaiveDateTime;
+use fuzzydate::parse as fuzzy_parse;
+use regex::Regex;
+use serde::Serialize;
+use std::collections::HashSet;
+
+use crate::aggregation::AggregateIntent;
+use crate::query_expansion::normalize_for_index;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub enum QueryKind {
+    HowMany,
+    HowMuch,
+    Who,
+    What,
+    When,
+    Where,
+    Which,
+    Why,
+    Statement,
+    Other,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub enum QuerySpanKind {
+    Entity,
+    NounPhrase,
+    VerbPhrase,
+    Subject,
+    Object,
+    Temporal,
+    Quantity,
+    QuestionWord,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum QueryTimeHint {
+    Past,
+    Present,
+    Ongoing,
+    Mixed,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub enum QueryRoutingIntent {
+    Count,
+    Sum,
+    Sequence,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QuerySpan {
+    pub kind: QuerySpanKind,
+    pub text: String,
+    pub normalized: String,
+    pub score: f32,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QueryTemporal {
+    pub phrase: String,
+    pub resolved_at: Option<String>,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QueryPosTag {
+    pub word: String,
+    pub label: String,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone)]
+struct POSTag {
+    word: String,
+    label: String,
+    score: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QueryAnalysis {
+    pub original_query: String,
+    pub normalized_query: String,
+    pub kind: QueryKind,
+    pub quantity_intent: Option<String>,
+    pub subject_hint: Option<String>,
+    pub object_hint: Option<String>,
+    pub temporal: Option<QueryTemporal>,
+    pub time_hint: Option<QueryTimeHint>,
+    pub query_routing_intent: Option<QueryRoutingIntent>,
+    pub raw_pos_tags: Vec<QueryPosTag>,
+    pub spans: Vec<QuerySpan>,
+    pub augmented_query: String,
+}
+
+pub fn analyze_query(query: &str) -> QueryAnalysis {
+    let original_query = query.trim().to_string();
+    let signals = analyze_query_signals(&original_query);
+    build_query_analysis(
+        original_query,
+        signals.pos_tags,
+        signals.entities,
+        signals.focused_pos_tags,
+        signals.source,
+    )
+}
+
+#[derive(Debug, Clone)]
+struct QuerySignals {
+    pos_tags: Vec<POSTag>,
+    entities: Vec<QuerySpan>,
+    focused_pos_tags: Option<Vec<POSTag>>,
+    source: QuerySignalSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuerySignalSource {
+    Heuristic,
+    RustBert,
+}
+
+#[cfg(feature = "rust-bert-query-semantics")]
+fn analyze_query_signals(query: &str) -> QuerySignals {
+    rust_bert_backend::analyze_query_signals(query)
+}
+
+#[cfg(not(feature = "rust-bert-query-semantics"))]
+fn analyze_query_signals(query: &str) -> QuerySignals {
+    heuristic_query_signals(query)
+}
+
+fn heuristic_query_signals(query: &str) -> QuerySignals {
+    let pos_tags = heuristic_pos_tags(query);
+    let entities = heuristic_entities(query);
+    QuerySignals {
+        pos_tags,
+        entities,
+        focused_pos_tags: None,
+        source: QuerySignalSource::Heuristic,
+    }
+}
+
+#[cfg(feature = "rust-bert-query-semantics")]
+mod rust_bert_backend {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    struct QueryModels {
+        ner: rust_bert::pipelines::ner::NERModel,
+        pos: rust_bert::pipelines::pos_tagging::POSModel,
+    }
+
+    static MODELS: OnceLock<Mutex<Option<QueryModels>>> = OnceLock::new();
+
+    fn with_models<R>(f: impl FnOnce(&QueryModels) -> R) -> Option<R> {
+        let lock = MODELS.get_or_init(|| {
+            Mutex::new({
+                let ner = rust_bert::pipelines::ner::NERModel::new(Default::default()).ok();
+                let pos = rust_bert::pipelines::pos_tagging::POSModel::new(Default::default()).ok();
+                match (ner, pos) {
+                    (Some(ner), Some(pos)) => Some(QueryModels { ner, pos }),
+                    _ => None,
+                }
+            })
+        });
+        let guard = lock.lock().ok()?;
+        let models = guard.as_ref()?;
+        Some(f(models))
+    }
+
+    pub fn analyze_query_signals(query: &str) -> QuerySignals {
+        let Some(signals) = with_models(|models| {
+            let pos_tags = models
+                .pos
+                .predict(&[query])
+                .into_iter()
+                .next()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|tag| POSTag {
+                    word: tag.word,
+                    label: tag.label,
+                    score: tag.score,
+                })
+                .collect::<Vec<_>>();
+
+            let first_sentence = first_sentence_text(query);
+            let first_sentence_pos = first_sentence.as_deref().map_or_else(Vec::new, |sentence| {
+                models
+                    .pos
+                    .predict(&[sentence])
+                    .into_iter()
+                    .next()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|tag| POSTag {
+                        word: tag.word,
+                        label: tag.label,
+                        score: tag.score,
+                    })
+                    .collect::<Vec<_>>()
+            });
+
+            let entities = models
+                .ner
+                .predict_full_entities(&[query])
+                .into_iter()
+                .next()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|entity| {
+                    let label = entity.label;
+                    let text = entity.word;
+                    QuerySpan {
+                        kind: QuerySpanKind::Entity,
+                        text: text.clone(),
+                        normalized: normalize_for_index(&text),
+                        score: entity.score as f32,
+                        source: format!("rust-bert-ner:{label}"),
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            let focused_pos_tags = if first_sentence_pos.is_empty() {
+                None
+            } else {
+                Some(first_sentence_pos)
+            };
+
+            // Previous behavior kept the first-sentence model outputs in the main streams:
+            //
+            // if !first_sentence_pos.is_empty() {
+            //     let first_sentence_entities = models
+            //         .ner
+            //         .predict_full_entities(&[first_sentence.as_deref().unwrap_or(query)])
+            //         .into_iter()
+            //         .next()
+            //         .unwrap_or_default()
+            //         .into_iter()
+            //         .map(|entity| {
+            //             let text = entity.word;
+            //             QuerySpan {
+            //                 kind: QuerySpanKind::Entity,
+            //                 text: text.clone(),
+            //                 normalized: normalize_for_index(&text),
+            //                 score: entity.score as f32,
+            //                 source: "rust-bert".to_string(),
+            //             }
+            //         })
+            //         .collect::<Vec<_>>();
+            //     signals.entities.extend(first_sentence_entities);
+            //     signals.pos_tags.extend(first_sentence_pos);
+            // }
+
+            QuerySignals {
+                pos_tags,
+                entities,
+                focused_pos_tags,
+                source: QuerySignalSource::RustBert,
+            }
+        }) else {
+            return super::heuristic_query_signals(query);
+        };
+        signals
+    }
+
+    fn first_sentence_text(query: &str) -> Option<String> {
+        let mut parts = query.split_terminator(['.', '!', '?']);
+        let first = parts.next()?.trim();
+        if first.is_empty() {
+            None
+        } else {
+            Some(first.to_string())
+        }
+    }
+}
+
+fn build_query_analysis(
+    original_query: String,
+    pos_tags: Vec<POSTag>,
+    entities: Vec<QuerySpan>,
+    focused_pos_tags: Option<Vec<POSTag>>,
+    source: QuerySignalSource,
+) -> QueryAnalysis {
+    let normalized_query = normalize_for_index(&original_query);
+    let kind = classify_query_kind(&original_query);
+    let aggregate_intent = quantity_intent(&original_query);
+    let quantity_intent = aggregate_intent.as_ref().map(|intent| match intent {
+        AggregateIntent::Count => "count".to_string(),
+        AggregateIntent::Sum => "sum".to_string(),
+    });
+
+    let temporal = extract_temporal(&original_query);
+    let query_routing_intent =
+        query_routing_intent(&original_query, aggregate_intent.as_ref(), &temporal);
+    let mut spans = Vec::new();
+    if let Some(qw) = leading_question_word(&original_query) {
+        spans.push(QuerySpan {
+            kind: QuerySpanKind::QuestionWord,
+            text: qw.clone(),
+            normalized: normalize_for_index(&qw),
+            score: 0.7,
+            source: "heuristic".to_string(),
+        });
+    }
+
+    let raw_pos_tags = pos_tags
+        .iter()
+        .map(|tag| QueryPosTag {
+            word: tag.word.clone(),
+            label: tag.label.clone(),
+            score: tag.score,
+        })
+        .collect::<Vec<_>>();
+    let time_hint = infer_time_hint_from_pos(&pos_tags);
+
+    spans.extend(entities.iter().cloned());
+
+    let span_tags = focused_pos_tags.as_ref().unwrap_or(&pos_tags);
+    let noun_chunks = extract_noun_phrases(span_tags);
+    let noun_phrases: Vec<String> = noun_chunks
+        .iter()
+        .filter_map(|p| clean_noun_phrase_for_query(&p.text))
+        .collect();
+    let verb_phrases = extract_verb_phrases(span_tags);
+    let (subject, object) = infer_subject_object(span_tags, &noun_chunks, &entities);
+
+    let rust_bert_model_signals = source == QuerySignalSource::RustBert;
+    let (subject_hint, object_hint) = if rust_bert_model_signals {
+        // Keep the model-backed branch close to the original rust-bert flow:
+        // infer from the focused POS stream and do not layer text-only fallback
+        // hints on top of model-derived subject/object hints.
+        (subject, object)
+    } else {
+        (
+            subject.or_else(|| {
+                let fallback_phrases = heuristic_noun_phrases(&original_query);
+                infer_subject_object_from_text(&original_query, &fallback_phrases).0
+            }),
+            object.or_else(|| {
+                let fallback_phrases = heuristic_noun_phrases(&original_query);
+                infer_subject_object_from_text(&original_query, &fallback_phrases).1
+            }),
+        )
+    };
+
+    if rust_bert_model_signals {
+        spans.extend(noun_chunks.iter().cloned().map(|phrase| QuerySpan {
+            kind: QuerySpanKind::NounPhrase,
+            text: phrase.text.clone(),
+            normalized: normalize_for_index(&phrase.text),
+            score: 0.6,
+            source: "rust-bert-pos".to_string(),
+        }));
+
+        // Current experiment, kept available for quick restore:
+        //
+        // spans.extend(verb_phrases.iter().cloned().map(|phrase| QuerySpan {
+        //     kind: QuerySpanKind::VerbPhrase,
+        //     text: phrase.clone(),
+        //     normalized: normalize_for_index(&phrase),
+        //     score: 0.35,
+        //     source: "rust-bert-pos".to_string(),
+        // }));
+    } else {
+        spans.extend(noun_chunks.iter().cloned().map(|phrase| QuerySpan {
+            kind: QuerySpanKind::NounPhrase,
+            text: phrase.text.clone(),
+            normalized: normalize_for_index(&phrase.text),
+            score: 0.4,
+            source: "pos".to_string(),
+        }));
+        spans.extend(verb_phrases.iter().cloned().map(|phrase| QuerySpan {
+            kind: QuerySpanKind::VerbPhrase,
+            text: phrase.clone(),
+            normalized: normalize_for_index(&phrase),
+            score: 0.35,
+            source: "pos".to_string(),
+        }));
+    }
+
+    if let Some(ref temporal) = temporal {
+        spans.push(QuerySpan {
+            kind: QuerySpanKind::Temporal,
+            text: temporal.phrase.clone(),
+            normalized: normalize_for_index(&temporal.phrase),
+            score: 0.8,
+            source: temporal.source.clone(),
+        });
+    }
+
+    if let Some(subject) = subject_hint.clone() {
+        spans.push(QuerySpan {
+            kind: QuerySpanKind::Subject,
+            text: subject.clone(),
+            normalized: normalize_for_index(&subject),
+            score: 0.75,
+            source: "heuristic".to_string(),
+        });
+    }
+
+    if let Some(object) = object_hint.clone() {
+        spans.push(QuerySpan {
+            kind: QuerySpanKind::Object,
+            text: object.clone(),
+            normalized: normalize_for_index(&object),
+            score: 0.75,
+            source: "heuristic".to_string(),
+        });
+    }
+
+    if quantity_intent.is_some() {
+        let quantity_text =
+            quantity_phrase(&original_query).unwrap_or_else(|| original_query.clone());
+        spans.push(QuerySpan {
+            kind: QuerySpanKind::Quantity,
+            normalized: normalize_for_index(&quantity_text),
+            text: quantity_text,
+            score: 0.85,
+            source: "heuristic".to_string(),
+        });
+    }
+
+    let augmented_verb_phrases: &[String] = if rust_bert_model_signals {
+        &[]
+    } else {
+        &verb_phrases
+    };
+    let augmented_query = build_augmented_query(
+        &original_query,
+        &entities,
+        &noun_phrases,
+        augmented_verb_phrases,
+        subject_hint.as_deref(),
+        object_hint.as_deref(),
+    );
+
+    if rust_bert_model_signals {
+        // Previous conservative variant for the model-backed branch:
+        //
+        // let augmented_query = original_query.clone();
+        //
+        // Previous permissive experiment:
+        //
+        // let (subject_hint, object_hint) = (
+        //     subject.or_else(|| {
+        //         let fallback_phrases = heuristic_noun_phrases(&original_query);
+        //         infer_subject_object_from_text(&original_query, &fallback_phrases).0
+        //     }),
+        //     object.or_else(|| {
+        //         let fallback_phrases = heuristic_noun_phrases(&original_query);
+        //         infer_subject_object_from_text(&original_query, &fallback_phrases).1
+        //     }),
+        // );
+    }
+
+    QueryAnalysis {
+        original_query,
+        normalized_query,
+        kind,
+        quantity_intent,
+        subject_hint,
+        object_hint,
+        temporal,
+        time_hint,
+        query_routing_intent,
+        raw_pos_tags,
+        spans: dedup_spans(spans),
+        augmented_query,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NounPhrase {
+    text: String,
+    start: usize,
+    end: usize,
+}
+
+fn classify_query_kind(query: &str) -> QueryKind {
+    let lower = query.trim().to_lowercase();
+    if lower.starts_with("how many") {
+        return QueryKind::HowMany;
+    }
+    if lower.starts_with("how much") {
+        return QueryKind::HowMuch;
+    }
+    if lower.starts_with("who ") || lower == "who" {
+        return QueryKind::Who;
+    }
+    if lower.starts_with("what ") || lower == "what" {
+        return QueryKind::What;
+    }
+    if lower.starts_with("when ") || lower == "when" {
+        return QueryKind::When;
+    }
+    if lower.starts_with("where ") || lower == "where" {
+        return QueryKind::Where;
+    }
+    if lower.starts_with("which ") || lower == "which" {
+        return QueryKind::Which;
+    }
+    if lower.starts_with("why ") || lower == "why" {
+        return QueryKind::Why;
+    }
+    QueryKind::Statement
+}
+
+fn quantity_intent(query: &str) -> Option<AggregateIntent> {
+    let lower = query.to_lowercase();
+    if lower.contains("how many")
+        || lower.starts_with("count ")
+        || lower.contains(" number of ")
+        || lower.contains(" number of")
+        || lower.contains("count the ")
+        || lower.contains("times did i")
+    {
+        return Some(AggregateIntent::Count);
+    }
+    if lower.contains("how much")
+        || lower.contains(" total ")
+        || lower.starts_with("total ")
+        || lower.contains("combined")
+        || lower.contains("in all")
+        || lower.contains("sum ")
+    {
+        return Some(AggregateIntent::Sum);
+    }
+    None
+}
+
+fn quantity_phrase(query: &str) -> Option<String> {
+    let lower = query.to_lowercase();
+    if let Some(m) = Regex::new(r"\bhow\s+(many|much)\b").ok()?.find(&lower) {
+        return Some(query[m.start()..m.end()].to_string());
+    }
+    if let Some(m) = Regex::new(r"\b(number of|count(?: the)?|total)\b")
+        .ok()?
+        .find(&lower)
+    {
+        return Some(query[m.start()..m.end()].to_string());
+    }
+    None
+}
+
+fn query_routing_intent(
+    query: &str,
+    quantity_intent: Option<&AggregateIntent>,
+    temporal: &Option<QueryTemporal>,
+) -> Option<QueryRoutingIntent> {
+    if let Some(intent) = quantity_intent {
+        return Some(match intent {
+            AggregateIntent::Count => QueryRoutingIntent::Count,
+            AggregateIntent::Sum => QueryRoutingIntent::Sum,
+        });
+    }
+
+    let lower = query.to_lowercase();
+    let sequence_markers = [
+        "consecutive",
+        "earliest",
+        "latest",
+        "first",
+        "last",
+        "next",
+        "previous",
+        "before",
+        "after",
+        "order",
+        "ordered",
+        "sequence",
+    ];
+    if temporal.is_some() && sequence_markers.iter().any(|marker| lower.contains(marker)) {
+        return Some(QueryRoutingIntent::Sequence);
+    }
+
+    if lower.contains("consecutive days")
+        || lower.contains("from earliest to latest")
+        || lower.contains("which happened first")
+    {
+        return Some(QueryRoutingIntent::Sequence);
+    }
+
+    None
+}
+
+fn heuristic_pos_tags(query: &str) -> Vec<POSTag> {
+    let mut tags = Vec::new();
+    for raw in query.split_whitespace() {
+        let word = raw.trim_matches(|c: char| c.is_ascii_punctuation());
+        if word.is_empty() {
+            continue;
+        }
+        let lower = word.to_lowercase();
+        let label = if matches!(
+            lower.as_str(),
+            "how" | "what" | "who" | "when" | "where" | "which" | "why"
+        ) {
+            "WRB"
+        } else if matches!(
+            lower.as_str(),
+            "i" | "me"
+                | "we"
+                | "us"
+                | "you"
+                | "he"
+                | "him"
+                | "she"
+                | "her"
+                | "it"
+                | "they"
+                | "them"
+                | "my"
+                | "mine"
+                | "our"
+                | "ours"
+                | "your"
+                | "yours"
+                | "their"
+                | "theirs"
+        ) {
+            "PRP"
+        } else if matches!(
+            lower.as_str(),
+            "a" | "an"
+                | "the"
+                | "this"
+                | "that"
+                | "these"
+                | "those"
+                | "many"
+                | "much"
+                | "some"
+                | "any"
+                | "each"
+                | "every"
+                | "all"
+        ) {
+            "DT"
+        } else if matches!(
+            lower.as_str(),
+            "of" | "to"
+                | "for"
+                | "on"
+                | "in"
+                | "at"
+                | "with"
+                | "from"
+                | "by"
+                | "about"
+                | "over"
+                | "under"
+                | "through"
+                | "during"
+                | "before"
+                | "after"
+                | "between"
+                | "into"
+                | "onto"
+                | "near"
+                | "within"
+                | "without"
+                | "per"
+        ) {
+            "IN"
+        } else if matches!(lower.as_str(), "and" | "or" | "but" | "nor") {
+            "CC"
+        } else if matches!(
+            lower.as_str(),
+            "is" | "am"
+                | "are"
+                | "was"
+                | "were"
+                | "be"
+                | "been"
+                | "being"
+                | "have"
+                | "has"
+                | "had"
+                | "do"
+                | "does"
+                | "did"
+                | "can"
+                | "could"
+                | "should"
+                | "would"
+                | "will"
+                | "shall"
+                | "may"
+                | "might"
+                | "must"
+        ) {
+            if matches!(
+                lower.as_str(),
+                "was" | "were" | "did" | "had" | "could" | "should" | "would"
+            ) {
+                "VBD"
+            } else if matches!(lower.as_str(), "been" | "being") {
+                "VBN"
+            } else if matches!(
+                lower.as_str(),
+                "am" | "is" | "are" | "has" | "does" | "will" | "shall"
+            ) {
+                "VBP"
+            } else {
+                "VB"
+            }
+        } else if lower.ends_with("ing") && lower.len() > 4 {
+            "VBG"
+        } else if lower.ends_with("ed") && lower.len() > 3 {
+            "VBD"
+        } else if lower.ends_with("ly") {
+            "RB"
+        } else if matches!(
+            lower.as_str(),
+            "currently" | "now" | "today" | "recently" | "already"
+        ) {
+            "RB"
+        } else if lower.chars().all(|c| c.is_ascii_digit()) {
+            "CD"
+        } else if word
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
+        {
+            "NNP"
+        } else if word
+            .chars()
+            .next()
+            .map_or(false, |c| c.is_ascii_uppercase())
+        {
+            "NNP"
+        } else if lower.ends_with('s') && lower.len() > 3 {
+            "NNS"
+        } else {
+            "NN"
+        };
+        tags.push(POSTag {
+            word: word.to_string(),
+            label: label.to_string(),
+            score: 0.55,
+        });
+    }
+    tags
+}
+
+fn heuristic_entities(query: &str) -> Vec<QuerySpan> {
+    let words: Vec<&str> = query.split_whitespace().collect();
+    let mut spans = Vec::new();
+    let mut current: Vec<String> = Vec::new();
+
+    let flush = |spans: &mut Vec<QuerySpan>, current: &mut Vec<String>| {
+        if current.is_empty() {
+            return;
+        }
+        let text = current.join(" ").trim().to_string();
+        if text.is_empty() {
+            current.clear();
+            return;
+        }
+        spans.push(QuerySpan {
+            kind: QuerySpanKind::Entity,
+            normalized: normalize_for_index(&text),
+            text,
+            score: 0.55,
+            source: "heuristic".to_string(),
+        });
+        current.clear();
+    };
+
+    for word in words {
+        let token = word.trim_matches(|c: char| c.is_ascii_punctuation());
+        if token.is_empty() {
+            flush(&mut spans, &mut current);
+            continue;
+        }
+        let looks_like_entity = token.len() > 1
+            && (token
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
+                || token
+                    .chars()
+                    .next()
+                    .map_or(false, |c| c.is_ascii_uppercase()));
+        if looks_like_entity {
+            current.push(token.to_string());
+        } else {
+            flush(&mut spans, &mut current);
+        }
+    }
+    flush(&mut spans, &mut current);
+    spans
+}
+
+fn extract_verb_phrases(tags: &[POSTag]) -> Vec<String> {
+    let mut phrases = Vec::new();
+    let mut current = Vec::new();
+    let mut seen_verb = false;
+
+    let flush = |phrases: &mut Vec<String>, current: &mut Vec<String>, seen_verb: &mut bool| {
+        if *seen_verb && !current.is_empty() {
+            phrases.push(current.join(" "));
+        }
+        current.clear();
+        *seen_verb = false;
+    };
+
+    for tag in tags {
+        if is_punct(&tag.label, &tag.word) {
+            flush(&mut phrases, &mut current, &mut seen_verb);
+            continue;
+        }
+        if is_verbish(&tag.label) || (tag.label == "RB" && seen_verb) {
+            current.push(tag.word.clone());
+            if is_verbish(&tag.label) {
+                seen_verb = true;
+            }
+        } else {
+            flush(&mut phrases, &mut current, &mut seen_verb);
+        }
+    }
+    flush(&mut phrases, &mut current, &mut seen_verb);
+    phrases
+}
+
+#[derive(Debug, Clone)]
+struct PhraseMatch {
+    text: String,
+    start: usize,
+    end: usize,
+}
+
+fn extract_temporal(query: &str) -> Option<QueryTemporal> {
+    for match_ in temporal_candidates(query) {
+        let resolved_at = fuzzy_parse(match_.text.as_str())
+            .ok()
+            .map(|dt: NaiveDateTime| dt.to_string());
+        return Some(QueryTemporal {
+            phrase: match_.text,
+            resolved_at,
+            source: "fuzzydate".to_string(),
+        });
+    }
+    None
+}
+
+fn temporal_candidates(query: &str) -> Vec<PhraseMatch> {
+    let lower = query.to_lowercase();
+    let mut out = Vec::new();
+    let patterns = [
+        r"\b(today|tomorrow|yesterday|tonight)\b",
+        r"\b(?:last|this|next)\s+(?:week|month|year|weekend)\b",
+        r"\b(?:last|this|next)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
+        r"\b(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten)\s+(?:day|days|week|weeks|month|months|year|years)(?:\s+ago)?\b",
+        r"\bconsecutive days\b",
+    ];
+
+    for pattern in patterns {
+        let re = Regex::new(pattern).expect("valid temporal regex");
+        for m in re.find_iter(&lower) {
+            out.push(PhraseMatch {
+                text: query[m.start()..m.end()].to_string(),
+                start: m.start(),
+                end: m.end(),
+            });
+        }
+    }
+
+    out.sort_by_key(|m| (m.start, m.end));
+    dedup_phrase_matches(out)
+}
+
+fn dedup_phrase_matches(mut items: Vec<PhraseMatch>) -> Vec<PhraseMatch> {
+    let mut seen = HashSet::new();
+    items
+        .drain(..)
+        .filter(|item| seen.insert(item.text.to_lowercase()))
+        .collect()
+}
+
+fn leading_question_word(query: &str) -> Option<String> {
+    let lower = query.trim().to_lowercase();
+    let first = lower.split_whitespace().next()?;
+    match first {
+        "how" => Some("how".to_string()),
+        "what" => Some("what".to_string()),
+        "who" => Some("who".to_string()),
+        "when" => Some("when".to_string()),
+        "where" => Some("where".to_string()),
+        "which" => Some("which".to_string()),
+        "why" => Some("why".to_string()),
+        _ => None,
+    }
+}
+
+fn infer_time_hint_from_pos(tags: &[POSTag]) -> Option<QueryTimeHint> {
+    let mut saw_past = false;
+    let mut saw_present = false;
+    let mut saw_ongoing = false;
+
+    for tag in tags {
+        let word = tag.word.to_lowercase();
+        match tag.label.as_str() {
+            "VBD" | "VBN" => saw_past = true,
+            "VBP" | "VBZ" => saw_present = true,
+            "VBG" => saw_ongoing = true,
+            "RB" if matches!(word.as_str(), "currently" | "now" | "today") => saw_ongoing = true,
+            _ => {}
+        }
+    }
+
+    if saw_past && (saw_present || saw_ongoing) {
+        return Some(QueryTimeHint::Mixed);
+    }
+    if saw_ongoing {
+        return Some(QueryTimeHint::Ongoing);
+    }
+    if saw_past {
+        return Some(QueryTimeHint::Past);
+    }
+    if saw_present {
+        return Some(QueryTimeHint::Present);
+    }
+    None
+}
+
+fn is_nounish(label: &str) -> bool {
+    label.starts_with("NN") || matches!(label, "CD" | "JJ" | "JJR" | "JJS")
+}
+
+fn is_verbish(label: &str) -> bool {
+    label.starts_with('V') || matches!(label, "MD")
+}
+
+fn is_punct(label: &str, word: &str) -> bool {
+    matches!(label, "." | "," | ":" | ";" | "``" | "''")
+        || word.chars().all(|c| !c.is_alphanumeric())
+}
+
+fn extract_noun_phrases(tags: &[POSTag]) -> Vec<NounPhrase> {
+    let mut phrases = Vec::new();
+    let mut current: Vec<String> = Vec::new();
+    let mut start = 0usize;
+
+    let flush =
+        |phrases: &mut Vec<NounPhrase>, current: &mut Vec<String>, start: usize, end: usize| {
+            if current.is_empty() {
+                return;
+            }
+            let text = current.join(" ").trim().to_string();
+            if text.is_empty() {
+                current.clear();
+                return;
+            }
+            phrases.push(NounPhrase { text, start, end });
+            current.clear();
+        };
+
+    for (idx, tag) in tags.iter().enumerate() {
+        if is_punct(&tag.label, &tag.word) {
+            flush(&mut phrases, &mut current, start, idx);
+            continue;
+        }
+        if is_nounish(&tag.label) {
+            if current.is_empty() {
+                start = idx;
+            }
+            current.push(tag.word.clone());
+        } else {
+            flush(&mut phrases, &mut current, start, idx);
+        }
+    }
+    flush(&mut phrases, &mut current, start, tags.len());
+    phrases
+}
+
+fn infer_subject_object(
+    tags: &[POSTag],
+    noun_phrases: &[NounPhrase],
+    entities: &[QuerySpan],
+) -> (Option<String>, Option<String>) {
+    let first_verb = tags.iter().position(|tag| is_verbish(&tag.label));
+    let subject = noun_phrases
+        .iter()
+        .find(|phrase| first_verb.map_or(true, |verb_idx| phrase.end <= verb_idx))
+        .and_then(|phrase| subject_head(&phrase.text))
+        .or_else(|| entities.first().map(|entity| entity.text.clone()));
+    let object = noun_phrases
+        .iter()
+        .rev()
+        .find(|phrase| first_verb.map_or(true, |verb_idx| phrase.start >= verb_idx))
+        .and_then(|phrase| subject_head(&phrase.text))
+        .or_else(|| {
+            noun_phrases
+                .last()
+                .and_then(|phrase| subject_head(&phrase.text))
+        });
+    (subject, object)
+}
+
+fn infer_subject_object_from_text(
+    query: &str,
+    noun_phrases: &[NounPhrase],
+) -> (Option<String>, Option<String>) {
+    let lower = query.to_lowercase();
+    let first_verb = lower
+        .split_whitespace()
+        .position(|token| {
+            matches!(
+                token,
+                "is" | "are"
+                    | "was"
+                    | "were"
+                    | "do"
+                    | "does"
+                    | "did"
+                    | "can"
+                    | "could"
+                    | "should"
+                    | "would"
+                    | "didn't"
+                    | "will"
+                    | "has"
+                    | "have"
+                    | "had"
+            )
+        })
+        .unwrap_or(usize::MAX);
+    let subject = noun_phrases
+        .iter()
+        .find(|phrase| phrase.start <= first_verb)
+        .and_then(|phrase| subject_head(&phrase.text));
+    let object = noun_phrases
+        .iter()
+        .rev()
+        .find(|phrase| phrase.start >= first_verb)
+        .and_then(|phrase| subject_head(&phrase.text))
+        .or_else(|| {
+            noun_phrases
+                .last()
+                .and_then(|phrase| subject_head(&phrase.text))
+        });
+    (subject, object)
+}
+
+fn subject_head(text: &str) -> Option<String> {
+    let stopwords = [
+        "a", "an", "the", "this", "that", "these", "those", "many", "much", "more", "most", "some",
+        "any", "each", "every", "all", "my", "your", "his", "her", "its", "our", "their", "me",
+        "i", "we", "you", "he", "she", "they", "it",
+    ];
+    let mut parts = text
+        .split_whitespace()
+        .filter(|part| {
+            let lower = part.to_lowercase();
+            !stopwords.contains(&lower.as_str())
+        })
+        .map(|part| part.trim_matches(|c: char| !c.is_alphanumeric()))
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    parts.pop().map(|s| s.to_string())
+}
+
+fn clean_noun_phrase_for_query(text: &str) -> Option<String> {
+    let stopwords = [
+        "a", "an", "the", "this", "that", "these", "those", "many", "much", "more", "most", "some",
+        "any", "each", "every", "all", "my", "your", "his", "her", "its", "our", "their", "me",
+        "i", "we", "you", "he", "she", "they", "it",
+    ];
+    let parts = text
+        .split_whitespace()
+        .map(|part| part.trim_matches(|c: char| !c.is_alphanumeric() && c != '-' && c != '_'))
+        .filter(|part| !part.is_empty())
+        .filter(|part| {
+            let lower = part.to_lowercase();
+            !stopwords.contains(&lower.as_str())
+        })
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" "))
+    }
+}
+
+fn heuristic_noun_phrases(query: &str) -> Vec<NounPhrase> {
+    if normalize_for_index(query).is_empty() {
+        return Vec::new();
+    }
+    let words: Vec<&str> = query.split_whitespace().collect();
+    let stop_words = [
+        "what", "who", "when", "where", "why", "how", "many", "much", "is", "are", "was", "were",
+        "do", "does", "did", "the", "a", "an", "of", "to", "for", "on", "in", "at", "with", "from",
+        "by", "about", "and",
+    ];
+    let mut phrases = Vec::new();
+    let mut current = Vec::new();
+    let mut start = 0usize;
+    for (idx, word) in words.iter().enumerate() {
+        let token = word.trim_matches(|c: char| !c.is_alphanumeric() && c != '-' && c != '_');
+        if token.is_empty() || stop_words.contains(&token.to_lowercase().as_str()) {
+            if !current.is_empty() {
+                phrases.push(NounPhrase {
+                    text: current.join(" "),
+                    start,
+                    end: idx,
+                });
+                current.clear();
+            }
+            continue;
+        }
+        if current.is_empty() {
+            start = idx;
+        }
+        current.push(token.to_string());
+    }
+    if !current.is_empty() {
+        phrases.push(NounPhrase {
+            text: current.join(" "),
+            start,
+            end: words.len(),
+        });
+    }
+    phrases
+}
+
+fn build_augmented_query(
+    original_query: &str,
+    entities: &[QuerySpan],
+    noun_phrases: &[String],
+    verb_phrases: &[String],
+    subject_hint: Option<&str>,
+    object_hint: Option<&str>,
+) -> String {
+    let mut seen = HashSet::new();
+    let mut terms = Vec::new();
+    let mut push_term = |term: &str| {
+        let normalized = normalize_for_index(term);
+        if normalized.is_empty() || !seen.insert(normalized.clone()) {
+            return;
+        }
+        terms.push(term.trim().to_string());
+    };
+
+    for entity in entities {
+        push_term(&entity.text);
+    }
+    for phrase in noun_phrases {
+        push_term(phrase);
+    }
+    for phrase in verb_phrases {
+        push_term(phrase);
+    }
+    if let Some(subject) = subject_hint {
+        push_term(subject);
+    }
+    if let Some(object) = object_hint {
+        push_term(object);
+    }
+
+    if terms.is_empty() {
+        original_query.to_string()
+    } else {
+        format!("{} {}", original_query.trim(), terms.join(" "))
+    }
+}
+
+fn dedup_spans(spans: Vec<QuerySpan>) -> Vec<QuerySpan> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for span in spans {
+        let key = format!("{:?}:{}", span.kind, span.normalized);
+        if span.normalized.is_empty() || !seen.insert(key) {
+            continue;
+        }
+        out.push(span);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_quantity_intent() {
+        assert_eq!(
+            quantity_intent("How many days did it take?"),
+            Some(AggregateIntent::Count)
+        );
+        assert_eq!(
+            quantity_intent("How much did it cost?"),
+            Some(AggregateIntent::Sum)
+        );
+    }
+
+    #[test]
+    fn extracts_temporal_phrase() {
+        let temporal = extract_temporal("What happened last Friday?");
+        assert!(temporal.is_some());
+        assert_eq!(temporal.unwrap().phrase.to_lowercase(), "last friday");
+    }
+
+    #[test]
+    fn classifies_query_routing_intent() {
+        let count = analyze_query("How many projects have I led?");
+        assert_eq!(count.query_routing_intent, Some(QueryRoutingIntent::Count));
+
+        let sum = analyze_query("How much did it cost in total?");
+        assert_eq!(sum.query_routing_intent, Some(QueryRoutingIntent::Sum));
+
+        let sequence = analyze_query("Which tasks happened in consecutive days?");
+        assert_eq!(
+            sequence.query_routing_intent,
+            Some(QueryRoutingIntent::Sequence)
+        );
+    }
+
+    #[test]
+    fn augments_query_with_terms() {
+        let aug = build_augmented_query(
+            "what happened",
+            &[QuerySpan {
+                kind: QuerySpanKind::Entity,
+                text: "Project Apollo".to_string(),
+                normalized: "project apollo".to_string(),
+                score: 1.0,
+                source: "test".to_string(),
+            }],
+            &["Project Apollo".to_string()],
+            &[],
+            Some("Project Apollo"),
+            None,
+        );
+        assert!(aug.contains("Project Apollo"));
+    }
+}

--- a/src/temporal_fact.rs
+++ b/src/temporal_fact.rs
@@ -275,11 +275,7 @@ impl TemporalFactStore {
         facts
     }
 
-    pub fn timeline_events_between(
-        &self,
-        start: &str,
-        end: &str,
-    ) -> Vec<TimelineEvent<'_>> {
+    pub fn timeline_events_between(&self, start: &str, end: &str) -> Vec<TimelineEvent<'_>> {
         let Some((start, end)) = normalize_range(start, end) else {
             return Vec::new();
         };
@@ -297,8 +293,16 @@ impl TemporalFactStore {
         events.sort_by(|a, b| {
             a.date
                 .cmp(&b.date)
-                .then_with(|| a.fact.normalized_subject().cmp(&b.fact.normalized_subject()))
-                .then_with(|| a.fact.normalized_predicate().cmp(&b.fact.normalized_predicate()))
+                .then_with(|| {
+                    a.fact
+                        .normalized_subject()
+                        .cmp(&b.fact.normalized_subject())
+                })
+                .then_with(|| {
+                    a.fact
+                        .normalized_predicate()
+                        .cmp(&b.fact.normalized_predicate())
+                })
                 .then_with(|| a.fact.source_doc_id.cmp(&b.fact.source_doc_id))
                 .then_with(|| a.fact.source_chunk_id.cmp(&b.fact.source_chunk_id))
         });
@@ -325,8 +329,16 @@ impl TemporalFactStore {
         events.sort_by(|a, b| {
             a.date
                 .cmp(&b.date)
-                .then_with(|| a.fact.normalized_subject().cmp(&b.fact.normalized_subject()))
-                .then_with(|| a.fact.normalized_predicate().cmp(&b.fact.normalized_predicate()))
+                .then_with(|| {
+                    a.fact
+                        .normalized_subject()
+                        .cmp(&b.fact.normalized_subject())
+                })
+                .then_with(|| {
+                    a.fact
+                        .normalized_predicate()
+                        .cmp(&b.fact.normalized_predicate())
+                })
                 .then_with(|| a.fact.source_doc_id.cmp(&b.fact.source_doc_id))
                 .then_with(|| a.fact.source_chunk_id.cmp(&b.fact.source_chunk_id))
         });
@@ -634,7 +646,8 @@ mod tests {
                 confidence: 0.8,
             }],
         );
-        let store = TemporalFactStore::from_records([&record1, &record2, &record3], &HashMap::new());
+        let store =
+            TemporalFactStore::from_records([&record1, &record2, &record3], &HashMap::new());
         let window = store.timeline_events_between("2024-01-01", "2024-01-03");
         assert_eq!(window.len(), 2);
         assert_eq!(window[0].fact.object.as_deref(), Some("Charity Walk"));
@@ -643,7 +656,10 @@ mod tests {
         let pairs = store.adjacent_pairs_between("2024-01-01", "2024-01-10", Some(2));
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].first.fact.object.as_deref(), Some("Charity Walk"));
-        assert_eq!(pairs[0].second.fact.object.as_deref(), Some("Charity Bike Ride"));
+        assert_eq!(
+            pairs[0].second.fact.object.as_deref(),
+            Some("Charity Bike Ride")
+        );
         assert_eq!(pairs[0].gap_days, 1);
     }
 }

--- a/src/tier1.rs
+++ b/src/tier1.rs
@@ -4,9 +4,13 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::OnceLock;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
+
+const SPACY_SUBPROCESS_TIMEOUT_SECS: u64 = 20;
 
 #[derive(Debug, Clone)]
 pub struct Tier1DocInput {
@@ -106,50 +110,46 @@ impl HeuristicKeyEntityRanker {
             );
         }
 
-        if let Ok(title_case_re) = Regex::new(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3})\b") {
-            for cap in title_case_re.captures_iter(&doc.content).take(80) {
-                let m = cap.get(1).expect("capture exists");
-                let text = m.as_str().trim();
-                if text.len() < 3 {
-                    continue;
-                }
-                let key = text.to_string();
-                let section_hits = section_bounds
-                    .iter()
-                    .filter(|(s, e)| m.start() >= *s && m.start() < *e)
-                    .count()
-                    .max(1);
-                let entry = candidates.entry(key).or_insert(Cand {
-                    start: m.start(),
-                    end: m.end(),
-                    mentions: 0,
-                    heading_hits: 0,
-                    section_hits: 0,
-                    first_pos: m.start(),
-                    label: "PROPN",
-                });
-                entry.mentions += 1;
-                entry.section_hits = entry.section_hits.max(section_hits);
-                entry.first_pos = entry.first_pos.min(m.start());
+        for cap in title_case_regex().captures_iter(&doc.content).take(80) {
+            let m = cap.get(1).expect("capture exists");
+            let text = m.as_str().trim();
+            if text.len() < 3 {
+                continue;
             }
+            let key = text.to_string();
+            let section_hits = section_bounds
+                .iter()
+                .filter(|(s, e)| m.start() >= *s && m.start() < *e)
+                .count()
+                .max(1);
+            let entry = candidates.entry(key).or_insert(Cand {
+                start: m.start(),
+                end: m.end(),
+                mentions: 0,
+                heading_hits: 0,
+                section_hits: 0,
+                first_pos: m.start(),
+                label: "PROPN",
+            });
+            entry.mentions += 1;
+            entry.section_hits = entry.section_hits.max(section_hits);
+            entry.first_pos = entry.first_pos.min(m.start());
         }
 
-        if let Ok(acronym_re) = Regex::new(r"\b([A-Z]{2,8})\b") {
-            for m in acronym_re.find_iter(&doc.content).take(50) {
-                let text = m.as_str();
-                let key = text.to_string();
-                let entry = candidates.entry(key).or_insert(Cand {
-                    start: m.start(),
-                    end: m.end(),
-                    mentions: 0,
-                    heading_hits: 0,
-                    section_hits: 1,
-                    first_pos: m.start(),
-                    label: "ACRONYM",
-                });
-                entry.mentions += 1;
-                entry.first_pos = entry.first_pos.min(m.start());
-            }
+        for m in acronym_regex().find_iter(&doc.content).take(50) {
+            let text = m.as_str();
+            let key = text.to_string();
+            let entry = candidates.entry(key).or_insert(Cand {
+                start: m.start(),
+                end: m.end(),
+                mentions: 0,
+                heading_hits: 0,
+                section_hits: 1,
+                first_pos: m.start(),
+                label: "ACRONYM",
+            });
+            entry.mentions += 1;
+            entry.first_pos = entry.first_pos.min(m.start());
         }
 
         for heading in &doc.headings {
@@ -224,6 +224,65 @@ pub struct SpacyKeyEntityRanker {
     pub script_path: String,
 }
 
+pub fn default_spacy_script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/spacy_ner.py")
+}
+
+pub fn detect_python_executable() -> String {
+    if let Ok(value) = std::env::var("PYTHON_EXECUTABLE") {
+        let value = value.trim();
+        if !value.is_empty() {
+            return value.to_string();
+        }
+    }
+    if let Ok(value) = std::env::var("PYTHON") {
+        let value = value.trim();
+        if !value.is_empty() {
+            return value.to_string();
+        }
+    }
+
+    if let Ok(venv) = std::env::var("VIRTUAL_ENV") {
+        let mut venv_path = PathBuf::from(venv);
+        if cfg!(windows) {
+            venv_path.push("Scripts");
+            venv_path.push("python.exe");
+        } else {
+            venv_path.push("bin");
+            venv_path.push("python3");
+            if !venv_path.exists() {
+                venv_path.pop();
+                venv_path.push("python");
+            }
+        }
+        if venv_path.exists() {
+            return venv_path.to_string_lossy().into_owned();
+        }
+    }
+
+    "python3".to_string()
+}
+
+fn title_case_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3})\b").expect("valid regex"))
+}
+
+fn acronym_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\b([A-Z]{2,8})\b").expect("valid regex"))
+}
+
+fn content_word_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"[A-Za-z][A-Za-z0-9_-]{2,}").expect("valid regex"))
+}
+
+fn rake_token_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"[A-Za-z][A-Za-z0-9_-]{1,}").expect("valid regex"))
+}
+
 #[derive(Serialize)]
 struct SpacyDocInput<'a> {
     id: &'a str,
@@ -271,7 +330,8 @@ impl KeyEntityRanker for SpacyKeyEntityRanker {
         };
         let input_json = serde_json::to_string(&payload)?;
 
-        let mut child = Command::new("python3")
+        let python_executable = detect_python_executable();
+        let mut child = Command::new(&python_executable)
             .arg("-I")
             .arg(&self.script_path)
             .stdin(Stdio::piped())
@@ -281,7 +341,7 @@ impl KeyEntityRanker for SpacyKeyEntityRanker {
         if let Some(stdin) = child.stdin.as_mut() {
             stdin.write_all(input_json.as_bytes())?;
         }
-        let timeout = Duration::from_secs(20);
+        let timeout = Duration::from_secs(SPACY_SUBPROCESS_TIMEOUT_SECS);
         let start = Instant::now();
         loop {
             if let Some(status) = child.try_wait()? {
@@ -343,8 +403,8 @@ fn default_stopwords() -> HashSet<&'static str> {
 }
 
 fn tokenize_words(content: &str) -> Vec<String> {
-    let re = Regex::new(r"[A-Za-z][A-Za-z0-9_-]{2,}").expect("valid regex");
-    re.find_iter(content)
+    content_word_regex()
+        .find_iter(content)
         .map(|m| m.as_str().to_lowercase())
         .collect()
 }
@@ -426,8 +486,7 @@ impl ImportantTermRanker for RakeStyleTermRanker {
 
     fn rank_terms(&self, doc: &Tier1DocInput) -> Vec<RankedTerm> {
         let stop = default_stopwords();
-        let token_re = Regex::new(r"[A-Za-z][A-Za-z0-9_-]{1,}").expect("valid regex");
-        let tokens: Vec<String> = token_re
+        let tokens: Vec<String> = rake_token_regex()
             .find_iter(&doc.content)
             .map(|m| m.as_str().to_lowercase())
             .collect();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,6 +8,11 @@ use lint_ai::tier1::{RankedTerm, Tier1Entity};
 use std::fs;
 use std::path::PathBuf;
 
+const MAX_BYTES: usize = 5_000_000;
+const MAX_FILES: usize = 50_000;
+const MAX_DEPTH: usize = 20;
+const MAX_TOTAL_BYTES: usize = 50_000_000;
+
 fn setup_fixture() -> PathBuf {
     let root = std::env::temp_dir().join(format!(
         "lint_ai_fixture_{}_{}",
@@ -62,7 +67,14 @@ Alpha Beta
 #[test]
 fn lint_reports_orphans_and_missing_links() {
     let root = setup_fixture();
-    let graph = Graph::build(root.to_str().unwrap(), 5_000_000, 50_000, 20, 50_000_000).unwrap();
+    let graph = Graph::build(
+        root.to_str().unwrap(),
+        MAX_BYTES,
+        MAX_FILES,
+        MAX_DEPTH,
+        MAX_TOTAL_BYTES,
+    )
+    .unwrap();
     let cfg = Config::default();
     let mut report = Report::new();
 
@@ -86,7 +98,14 @@ fn lint_reports_orphans_and_missing_links() {
 #[test]
 fn ignore_related_section_for_crossrefs() {
     let root = setup_fixture();
-    let graph = Graph::build(root.to_str().unwrap(), 5_000_000, 50_000, 20, 50_000_000).unwrap();
+    let graph = Graph::build(
+        root.to_str().unwrap(),
+        MAX_BYTES,
+        MAX_FILES,
+        MAX_DEPTH,
+        MAX_TOTAL_BYTES,
+    )
+    .unwrap();
     let mut cfg = Config::default();
     cfg.ignore_crossref_sections = vec!["related".to_string()];
     let mut report = Report::new();
@@ -100,7 +119,14 @@ fn ignore_related_section_for_crossrefs() {
 #[test]
 fn allowlist_limits_crossrefs() {
     let root = setup_fixture();
-    let graph = Graph::build(root.to_str().unwrap(), 5_000_000, 50_000, 20, 50_000_000).unwrap();
+    let graph = Graph::build(
+        root.to_str().unwrap(),
+        MAX_BYTES,
+        MAX_FILES,
+        MAX_DEPTH,
+        MAX_TOTAL_BYTES,
+    )
+    .unwrap();
     let mut cfg = Config::default();
     cfg.allowlist_concepts = vec!["gamma".to_string()];
     let mut report = Report::new();
@@ -114,7 +140,14 @@ fn allowlist_limits_crossrefs() {
 #[test]
 fn analyze_suggests_config() {
     let root = setup_fixture();
-    let graph = Graph::build(root.to_str().unwrap(), 5_000_000, 50_000, 20, 50_000_000).unwrap();
+    let graph = Graph::build(
+        root.to_str().unwrap(),
+        MAX_BYTES,
+        MAX_FILES,
+        MAX_DEPTH,
+        MAX_TOTAL_BYTES,
+    )
+    .unwrap();
     let cfg = Config::default();
 
     let output = lint_ai::engine::analyze_for_tests(&graph, &cfg);
@@ -138,6 +171,7 @@ fn query_baseline_still_works_without_semantic_match() {
         doc_type_guess: None,
         headings: vec!["Install".to_string()],
         doc_links: vec![],
+        temporal_terms: vec![],
         key_entities: vec![Tier1Entity {
             text: "docker".to_string(),
             label: "CONCEPT".to_string(),
@@ -182,6 +216,7 @@ fn semantic_expansion_improves_recall_for_synonyms() {
         doc_type_guess: None,
         headings: vec!["Occupation".to_string()],
         doc_links: vec![],
+        temporal_terms: vec![],
         key_entities: vec![],
         important_terms: vec![RankedTerm {
             term: "job".to_string(),


### PR DESCRIPTION
## Summary
  - Add query semantics with count/sum/sequence routing
  - Add heuristic query backend by default and optional rust-bert backend
  - Add evidence-aware retrieval and benchmark timing breakdowns
  - Add scoped LongMemEval benchmark runner and benchmark docs
  - Add ingestion adapters for markdown/code documents
  - Harden index persistence and spaCy script resolution
  - Refresh README, quickstart, Tier 1 docs, and release notes

  ## Verification
  - cargo fmt --all
  - cargo check -p lint-ai
  - cargo check -p lint-ai --no-default-features --features rust-bert-query-semantics
  - cargo test -p lint-ai --quiet
  - cargo test -p lint-ai --no-default-features --features rust-bert-query-semantics --quiet

  ## Note
  The LongMemEval raw dataset is intentionally not committed because it exceeds GitHub's 100 MB file limit.