### PR TITLE
Add semantic graph and review packet models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lint-ai"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Semantic wiki and docs linting for contradictions, stale claims, orphan pages, and missing cross-references"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # Lint-AI
 
-Lint-AI is for teams building agent memory over large, fast-changing corpora: assistant sessions, task notes, traces, reports, decisions, and documentation that accumulate faster than any team can review manually.
+Lint-AI is for teams building agent memory and semantic review over large, fast-changing corpora: assistant sessions, task notes, traces, reports, decisions, code, and documentation that accumulate faster than any team can review manually.
 
 It is a good fit for people who maintain:
 - long-running agent memory over conversations, notes, and decisions
 - markdown knowledge bases with lots of cross-links
 - internal docs where terminology drifts over time
+- codebases where symbols, ownership, usage, and review context matter
 - corpora where “what changed?” and “what is current?” matter as much as keyword search
 
-Use Lint-AI when plain search is not enough and memory recall needs evidence. It treats stored context as a network of facts, concepts, links, claims, and timestamps, then surfaces misalignment, missing context, and retrieval results suited for downstream review or LLM grounding.
+Use Lint-AI when plain search is not enough and memory recall needs evidence. It treats stored context as a network of facts, concepts, links, symbols, ownership facts, and timestamps, then surfaces misalignment, missing context, and retrieval results suited for downstream review or LLM grounding.
 
-The problem it solves is **system-level consistency**: reading individual documents is not enough when terminology drifts, definitions conflict, or outdated claims persist across a growing corpus. Lint-AI analyzes documentation collectively, not in isolation, to catch these issues before they spread.
+The problem it solves is **system-level consistency**: reading individual documents is not enough when terminology drifts, definitions conflict, ownership changes, or outdated claims persist across a growing corpus. Lint-AI analyzes corpora collectively, not in isolation, to catch these issues before they spread.
 
 Why people use it:
 - to recover the right past session or note when an agent needs context
 - to catch contradictions before they spread
 - to detect terminology drift across documents
 - to find orphaned or weakly linked pages
-- to ask corpus-level questions over facts, entities, and time
+- to ask corpus-level questions over facts, entities, symbols, and time
+- to build review packets from changed files and related semantic context
 - to feed grounded context into an LLM instead of raw text blobs
 
 ## Benchmark
@@ -93,7 +95,7 @@ See [docs/quickstart.md](docs/quickstart.md) for the shortest path to build, run
 
 ## How It Works
 
-Lint-AI ingests sessions, notes, traces, and documents, builds a lexical index plus sparse entity/term tables, and overlays graph structure for links and co-occurrence. Queries are analyzed for intent, entities, and temporal hints, then scored with a blend of lexical, semantic, claim, topic, timestamp, and graph signals. The same corpus analysis also powers misalignment checks such as missing cross-refs, orphan pages, and low-confidence claims.
+Lint-AI ingests sessions, notes, traces, documents, and code-oriented artifacts, builds a lexical index plus sparse entity/term tables, and overlays graph structure for links, symbols, ownership, and co-occurrence. Queries are analyzed for intent, entities, and temporal hints, then scored with a blend of lexical, semantic, claim, topic, timestamp, and graph signals. The same corpus analysis also powers misalignment checks such as missing cross-refs, orphan pages, low-confidence claims, and review-oriented packet generation.
 
 If you want the deeper implementation view, see:
 - `docs/chunk-strategy.md`
@@ -157,7 +159,7 @@ Common graph exports, chunking knobs, lexical subset regeneration, and artifact 
 
 ### Rust Library
 
-Use `IndexStore` when you want mutable ingestion, `MemoryIndex` when you want an immutable query snapshot, and `SourceDocument` to add content.
+Use `IndexStore` when you want mutable ingestion, `MemoryIndex` when you want an immutable query snapshot, and `SourceDocument` to add content. For the broader semantic graph, use `CorpusGraph`, `SymbolStore`, `UsageGraph`, and the review model types that are re-exported from the crate root.
 
 ```rust
 use lint_ai::{IndexStore, PipelineOptions, SourceDocument};
@@ -194,6 +196,14 @@ let index = IndexStore::for_corpus(Path::new("/path/to/corpus"), PipelineOptions
 ```
 
 If you already have prepared `DocRecord` values and want the built search structure directly, use `lint_ai::index::MemoryIndex`.
+
+For symbol and review workflows, the crate root also re-exports:
+
+- `CorpusGraph` for querying documents, symbols, and usage together
+- `SymbolRecord` / `SymbolStore` for symbol indexing
+- `OwnershipRecord` / `OwnershipSummary` for ownership facts and summaries
+- `UsageGraph` / `UsageEdge` / `UsageNode` for symbol and ownership relationship tracing
+- `ReviewPacket` / `ReviewFinding` / `ReviewDiff` for structured review output
 
 ## Advanced
 

--- a/docs/releases/0.1.7.md
+++ b/docs/releases/0.1.7.md
@@ -1,0 +1,68 @@
+# Release Notes: v0.1.7
+
+Date: 2026-05-29
+
+This release expands the core `lint-ai` model beyond document indexing and
+retrieval into a more general semantic graph for code-oriented workflows. It
+adds shared symbol, ownership, usage, and review packet structures that can be
+consumed by language adapters and higher-level review tools. The existing
+`SourceDocument` schema remains unchanged in this release.
+
+## Highlights
+
+- Bumped crate version from `0.1.6` to `0.1.7`.
+- Added a generic `SymbolRecord` / `SymbolStore` layer for symbol indexing.
+- Added a generic `OwnershipRecord` model for allocation, release, transfer,
+  and borrow facts.
+- Added a generic `UsageGraph` layer for connecting documents, symbols, and
+  ownership edges.
+- Added a `CorpusGraph` wrapper so document, symbol, and usage state can be
+  queried together.
+- Added generic review packet and review finding models for AI-assisted code
+  review workflows.
+
+## Semantic Graph Layers
+
+The main architectural change in this release is the addition of shared
+semantic layers alongside the existing document model:
+
+- `SourceDocument`
+  - the existing raw artifact record
+  - unchanged in this release
+  - still suitable for Markdown, code, and other source types
+- `SymbolRecord`
+  - language-agnostic symbol metadata
+  - supports declarations, references, uses, calls, imports, and inheritance
+- `OwnershipRecord`
+  - language-agnostic lifetime and ownership facts
+  - supports allocations, releases, transfers, borrows, aliases, and escapes
+- `UsageGraph`
+  - stores nodes and edges for symbol and ownership relationships
+  - supports symbol-centric and document-centric queries
+- `CorpusGraph`
+  - bundles document, symbol, and usage state into one queryable view
+
+## Review Model
+
+This release also adds the shared data model needed for AI review packets.
+
+### Review packet data
+
+- file-centric summaries
+- symbol summaries
+- ownership summaries
+- usage summaries
+- review findings and recommendations
+
+### Review intent
+
+- represent changed files as a compact review packet
+- keep the packet structured but queryable
+- let higher-level tooling decide how to surface and rank findings
+
+## Why This Matters
+
+`lint-ai` is now more than a Markdown/document index. It provides the shared
+semantic layer needed for multi-language symbol search, ownership reasoning,
+usage tracing, and review-oriented packet generation, while keeping the
+`SourceDocument` schema stable.

--- a/src/corpus_graph.rs
+++ b/src/corpus_graph.rs
@@ -1,0 +1,87 @@
+use crate::index::MemoryIndex;
+use crate::ownership::OwnershipRecord;
+use crate::pipeline::{build_query_snapshot, PipelineOptions};
+use crate::symbols::{IngestBundle, SymbolRecord, SymbolStore};
+use crate::usage::{UsageGraph, UsageSummary};
+use anyhow::Result;
+
+pub struct CorpusGraph {
+    pub documents: MemoryIndex,
+    pub symbols: SymbolStore,
+    pub usage: UsageGraph,
+}
+
+impl CorpusGraph {
+    pub fn new(documents: MemoryIndex, symbols: SymbolStore, usage: UsageGraph) -> Self {
+        Self {
+            documents,
+            symbols,
+            usage,
+        }
+    }
+
+    pub fn from_bundle(bundle: IngestBundle, options: &PipelineOptions) -> Result<Self> {
+        let IngestBundle { documents: source_documents, symbols } = bundle;
+        let documents = build_query_snapshot(&source_documents, options)?;
+        let usage_bundle = IngestBundle::new(source_documents, symbols.clone());
+        let symbols = SymbolStore::from_records(symbols);
+        let usage = UsageGraph::from_bundle(&usage_bundle);
+        Ok(Self {
+            documents,
+            symbols,
+            usage,
+        })
+    }
+
+    pub fn with_ownership(mut self, records: impl IntoIterator<Item = OwnershipRecord>) -> Self {
+        self.usage.ingest_ownership(records);
+        self
+    }
+
+    pub fn symbol_usage_summary(&self, symbol_id: &str) -> UsageSummary {
+        self.usage.summary_for_symbol(symbol_id)
+    }
+
+    pub fn symbols_for_doc(&self, doc_id: &str) -> Vec<&SymbolRecord> {
+        self.symbols.lookup_by_doc(doc_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::SourceDocument;
+
+    #[test]
+    fn from_bundle_builds_documents_symbols_and_usage() {
+        let document = SourceDocument {
+            doc_id: "doc-1".to_string(),
+            source: "docs/install.md".to_string(),
+            content: "install guide for linux hosts".to_string(),
+            concept: "install guide".to_string(),
+            group_id: None,
+            headings: vec!["Overview".to_string()],
+            links: vec![],
+            timestamp: None,
+            doc_length: "install guide for linux hosts".len(),
+            author_agent: None,
+        };
+        let symbol = SymbolRecord::declared(
+            "doc-1",
+            "install",
+            crate::symbols::SymbolKind::Function,
+            Some("cpp".to_string()),
+        );
+        let bundle = IngestBundle::new(vec![document], vec![symbol.clone()]);
+
+        let graph = CorpusGraph::from_bundle(bundle, &PipelineOptions::default()).unwrap();
+
+        assert_eq!(graph.symbols_for_doc("doc-1").len(), 1);
+        let summary = graph.symbol_usage_summary(&symbol.symbol_id);
+        assert_eq!(summary.edge_count, 1);
+        assert_eq!(
+            summary.edge_counts.get(&crate::usage::UsageEdgeKind::Declares).copied(),
+            Some(1)
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
-//! Lint AI — semantic linting for Markdown documentation.
+//! Lint AI — semantic linting for Markdown documentation and related semantic graphs.
 //!
 //! This crate provides the core pipeline for building a concept inventory from
-//! a Markdown corpus, matching mentions, and reporting missing cross-references
-//! and orphan/unreachable pages.
+//! a Markdown corpus, matching mentions, building symbol and ownership graphs,
+//! and reporting missing cross-references and orphan/unreachable pages.
 //!
 //! Basic usage:
 //! ```no_run
@@ -23,31 +23,50 @@ pub mod aggregation;
 pub mod chunking;
 pub mod claim_extractor;
 pub mod cli;
+pub mod corpus_graph;
 pub mod config;
 pub mod engine;
 pub mod filters;
 pub mod graph;
 pub mod ids;
 pub mod index;
+pub mod ownership;
 pub mod pipeline;
 pub mod query_expansion;
 pub mod query_semantics;
 pub mod report;
+pub mod review;
 pub mod rules;
 pub mod source;
+pub mod symbols;
 pub mod temporal;
 pub mod temporal_fact;
 pub mod tier1;
+pub mod usage;
 
 pub use crate::claim_extractor::{ClaimExtractor, ConservativeClaimExtractor, ExtractedClaims};
+pub use crate::corpus_graph::CorpusGraph;
 pub use crate::ids::{stable_chunk_id, stable_doc_id_from_source};
 pub use crate::index::{
     MemoryIndex, QueryDiagnostics, QueryTimings, SearchResult, TemporalQueryContext,
+};
+pub use crate::ownership::{
+    FlowEdge, FlowEdgeKind, FlowState, LeakFinding, OwnershipKind, OwnershipRecord,
 };
 pub use crate::pipeline::{
     build_index_store, build_query_snapshot, build_query_snapshot_from_source_documents,
     resolve_store_paths, ChunkStrategy, IndexLocation, IndexStore, PipelineOptions, StorePaths,
     Tier1NerProvider, Tier1TermRankerKind,
 };
+pub use crate::review::{
+    DocumentSummary, OwnershipSummary, ReviewCategory, ReviewContext, ReviewDiff,
+    ReviewDiffSummary, ReviewEvidence, ReviewFileChange, ReviewFinding, ReviewHunk, ReviewPacket,
+    ReviewRepoRef, ReviewSeverity, ReviewUsageSummary, SymbolSummary,
+};
 pub use crate::source::SourceDocument;
+pub use crate::symbols::{
+    CorpusIndex, IngestBundle, SymbolKind, SymbolLocation, SymbolRecord, SymbolRelationKind,
+    SymbolStore,
+};
 pub use crate::temporal_fact::{TemporalFact, TemporalFactStore, TimelineEvent, TimelinePair};
+pub use crate::usage::{UsageEdge, UsageEdgeKind, UsageGraph, UsageNode, UsageNodeKind};

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -1,0 +1,81 @@
+use crate::symbols::SymbolLocation;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum OwnershipKind {
+    Allocates,
+    Releases,
+    Transfers,
+    Borrows,
+    Aliases,
+    Managed,
+    Escapes,
+    Invalidates,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum FlowState {
+    Unknown,
+    Owned,
+    Borrowed,
+    Shared,
+    Escaped,
+    Released,
+    Dangling,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum FlowEdgeKind {
+    Allocates,
+    Transfers,
+    Borrows,
+    Aliases,
+    Releases,
+    Escapes,
+    Invalidates,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FlowEdge {
+    pub from: String,
+    pub to: String,
+    pub kind: FlowEdgeKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OwnershipRecord {
+    pub fact_id: String,
+    pub doc_id: String,
+    #[serde(default)]
+    pub symbol_id: Option<String>,
+    pub kind: OwnershipKind,
+    #[serde(default)]
+    pub source: String,
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub location: Option<SymbolLocation>,
+    #[serde(default)]
+    pub confidence: f32,
+    #[serde(default)]
+    pub state: Option<FlowState>,
+    #[serde(default)]
+    pub attributes: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LeakFinding {
+    pub doc_id: String,
+    #[serde(default)]
+    pub target: Option<String>,
+    pub allocation_fact_id: String,
+    #[serde(default)]
+    pub release_fact_ids: Vec<String>,
+    #[serde(default)]
+    pub location: Option<SymbolLocation>,
+    #[serde(default)]
+    pub confidence: f32,
+    pub summary: String,
+}

--- a/src/review.rs
+++ b/src/review.rs
@@ -1,0 +1,436 @@
+use crate::ownership::OwnershipRecord;
+use crate::source::SourceDocument;
+use crate::symbols::{SymbolLocation, SymbolRecord};
+use crate::usage::{UsageEdge, UsageGraph};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ReviewSeverity {
+    Info,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ReviewCategory {
+    Ownership,
+    ApiMisuse,
+    UsageRegression,
+    DeadCode,
+    MissingReference,
+    RippleEffect,
+    BehaviorChange,
+    StyleOrNaming,
+    Other(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewRepoRef {
+    pub name: String,
+    #[serde(default)]
+    pub base_ref: Option<String>,
+    #[serde(default)]
+    pub head_ref: Option<String>,
+    #[serde(default)]
+    pub commit_sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewHunk {
+    pub hunk_id: String,
+    pub path: String,
+    #[serde(default)]
+    pub old_start: Option<usize>,
+    #[serde(default)]
+    pub old_end: Option<usize>,
+    #[serde(default)]
+    pub new_start: Option<usize>,
+    #[serde(default)]
+    pub new_end: Option<usize>,
+    #[serde(default)]
+    pub added_lines: Vec<String>,
+    #[serde(default)]
+    pub removed_lines: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewFileChange {
+    pub path: String,
+    pub status: String,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub hunks: Vec<ReviewHunk>,
+    #[serde(default)]
+    pub changed_symbols: Vec<String>,
+    #[serde(default)]
+    pub symbol_ids: Vec<String>,
+    #[serde(default)]
+    pub ownership_fact_ids: Vec<String>,
+    #[serde(default)]
+    pub usage_edge_kinds: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewFileSummary {
+    pub path: String,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewSummary {
+    pub files_changed: usize,
+    pub lines_added: usize,
+    pub lines_removed: usize,
+    pub symbols_touched: usize,
+    #[serde(default)]
+    pub files: Vec<ReviewFileSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewDiffSummary {
+    pub files_changed: usize,
+    pub lines_added: usize,
+    pub lines_removed: usize,
+    pub symbols_touched: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DocumentSummary {
+    pub doc_id: String,
+    pub source: String,
+    pub concept: String,
+    #[serde(default)]
+    pub headings: Vec<String>,
+    #[serde(default)]
+    pub links: Vec<String>,
+    pub doc_length: usize,
+}
+
+impl From<&SourceDocument> for DocumentSummary {
+    fn from(value: &SourceDocument) -> Self {
+        Self {
+            doc_id: value.doc_id.clone(),
+            source: value.source.clone(),
+            concept: value.concept.clone(),
+            headings: value.headings.clone(),
+            links: value.links.clone(),
+            doc_length: value.doc_length,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SymbolSummary {
+    pub symbol_id: String,
+    pub doc_id: String,
+    pub name: String,
+    pub kind: String,
+    pub relation: String,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub container: Option<String>,
+    #[serde(default)]
+    pub location: Option<SymbolLocation>,
+    #[serde(default)]
+    pub signature: Option<String>,
+}
+
+impl From<&SymbolRecord> for SymbolSummary {
+    fn from(value: &SymbolRecord) -> Self {
+        Self {
+            symbol_id: value.symbol_id.clone(),
+            doc_id: value.doc_id.clone(),
+            name: value.name.clone(),
+            kind: format!("{:?}", value.kind),
+            relation: format!("{:?}", value.relation),
+            language: value.language.clone(),
+            container: value.container.clone(),
+            location: value.location.clone(),
+            signature: value.signature.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OwnershipSummary {
+    pub fact_id: String,
+    pub doc_id: String,
+    #[serde(default)]
+    pub symbol_id: Option<String>,
+    pub kind: String,
+    #[serde(default)]
+    pub source: String,
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub location: Option<SymbolLocation>,
+    #[serde(default)]
+    pub confidence: f32,
+}
+
+impl From<&OwnershipRecord> for OwnershipSummary {
+    fn from(value: &OwnershipRecord) -> Self {
+        Self {
+            fact_id: value.fact_id.clone(),
+            doc_id: value.doc_id.clone(),
+            symbol_id: value.symbol_id.clone(),
+            kind: format!("{:?}", value.kind),
+            source: value.source.clone(),
+            target: value.target.clone(),
+            location: value.location.clone(),
+            confidence: value.confidence,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewUsageNodeSummary {
+    #[serde(default)]
+    pub node_id: Option<String>,
+    pub kind: crate::usage::UsageNodeKind,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub doc_id: Option<String>,
+    #[serde(default)]
+    pub symbol_id: Option<String>,
+    #[serde(default)]
+    pub location: Option<SymbolLocation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewUsageSummary {
+    #[serde(default)]
+    pub nodes: Vec<ReviewUsageNodeSummary>,
+    #[serde(default)]
+    pub edges: Vec<UsageEdge>,
+}
+
+impl From<&UsageGraph> for ReviewUsageSummary {
+    fn from(value: &UsageGraph) -> Self {
+        Self {
+            nodes: value
+                .nodes
+                .iter()
+                .map(|node| ReviewUsageNodeSummary {
+                    node_id: Some(node.node_id.clone()),
+                    kind: node.kind,
+                    label: node.label.clone(),
+                    doc_id: node.doc_id.clone(),
+                    symbol_id: node.symbol_id.clone(),
+                    location: node.location.clone(),
+                })
+                .collect(),
+            edges: value.edges.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewEvidence {
+    #[serde(default)]
+    pub doc_id: Option<String>,
+    #[serde(default)]
+    pub symbol_id: Option<String>,
+    #[serde(default)]
+    pub location: Option<SymbolLocation>,
+    #[serde(default)]
+    pub snippet: Option<String>,
+    pub kind: String,
+    #[serde(default)]
+    pub attributes: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewFinding {
+    pub finding_id: String,
+    pub severity: ReviewSeverity,
+    pub category: ReviewCategory,
+    pub summary: String,
+    pub rationale: String,
+    pub confidence: f32,
+    #[serde(default)]
+    pub evidence: Vec<ReviewEvidence>,
+    #[serde(default)]
+    pub recommendation: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewContext {
+    #[serde(default)]
+    pub documents: Vec<DocumentSummary>,
+    #[serde(default)]
+    pub symbols: Vec<SymbolSummary>,
+    #[serde(default)]
+    pub ownership: Vec<OwnershipSummary>,
+    #[serde(default)]
+    pub usage: Option<ReviewUsageSummary>,
+    #[serde(default)]
+    pub source_spans: Vec<ReviewEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewPacket {
+    pub review_id: String,
+    pub repo: ReviewRepoRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ReviewSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<ReviewDiff>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<ReviewContext>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<ReviewFinding>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub instructions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewDiff {
+    pub summary: ReviewDiffSummary,
+    #[serde(default)]
+    pub files: Vec<ReviewFileChange>,
+}
+
+impl ReviewPacket {
+    pub fn new(
+        review_id: impl Into<String>,
+        repo: ReviewRepoRef,
+        summary: Option<ReviewSummary>,
+        diff: Option<ReviewDiff>,
+        context: Option<ReviewContext>,
+    ) -> Self {
+        Self {
+            review_id: review_id.into(),
+            repo,
+            summary,
+            diff,
+            context,
+            findings: Vec::new(),
+            instructions: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::usage::{UsageEdgeKind, UsageNode, UsageNodeKind};
+
+    #[test]
+    fn summary_conversions_preserve_source_fields() {
+        let doc = SourceDocument {
+            doc_id: "doc-1".to_string(),
+            source: "docs/install.md".to_string(),
+            content: "install guide".to_string(),
+            concept: "install guide".to_string(),
+            group_id: None,
+            headings: vec!["Overview".to_string()],
+            links: vec!["docs/setup.md".to_string()],
+            timestamp: None,
+            doc_length: 13,
+            author_agent: None,
+        };
+        let symbol = SymbolRecord::declared(
+            "doc-1",
+            "install",
+            crate::symbols::SymbolKind::Function,
+            Some("cpp".to_string()),
+        );
+        let ownership = OwnershipRecord {
+            fact_id: "fact-1".to_string(),
+            doc_id: "doc-1".to_string(),
+            symbol_id: Some(symbol.symbol_id.clone()),
+            kind: crate::ownership::OwnershipKind::Allocates,
+            source: "allocate()".to_string(),
+            target: Some("buffer".to_string()),
+            location: None,
+            confidence: 0.95,
+            state: None,
+            attributes: HashMap::new(),
+        };
+
+        let doc_summary = DocumentSummary::from(&doc);
+        assert_eq!(doc_summary.doc_id, doc.doc_id);
+        assert_eq!(doc_summary.source, doc.source);
+        assert_eq!(doc_summary.links, doc.links);
+
+        let symbol_summary = SymbolSummary::from(&symbol);
+        assert_eq!(symbol_summary.symbol_id, symbol.symbol_id);
+        assert_eq!(symbol_summary.kind, "Function");
+        assert_eq!(symbol_summary.relation, "Declares");
+
+        let ownership_summary = OwnershipSummary::from(&ownership);
+        assert_eq!(ownership_summary.fact_id, ownership.fact_id);
+        assert_eq!(ownership_summary.symbol_id, ownership.symbol_id);
+        assert_eq!(ownership_summary.kind, "Allocates");
+    }
+
+    #[test]
+    fn review_usage_summary_copies_nodes_and_edges() {
+        let mut graph = UsageGraph::new();
+        graph.insert_node(UsageNode {
+            node_id: "symbol:a".to_string(),
+            kind: UsageNodeKind::Symbol,
+            label: Some("Alpha".to_string()),
+            doc_id: Some("doc-1".to_string()),
+            symbol_id: Some("sym-a".to_string()),
+            location: None,
+        });
+        graph.insert_node(UsageNode {
+            node_id: "symbol:b".to_string(),
+            kind: UsageNodeKind::Symbol,
+            label: Some("Beta".to_string()),
+            doc_id: Some("doc-2".to_string()),
+            symbol_id: Some("sym-b".to_string()),
+            location: None,
+        });
+        graph.insert_edge(UsageEdge {
+            from: "symbol:a".to_string(),
+            to: "symbol:b".to_string(),
+            kind: UsageEdgeKind::Calls,
+            doc_id: Some("doc-1".to_string()),
+            symbol_id: Some("sym-a".to_string()),
+            location: None,
+            confidence: 1.0,
+            attributes: HashMap::new(),
+        });
+
+        let summary = ReviewUsageSummary::from(&graph);
+        assert_eq!(summary.nodes.len(), 2);
+        assert_eq!(summary.edges.len(), 1);
+        assert_eq!(summary.nodes[0].node_id.as_deref(), Some("symbol:a"));
+        assert_eq!(summary.edges[0].kind, UsageEdgeKind::Calls);
+    }
+
+    #[test]
+    fn review_packet_new_initializes_empty_lists() {
+        let packet = ReviewPacket::new(
+            "review-1",
+            ReviewRepoRef {
+                name: "owner/repo".to_string(),
+                base_ref: Some("main".to_string()),
+                head_ref: Some("feature".to_string()),
+                commit_sha: Some("abc123".to_string()),
+            },
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(packet.review_id, "review-1");
+        assert!(packet.summary.is_none());
+        assert!(packet.diff.is_none());
+        assert!(packet.context.is_none());
+        assert!(packet.findings.is_empty());
+        assert!(packet.instructions.is_empty());
+    }
+}

--- a/src/source.rs
+++ b/src/source.rs
@@ -46,3 +46,85 @@ impl SourceDocument {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_stable_doc_id_sets_doc_length_from_content() {
+        let doc = SourceDocument::with_stable_doc_id_from_source(
+            "docs/install.md".to_string(),
+            "install guide for linux hosts".to_string(),
+            "install guide".to_string(),
+            None,
+            vec!["Overview".to_string()],
+            vec!["docs/setup.md".to_string()],
+            Some("2026-05-29".to_string()),
+            Some("agent".to_string()),
+        );
+
+        assert_eq!(doc.doc_length, "install guide for linux hosts".len());
+        assert_eq!(doc.source, "docs/install.md");
+        assert_eq!(doc.concept, "install guide");
+        assert_eq!(doc.headings, vec!["Overview".to_string()]);
+        assert_eq!(doc.links, vec!["docs/setup.md".to_string()]);
+        assert_eq!(doc.author_agent.as_deref(), Some("agent"));
+        assert_eq!(doc.timestamp.as_deref(), Some("2026-05-29"));
+        assert!(!doc.doc_id.is_empty());
+    }
+
+    #[test]
+    fn with_stable_doc_id_is_deterministic_for_same_source() {
+        let first = SourceDocument::with_stable_doc_id_from_source(
+            "docs/install.md".to_string(),
+            "content one".to_string(),
+            "install guide".to_string(),
+            None,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
+        let second = SourceDocument::with_stable_doc_id_from_source(
+            "docs/install.md".to_string(),
+            "different content".to_string(),
+            "install guide".to_string(),
+            None,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
+
+        assert_eq!(first.doc_id, second.doc_id);
+    }
+
+    #[test]
+    fn source_document_round_trips_through_json() {
+        let doc = SourceDocument::with_stable_doc_id_from_source(
+            "docs/install.md".to_string(),
+            "install guide for linux hosts".to_string(),
+            "install guide".to_string(),
+            Some("group-1".to_string()),
+            vec!["Overview".to_string()],
+            vec!["docs/setup.md".to_string()],
+            Some("2026-05-29".to_string()),
+            Some("agent".to_string()),
+        );
+
+        let json = serde_json::to_string(&doc).unwrap();
+        let decoded: SourceDocument = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.doc_id, doc.doc_id);
+        assert_eq!(decoded.source, doc.source);
+        assert_eq!(decoded.content, doc.content);
+        assert_eq!(decoded.concept, doc.concept);
+        assert_eq!(decoded.group_id, doc.group_id);
+        assert_eq!(decoded.headings, doc.headings);
+        assert_eq!(decoded.links, doc.links);
+        assert_eq!(decoded.timestamp, doc.timestamp);
+        assert_eq!(decoded.doc_length, doc.doc_length);
+        assert_eq!(decoded.author_agent, doc.author_agent);
+    }
+}

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,0 +1,399 @@
+use crate::index::MemoryIndex;
+use crate::pipeline::{build_query_snapshot, PipelineOptions};
+use crate::query_expansion::normalize_for_index;
+use crate::source::SourceDocument;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum SymbolKind {
+    Namespace,
+    Type,
+    Class,
+    Struct,
+    Enum,
+    Function,
+    Method,
+    Field,
+    Variable,
+    Module,
+    File,
+    Other(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum SymbolRelationKind {
+    Declares,
+    References,
+    Defines,
+    Uses,
+    Imports,
+    Inherits,
+    Calls,
+    Contains,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SymbolLocation {
+    pub source: String,
+    #[serde(default)]
+    pub start_line: Option<usize>,
+    #[serde(default)]
+    pub end_line: Option<usize>,
+    #[serde(default)]
+    pub start_byte: Option<usize>,
+    #[serde(default)]
+    pub end_byte: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SymbolRecord {
+    pub symbol_id: String,
+    pub doc_id: String,
+    pub name: String,
+    pub kind: SymbolKind,
+    pub relation: SymbolRelationKind,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub container: Option<String>,
+    #[serde(default)]
+    pub location: Option<SymbolLocation>,
+    #[serde(default)]
+    pub signature: Option<String>,
+    #[serde(default)]
+    pub modifiers: Vec<String>,
+    #[serde(default)]
+    pub scope_path: Vec<String>,
+    #[serde(default)]
+    pub targets: Vec<String>,
+    #[serde(default)]
+    pub attributes: HashMap<String, Value>,
+}
+
+impl SymbolRecord {
+    pub fn new(
+        symbol_id: impl Into<String>,
+        doc_id: impl Into<String>,
+        name: impl Into<String>,
+        kind: SymbolKind,
+        relation: SymbolRelationKind,
+    ) -> Self {
+        Self {
+            symbol_id: symbol_id.into(),
+            doc_id: doc_id.into(),
+            name: name.into(),
+            kind,
+            relation,
+            language: None,
+            container: None,
+            location: None,
+            signature: None,
+            modifiers: Vec::new(),
+            scope_path: Vec::new(),
+            targets: Vec::new(),
+            attributes: HashMap::new(),
+        }
+    }
+
+    pub fn declared(
+        doc_id: impl Into<String>,
+        name: impl Into<String>,
+        kind: SymbolKind,
+        language: Option<String>,
+    ) -> Self {
+        let doc_id = doc_id.into();
+        let name = name.into();
+        let symbol_id = symbol_id_for(&doc_id, &name, &kind, &SymbolRelationKind::Declares);
+        Self {
+            language,
+            ..Self::new(symbol_id, doc_id, name, kind, SymbolRelationKind::Declares)
+        }
+    }
+
+    pub fn referenced(
+        doc_id: impl Into<String>,
+        name: impl Into<String>,
+        kind: SymbolKind,
+        language: Option<String>,
+    ) -> Self {
+        let doc_id = doc_id.into();
+        let name = name.into();
+        let symbol_id = symbol_id_for(&doc_id, &name, &kind, &SymbolRelationKind::References);
+        Self {
+            language,
+            ..Self::new(
+                symbol_id,
+                doc_id,
+                name,
+                kind,
+                SymbolRelationKind::References,
+            )
+        }
+    }
+
+    pub fn with_attribute(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.attributes.insert(key.into(), value);
+        self
+    }
+}
+
+fn symbol_id_for(
+    doc_id: &str,
+    name: &str,
+    kind: &SymbolKind,
+    relation: &SymbolRelationKind,
+) -> String {
+    format!("{doc_id}::{name}::{kind:?}::{relation:?}")
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SymbolStore {
+    pub records: Vec<SymbolRecord>,
+    #[serde(default)]
+    pub by_name: HashMap<String, Vec<usize>>,
+    #[serde(default)]
+    pub by_normalized_name: HashMap<String, Vec<usize>>,
+    #[serde(default)]
+    pub by_doc: HashMap<String, Vec<usize>>,
+    #[serde(default)]
+    pub by_kind: HashMap<SymbolKind, Vec<usize>>,
+    #[serde(default)]
+    pub by_relation: HashMap<SymbolRelationKind, Vec<usize>>,
+}
+
+impl SymbolStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from_records(records: impl IntoIterator<Item = SymbolRecord>) -> Self {
+        let mut store = Self::new();
+        store.extend(records);
+        store
+    }
+
+    pub fn extend(&mut self, records: impl IntoIterator<Item = SymbolRecord>) {
+        for record in records {
+            self.insert(record);
+        }
+    }
+
+    pub fn insert(&mut self, record: SymbolRecord) {
+        let index = self.records.len();
+        let exact_name = record.name.clone();
+        let normalized_name = normalize_for_index(&exact_name);
+        let doc_id = record.doc_id.clone();
+        let kind = record.kind.clone();
+        let relation = record.relation.clone();
+
+        self.records.push(record);
+        self.by_name.entry(exact_name).or_default().push(index);
+        if !normalized_name.is_empty() {
+            self.by_normalized_name
+                .entry(normalized_name)
+                .or_default()
+                .push(index);
+        }
+        self.by_doc.entry(doc_id).or_default().push(index);
+        self.by_kind.entry(kind).or_default().push(index);
+        self.by_relation.entry(relation).or_default().push(index);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    pub fn lookup_by_name<'a>(&'a self, name: &str) -> Vec<&'a SymbolRecord> {
+        let mut seen = HashSet::new();
+        let mut out = Vec::new();
+        self.append_matches(name, &mut seen, &mut out);
+        let normalized = normalize_for_index(name);
+        if normalized != name {
+            self.append_normalized_matches(&normalized, &mut seen, &mut out);
+        }
+        out
+    }
+
+    pub fn lookup_by_doc<'a>(&'a self, doc_id: &str) -> Vec<&'a SymbolRecord> {
+        self.lookup_indices(self.by_doc.get(doc_id))
+    }
+
+    pub fn lookup_by_kind<'a>(&'a self, kind: &SymbolKind) -> Vec<&'a SymbolRecord> {
+        self.lookup_indices(self.by_kind.get(kind))
+    }
+
+    pub fn lookup_by_relation<'a>(
+        &'a self,
+        relation: &SymbolRelationKind,
+    ) -> Vec<&'a SymbolRecord> {
+        self.lookup_indices(self.by_relation.get(relation))
+    }
+
+    pub fn lookup_by_attribute<'a>(&'a self, key: &str, value: &Value) -> Vec<&'a SymbolRecord> {
+        let mut seen = HashSet::new();
+        let mut out = Vec::new();
+        for (idx, record) in self.records.iter().enumerate() {
+            if record.attributes.get(key) == Some(value) && seen.insert(idx) {
+                out.push(record);
+            }
+        }
+        out
+    }
+
+    fn append_matches<'a>(
+        &'a self,
+        name: &str,
+        seen: &mut HashSet<usize>,
+        out: &mut Vec<&'a SymbolRecord>,
+    ) {
+        if let Some(indices) = self.by_name.get(name) {
+            self.append_indices(indices, seen, out);
+        }
+    }
+
+    fn append_normalized_matches<'a>(
+        &'a self,
+        name: &str,
+        seen: &mut HashSet<usize>,
+        out: &mut Vec<&'a SymbolRecord>,
+    ) {
+        if let Some(indices) = self.by_normalized_name.get(name) {
+            self.append_indices(indices, seen, out);
+        }
+    }
+
+    fn lookup_indices<'a>(&'a self, indices: Option<&Vec<usize>>) -> Vec<&'a SymbolRecord> {
+        let mut seen = HashSet::new();
+        let mut out = Vec::new();
+        if let Some(indices) = indices {
+            self.append_indices(indices, &mut seen, &mut out);
+        }
+        out
+    }
+
+    fn append_indices<'a>(
+        &'a self,
+        indices: &[usize],
+        seen: &mut HashSet<usize>,
+        out: &mut Vec<&'a SymbolRecord>,
+    ) {
+        for &index in indices {
+            if seen.insert(index) {
+                if let Some(record) = self.records.get(index) {
+                    out.push(record);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct IngestBundle {
+    pub documents: Vec<SourceDocument>,
+    pub symbols: Vec<SymbolRecord>,
+}
+
+impl IngestBundle {
+    pub fn new(documents: Vec<SourceDocument>, symbols: Vec<SymbolRecord>) -> Self {
+        Self { documents, symbols }
+    }
+}
+
+pub struct CorpusIndex {
+    pub documents: MemoryIndex,
+    pub symbols: SymbolStore,
+}
+
+impl CorpusIndex {
+    pub fn new(documents: MemoryIndex, symbols: SymbolStore) -> Self {
+        Self { documents, symbols }
+    }
+
+    pub fn from_bundle(bundle: IngestBundle, options: &PipelineOptions) -> Result<Self> {
+        let documents = build_query_snapshot(&bundle.documents, options)?;
+        let symbols = SymbolStore::from_records(bundle.symbols);
+        Ok(Self { documents, symbols })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_source_document() -> SourceDocument {
+        SourceDocument {
+            doc_id: "doc-1".to_string(),
+            source: "docs/install.md".to_string(),
+            content: "install guide for linux hosts".to_string(),
+            concept: "install guide".to_string(),
+            group_id: None,
+            headings: vec!["Overview".to_string()],
+            links: vec![],
+            timestamp: None,
+            doc_length: "install guide for linux hosts".len(),
+            author_agent: None,
+        }
+    }
+
+    #[test]
+    fn lookup_by_name_matches_exact_and_normalized_forms() {
+        let exact = SymbolRecord::declared(
+            "doc-1",
+            "virtual machine",
+            SymbolKind::Class,
+            Some("cpp".to_string()),
+        );
+        let hyphenated = SymbolRecord::declared(
+            "doc-2",
+            "virtual-machine",
+            SymbolKind::Class,
+            Some("cpp".to_string()),
+        );
+        let store = SymbolStore::from_records(vec![exact, hyphenated]);
+
+        let matches = store.lookup_by_name("virtual machine");
+        assert_eq!(matches.len(), 2);
+        assert!(matches.iter().all(|record| record.kind == SymbolKind::Class));
+    }
+
+    #[test]
+    fn lookup_by_doc_and_attribute_return_matching_records() {
+        let record = SymbolRecord::referenced(
+            "doc-1",
+            "install",
+            SymbolKind::Function,
+            Some("cpp".to_string()),
+        )
+        .with_attribute("visibility", json!("public"));
+        let store = SymbolStore::from_records(vec![record.clone()]);
+
+        let by_doc = store.lookup_by_doc("doc-1");
+        assert_eq!(by_doc.len(), 1);
+        assert_eq!(by_doc[0].symbol_id, record.symbol_id);
+
+        let by_attr = store.lookup_by_attribute("visibility", &json!("public"));
+        assert_eq!(by_attr.len(), 1);
+        assert_eq!(by_attr[0].symbol_id, record.symbol_id);
+    }
+
+    #[test]
+    fn corpus_index_from_bundle_preserves_documents_and_symbols() {
+        let doc = sample_source_document();
+        let symbol = SymbolRecord::declared(
+            "doc-1",
+            "install",
+            SymbolKind::Function,
+            Some("cpp".to_string()),
+        );
+        let bundle = IngestBundle::new(vec![doc], vec![symbol.clone()]);
+
+        let index = CorpusIndex::from_bundle(bundle, &PipelineOptions::default()).unwrap();
+
+        assert_eq!(index.symbols.lookup_by_doc("doc-1").len(), 1);
+        assert!(!index.documents.query("install", 5).is_empty());
+    }
+}

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,0 +1,320 @@
+use crate::ownership::{OwnershipKind, OwnershipRecord};
+use crate::symbols::{SymbolLocation, SymbolRecord};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum UsageNodeKind {
+    Symbol,
+    Span,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum UsageEdgeKind {
+    Declares,
+    References,
+    Uses,
+    Calls,
+    Allocates,
+    Transfers,
+    Releases,
+    Imports,
+    Inherits,
+    Contains,
+    Anchors,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UsageNode {
+    pub node_id: String,
+    pub kind: UsageNodeKind,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub doc_id: Option<String>,
+    #[serde(default)]
+    pub symbol_id: Option<String>,
+    #[serde(default)]
+    pub location: Option<SymbolLocation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UsageEdge {
+    pub from: String,
+    pub to: String,
+    pub kind: UsageEdgeKind,
+    #[serde(default)]
+    pub doc_id: Option<String>,
+    #[serde(default)]
+    pub symbol_id: Option<String>,
+    #[serde(default)]
+    pub location: Option<SymbolLocation>,
+    #[serde(default)]
+    pub confidence: f32,
+    #[serde(default)]
+    pub attributes: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UsageGraph {
+    pub nodes: Vec<UsageNode>,
+    pub edges: Vec<UsageEdge>,
+    #[serde(default)]
+    pub by_node: HashMap<String, Vec<usize>>,
+    #[serde(default)]
+    pub by_doc: HashMap<String, Vec<usize>>,
+    #[serde(default)]
+    pub by_symbol: HashMap<String, Vec<usize>>,
+    #[serde(default)]
+    pub by_kind: HashMap<UsageEdgeKind, Vec<usize>>,
+}
+
+impl UsageGraph {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a usage graph from symbol records.
+    ///
+    /// Documents are not represented as graph nodes; document provenance stays
+    /// on edges through `doc_id`.
+    pub fn from_bundle(bundle: &crate::symbols::IngestBundle) -> Self {
+        let mut graph = Self::new();
+        graph.ingest_symbols(bundle.symbols.iter().cloned());
+        graph
+    }
+
+    pub fn insert_node(&mut self, node: UsageNode) -> usize {
+        let index = self.nodes.len();
+        self.nodes.push(node);
+        index
+    }
+
+    pub fn insert_edge(&mut self, edge: UsageEdge) {
+        let index = self.edges.len();
+        let from = edge.from.clone();
+        let to = edge.to.clone();
+        let doc_id = edge.doc_id.clone();
+        let symbol_id = edge.symbol_id.clone();
+        let kind = edge.kind;
+        self.edges.push(edge);
+        self.by_node.entry(from).or_default().push(index);
+        self.by_node.entry(to).or_default().push(index);
+        if let Some(doc_id) = doc_id {
+            self.by_doc.entry(doc_id).or_default().push(index);
+        }
+        if let Some(symbol_id) = symbol_id {
+            self.by_symbol.entry(symbol_id).or_default().push(index);
+        }
+        self.by_kind.entry(kind).or_default().push(index);
+    }
+
+    pub fn lookup_by_node(&self, node_id: &str) -> Vec<&UsageEdge> {
+        self.lookup_indices(self.by_node.get(node_id))
+    }
+
+    pub fn lookup_by_doc(&self, doc_id: &str) -> Vec<&UsageEdge> {
+        self.lookup_indices(self.by_doc.get(doc_id))
+    }
+
+    pub fn lookup_by_symbol(&self, symbol_id: &str) -> Vec<&UsageEdge> {
+        self.lookup_indices(self.by_symbol.get(symbol_id))
+    }
+
+    pub fn lookup_by_kind(&self, kind: UsageEdgeKind) -> Vec<&UsageEdge> {
+        self.lookup_indices(self.by_kind.get(&kind))
+    }
+
+    fn lookup_indices(&self, indices: Option<&Vec<usize>>) -> Vec<&UsageEdge> {
+        indices
+            .into_iter()
+            .flat_map(|indices| indices.iter())
+            .filter_map(|index| self.edges.get(*index))
+            .collect()
+    }
+
+    pub fn ingest_symbols(&mut self, symbols: impl IntoIterator<Item = SymbolRecord>) {
+        for symbol in symbols {
+            let node_id = format!("symbol:{}", symbol.symbol_id);
+            self.insert_node(UsageNode {
+                node_id: node_id.clone(),
+                kind: UsageNodeKind::Symbol,
+                label: Some(symbol.name.clone()),
+                doc_id: Some(symbol.doc_id.clone()),
+                symbol_id: Some(symbol.symbol_id.clone()),
+                location: symbol.location.clone(),
+            });
+
+            let doc_node_id = format!("doc:{}", symbol.doc_id);
+            self.insert_edge(UsageEdge {
+                from: doc_node_id,
+                to: node_id,
+                kind: match symbol.relation {
+                    crate::symbols::SymbolRelationKind::Declares
+                    | crate::symbols::SymbolRelationKind::Defines => UsageEdgeKind::Declares,
+                    crate::symbols::SymbolRelationKind::References => UsageEdgeKind::References,
+                    crate::symbols::SymbolRelationKind::Uses => UsageEdgeKind::Uses,
+                    crate::symbols::SymbolRelationKind::Calls => UsageEdgeKind::Calls,
+                    crate::symbols::SymbolRelationKind::Imports => UsageEdgeKind::Imports,
+                    crate::symbols::SymbolRelationKind::Inherits => UsageEdgeKind::Inherits,
+                    crate::symbols::SymbolRelationKind::Contains => UsageEdgeKind::Contains,
+                },
+                doc_id: Some(symbol.doc_id),
+                symbol_id: Some(symbol.symbol_id),
+                location: symbol.location,
+                confidence: 1.0,
+                attributes: HashMap::new(),
+            });
+        }
+    }
+
+    pub fn ingest_ownership(&mut self, records: impl IntoIterator<Item = OwnershipRecord>) {
+        for record in records {
+            let kind = match record.kind {
+                OwnershipKind::Allocates | OwnershipKind::Managed => UsageEdgeKind::Allocates,
+                OwnershipKind::Transfers => UsageEdgeKind::Transfers,
+                OwnershipKind::Releases => UsageEdgeKind::Releases,
+                OwnershipKind::Borrows => UsageEdgeKind::Uses,
+                OwnershipKind::Aliases => UsageEdgeKind::Uses,
+                OwnershipKind::Escapes => UsageEdgeKind::Uses,
+                OwnershipKind::Invalidates => UsageEdgeKind::Anchors,
+            };
+            let from = record
+                .symbol_id
+                .clone()
+                .unwrap_or_else(|| format!("doc:{}", record.doc_id));
+            let to = record
+                .target
+                .clone()
+                .unwrap_or_else(|| format!("doc:{}", record.doc_id));
+            self.insert_edge(UsageEdge {
+                from,
+                to,
+                kind,
+                doc_id: Some(record.doc_id),
+                symbol_id: record.symbol_id,
+                location: record.location,
+                confidence: record.confidence,
+                attributes: record.attributes,
+            });
+        }
+    }
+
+    /// Return node ids that are connected to the given symbol through usage or
+    /// ownership edges.
+    pub fn connected_symbols(&self, symbol_id: &str) -> Vec<String> {
+        let mut out = HashSet::new();
+        for edge in self.lookup_by_symbol(symbol_id) {
+            if self.nodes.iter().any(|node| node.node_id == edge.from) {
+                out.insert(edge.from.clone());
+            }
+            if self.nodes.iter().any(|node| node.node_id == edge.to) {
+                out.insert(edge.to.clone());
+            }
+        }
+        out.into_iter().collect()
+    }
+
+    /// Summarize the edges and adjacent nodes associated with a symbol.
+    pub fn summary_for_symbol(&self, symbol_id: &str) -> UsageSummary {
+        let edges = self.lookup_by_symbol(symbol_id);
+        let mut counts = HashMap::new();
+        for kind in [
+            UsageEdgeKind::Declares,
+            UsageEdgeKind::References,
+            UsageEdgeKind::Uses,
+            UsageEdgeKind::Calls,
+            UsageEdgeKind::Allocates,
+            UsageEdgeKind::Transfers,
+            UsageEdgeKind::Releases,
+            UsageEdgeKind::Imports,
+            UsageEdgeKind::Inherits,
+            UsageEdgeKind::Contains,
+            UsageEdgeKind::Anchors,
+        ] {
+            counts.insert(kind, 0usize);
+        }
+        for edge in edges {
+            *counts.entry(edge.kind).or_insert(0) += 1;
+        }
+        UsageSummary {
+            symbol_id: symbol_id.to_string(),
+            edge_count: self.lookup_by_symbol(symbol_id).len(),
+            related_nodes: self.connected_symbols(symbol_id),
+            edge_counts: counts,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UsageSummary {
+    pub symbol_id: String,
+    pub edge_count: usize,
+    pub related_nodes: Vec<String>,
+    pub edge_counts: HashMap<UsageEdgeKind, usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_by_node_is_bidirectional() {
+        let mut graph = UsageGraph::new();
+        graph.insert_edge(UsageEdge {
+            from: "node:a".to_string(),
+            to: "node:b".to_string(),
+            kind: UsageEdgeKind::Calls,
+            doc_id: Some("doc-1".to_string()),
+            symbol_id: Some("sym-1".to_string()),
+            location: None,
+            confidence: 1.0,
+            attributes: HashMap::new(),
+        });
+
+        assert_eq!(graph.lookup_by_node("node:a").len(), 1);
+        assert_eq!(graph.lookup_by_node("node:b").len(), 1);
+    }
+
+    #[test]
+    fn summary_for_symbol_counts_edges_and_connected_nodes() {
+        let mut graph = UsageGraph::new();
+        graph.insert_node(UsageNode {
+            node_id: "symbol:a".to_string(),
+            kind: UsageNodeKind::Symbol,
+            label: Some("Alpha".to_string()),
+            doc_id: Some("doc-1".to_string()),
+            symbol_id: Some("sym-a".to_string()),
+            location: None,
+        });
+        graph.insert_node(UsageNode {
+            node_id: "symbol:b".to_string(),
+            kind: UsageNodeKind::Symbol,
+            label: Some("Beta".to_string()),
+            doc_id: Some("doc-2".to_string()),
+            symbol_id: Some("sym-b".to_string()),
+            location: None,
+        });
+        graph.insert_edge(UsageEdge {
+            from: "symbol:a".to_string(),
+            to: "symbol:b".to_string(),
+            kind: UsageEdgeKind::Calls,
+            doc_id: Some("doc-1".to_string()),
+            symbol_id: Some("sym-a".to_string()),
+            location: None,
+            confidence: 1.0,
+            attributes: HashMap::new(),
+        });
+
+        let summary = graph.summary_for_symbol("sym-a");
+        assert_eq!(summary.symbol_id, "sym-a");
+        assert_eq!(summary.edge_count, 1);
+        assert_eq!(
+            summary.edge_counts.get(&UsageEdgeKind::Calls).copied(),
+            Some(1)
+        );
+        assert!(summary.related_nodes.contains(&"symbol:a".to_string()));
+        assert!(summary.related_nodes.contains(&"symbol:b".to_string()));
+    }
+}


### PR DESCRIPTION
Adds the new semantic graph and review model layer, plus direct SourceDocument tests and README/release-note updates.

Summary:
- add SymbolStore, OwnershipRecord, UsageGraph, CorpusGraph, and review packet types
- update the crate docs and README to match the broader public API
- add focused tests for SourceDocument and the new graph/review models

Verification:
- cargo test