### PR TITLE
v0.1.8: Add filtered search with BTreeMap filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lint-ai"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Semantic wiki and docs linting for contradictions, stale claims, orphan pages, and missing cross-references"
 license = "Apache-2.0"

--- a/docs/filtered-search.md
+++ b/docs/filtered-search.md
@@ -1,0 +1,237 @@
+# Filtered Search Design
+
+This document describes the filtered search feature added in v0.1.8: how
+`filters` work, where they live in the data model, the query API, and the
+design rationale.
+
+## Problem
+
+A single `IndexStore` can hold documents from many logical scopes — different
+runs, workspaces, graphs, or artifact types. Without a way to restrict a query
+to a subset of documents, callers must post-filter results or maintain separate
+`IndexStore` instances per scope.
+
+Separate stores work at small scale but become expensive at large scale: each
+store carries its own Tantivy index, in-memory `MemoryIndex`, and rebuild cost.
+Shared stores with post-filtering waste BM25 candidate budget on documents the
+caller will discard anyway.
+
+Filtered search solves this by pushing scope constraints into the query layer.
+
+## Data Model
+
+### `SourceDocument.filters`
+
+`filters` is an opaque `BTreeMap<String, String>` on `SourceDocument`:
+
+```rust
+pub struct SourceDocument {
+    pub doc_id: String,
+    pub source: String,
+    pub content: String,
+    // ... existing fields ...
+    pub filters: BTreeMap<String, String>,
+}
+```
+
+Callers populate it with whatever key-value scoping they need:
+
+```rust
+SourceDocument {
+    doc_id: "post::abc::item::0".into(),
+    content: "...",
+    filters: BTreeMap::from([
+        ("run_id".into(),       "3b0217db-f83c-...".into()),
+        ("workspace_id".into(), "ws-456".into()),
+        ("artifact_id".into(),  "cb629d14-...".into()),
+    ]),
+    ..
+}
+```
+
+Keys and values are arbitrary strings. The library treats them as opaque; it
+does not interpret or validate them.
+
+`filters` defaults to an empty map (`#[serde(default)]`) so existing
+serialized records without the field remain valid.
+
+### Propagation
+
+`filters` flows through every layer without transformation:
+
+```
+SourceDocument.filters
+  → assemble_doc_record    → DocRecord.filters
+  → PersistedDocRecord     → serialized to disk
+  → From<PersistedDocRecord> for DocRecord   → restored on load
+  → source_document_from_record → SourceDocument.filters (round-trip)
+```
+
+Nothing in the pipeline modifies, normalizes, or indexes `filters` as a
+searchable field. It is metadata used only at query time.
+
+## Query Semantics
+
+All filter predicates use **exact-match AND** semantics:
+
+- every key-value pair in the supplied filter map must match the document's
+  `filters` map
+- a document that is missing a required key does not match
+- an empty filter map means no restriction — all documents are candidates
+
+This is intentionally simple. Range queries, OR conditions, and prefix matches
+are not supported.
+
+## Query API
+
+### Single-term: `IndexStore::query_filtered`
+
+```rust
+pub fn query_filtered(
+    &mut self,
+    query: &str,
+    top_k: usize,
+    filters: &BTreeMap<String, String>,
+) -> Result<Vec<SearchResult>>
+```
+
+1. Calls `self.refresh()` to ensure the snapshot is current.
+2. Runs `self.lexical.search(query, candidate_k)` — BM25 via Tantivy — to get
+   a set of lexical hit scores keyed by `doc_id`.
+3. Passes lexical hits and `filters` to `MemoryIndex::query_with_filters_and_lexical`.
+4. `MemoryIndex` builds the allowed set, then scores candidates that are in
+   both the lexical hits and the allowed set.
+
+### Multi-term: `IndexStore::query_filtered_multi`
+
+```rust
+pub fn query_filtered_multi(
+    &mut self,
+    queries: &[&str],
+    top_k: usize,
+    filters: &BTreeMap<String, String>,
+) -> Result<Vec<Vec<SearchResult>>>
+```
+
+Returns one `Vec<SearchResult>` per input query, in the same order.
+
+Key difference from calling `query_filtered` N times: the allowed-doc set is
+built **once** from `filters` and reused for every query term. BM25 is still
+called once per term (Tantivy does not batch lexical searches), but the O(n_docs)
+filter scan is paid exactly once.
+
+At small corpus sizes the difference is negligible. At thousands of documents
+with many query terms per call, `query_filtered_multi` avoids O(n_docs × N)
+rescanning.
+
+### `MemoryIndex` layer
+
+Two methods on `MemoryIndex` back the public API:
+
+```rust
+// single-term, no pre-computed lexical hits
+pub fn query_with_filters(
+    &self,
+    query: &str,
+    top_k: usize,
+    filters: &BTreeMap<String, String>,
+) -> Vec<SearchResult>
+
+// single-term, with pre-computed BM25 hits
+pub fn query_with_filters_and_lexical(
+    &self,
+    query: &str,
+    top_k: usize,
+    filters: &BTreeMap<String, String>,
+    lexical_hits: Option<&HashMap<String, f32>>,
+) -> Vec<SearchResult>
+
+// multi-term, allowed set built once
+pub fn query_with_filters_multi(
+    &self,
+    queries: &[&str],
+    top_k: usize,
+    filters: &BTreeMap<String, String>,
+    lexical_hits_per_query: &[HashMap<String, f32>],
+) -> Vec<Vec<SearchResult>>
+```
+
+`IndexStore` is the recommended entry point. The `MemoryIndex` methods are
+public for callers that manage their own BM25 pipeline.
+
+## Implementation Notes
+
+### Why BM25 before filter
+
+BM25 runs first and produces a candidate set. The filter then restricts that
+set. This order avoids scoring documents that would be excluded anyway — Tantivy
+already narrows the field to lexically relevant documents before the filter scan.
+
+An alternative — filter first, then BM25 — would require a Tantivy reader that
+restricts to a doc-id allowlist. Tantivy supports this via `BitSetDocSet` but it
+requires building a Tantivy `DocId` bitset, which needs a mapping from our
+string `doc_id` to internal Tantivy row ids. That mapping is not currently
+maintained. The current approach (BM25 → filter on string `doc_id`) is simpler
+and correct for corpora up to tens of thousands of documents.
+
+### Why `BTreeMap` not `HashMap`
+
+`BTreeMap` gives deterministic iteration order, which matters for consistent
+behaviour in tests and for stable serialization. Filter maps are small (typically
+2–5 keys), so the O(log n) lookup cost versus `HashMap` is irrelevant.
+
+### No filter indexing
+
+Filters are not stored in Tantivy and are not indexed as facets in `MemoryIndex`.
+The allowed-doc set is built by a linear scan over `MemoryIndex.docs` at query
+time. This is intentional: the scan is O(n_docs) regardless of how selective the
+filter is, but it is cache-friendly and requires no additional index structure.
+If filter selectivity becomes a bottleneck, a secondary facet index keyed on
+filter fields would be the natural next step.
+
+## Usage Example
+
+```rust
+use lint_ai::{IndexStore, PipelineOptions, SourceDocument};
+use std::collections::BTreeMap;
+
+let mut store = IndexStore::new(PipelineOptions::default());
+
+// Index documents tagged with run and artifact scope
+for (i, text) in texts.iter().enumerate() {
+    store.upsert(SourceDocument {
+        doc_id: format!("doc-{i}"),
+        content: text.clone(),
+        filters: BTreeMap::from([
+            ("run_id".into(), "run-abc".into()),
+            ("artifact_id".into(), "artifact-xyz".into()),
+        ]),
+        ..Default::default()
+    });
+}
+
+// Single-term filtered query
+let scope = BTreeMap::from([("run_id".into(), "run-abc".into())]);
+let results = store.query_filtered("NVDA earnings", 5, &scope)?;
+
+// Multi-term filtered query — filter scan happens once
+let terms = &["NVDA", "TSLA", "AMD"];
+let per_term = store.query_filtered_multi(terms, 5, &scope)?;
+// per_term[0] = results for "NVDA"
+// per_term[1] = results for "TSLA"
+// per_term[2] = results for "AMD"
+```
+
+## Design Constraints
+
+- **No deep merge in `filters`**: values are plain strings, not nested objects.
+  Compound keys (e.g. `"workspace_id:graph_id"`) are the caller's responsibility.
+- **No negation**: there is no way to express "exclude documents where key=value".
+- **No partial match**: filter values are compared with `==`, not `starts_with`
+  or regex.
+- **Filters are not returned in `SearchResult`**: callers already know what
+  filters they applied. Echoing them in results adds noise.
+
+These constraints keep the implementation simple and the performance predictable.
+If richer filter semantics are needed in the future, the right direction is a
+dedicated facet index rather than extending the current linear-scan model.

--- a/docs/releases/0.1.8.md
+++ b/docs/releases/0.1.8.md
@@ -1,0 +1,73 @@
+# Release Notes: v0.1.8
+
+Date: 2026-06-13
+
+This release adds exact-match field filtering to `SourceDocument` and the
+index query layer. Callers can now tag documents with arbitrary key-value
+metadata at index time and scope searches to a matching subset without
+post-filtering the result set. A multi-term variant builds the allowed-doc set
+once and reuses it across all queries, making filtered multi-term searches
+efficient at scale.
+
+## Highlights
+
+- Bumped crate version from `0.1.7` to `0.1.8`.
+- Added `filters: BTreeMap<String, String>` field to `SourceDocument`,
+  `DocRecord`, and `PersistedDocRecord`.
+- Added `IndexStore::query_filtered` — single-term filtered search.
+- Added `IndexStore::query_filtered_multi` — multi-term filtered search;
+  builds the allowed-doc set once regardless of query count.
+- Added `MemoryIndex::query_with_filters` and
+  `MemoryIndex::query_with_filters_and_lexical` for filtered in-memory queries.
+- Added `MemoryIndex::query_with_filters_multi` — multi-term variant that
+  reuses the allowed-doc set across all queries.
+- Propagated `filters` through all serialization round-trips (`PersistedDocRecord`
+  `From` conversions, `assemble_doc_record`, `source_document_from_record`).
+- Updated `MarkdownAdapter`, `engine.rs`, and the haystack benchmark binary to
+  supply an empty `filters` map on construction.
+
+## Filtered Search
+
+### `SourceDocument.filters`
+
+Documents can now carry arbitrary key-value metadata:
+
+```rust
+let doc = SourceDocument {
+    filters: BTreeMap::from([
+        ("run_id".into(), "abc-123".into()),
+        ("workspace_id".into(), "ws-456".into()),
+    ]),
+    ..
+};
+```
+
+All filter entries must match (`AND` semantics) for a document to be included
+in results. An empty `filters` map means no restriction.
+
+### `IndexStore::query_filtered`
+
+```rust
+let results = store.query_filtered(query, top_k, &filters)?;
+```
+
+Runs BM25 first (via tantivy), then applies the filter to the candidate set
+before returning results.
+
+### `IndexStore::query_filtered_multi`
+
+```rust
+let per_term_results = store.query_filtered_multi(&queries, top_k, &filters)?;
+```
+
+Runs N BM25 searches (one per query term — tantivy cannot batch these), but
+builds the allowed-doc set from `filters` only once. At scale this avoids
+scanning all documents once per query term.
+
+Returns `Vec<Vec<SearchResult>>` in the same order as the input `queries` slice.
+
+## Performance Note
+
+For workloads with many query terms against a large document corpus, prefer
+`query_filtered_multi` over calling `query_filtered` in a loop. The filter
+scan cost is O(n_docs) and is paid exactly once regardless of query count.

--- a/src/adapters/markdown.rs
+++ b/src/adapters/markdown.rs
@@ -62,6 +62,7 @@ impl SourceAdapter for MarkdownAdapter {
                     content: page.content,
                     concept: page.raw_concept,
                     group_id: None,
+                    filters: std::collections::BTreeMap::new(),
                     headings: page.headings,
                     links: page.links.into_iter().collect(),
                     timestamp: None,

--- a/src/bin/haystack_scoped_benchmark.rs
+++ b/src/bin/haystack_scoped_benchmark.rs
@@ -326,6 +326,7 @@ fn build_scoped_source_docs(entry: &LongMemEvalEntry) -> Vec<SourceDocument> {
                 content: format!("{}: {}", turn.role, turn.content),
                 concept: "longmemeval-turn".to_string(),
                 group_id: Some(session_id.clone()),
+                filters: std::collections::BTreeMap::new(),
                 headings: vec![format!("session:{session_id}")],
                 links: vec![],
                 timestamp: Some(session_date.clone()),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -56,6 +56,7 @@ fn graph_to_source_documents(graph: &Graph) -> Vec<SourceDocument> {
                 content: p.content.clone(),
                 concept: p.raw_concept.clone(),
                 group_id: None,
+                filters: std::collections::BTreeMap::new(),
                 headings: p.headings.clone(),
                 links: p
                     .links

--- a/src/index.rs
+++ b/src/index.rs
@@ -91,6 +91,8 @@ pub struct DocRecord {
     pub doc_length: usize,
     pub author_agent: Option<String>,
     pub group_id: Option<String>,
+    #[serde(default)]
+    pub filters: std::collections::BTreeMap<String, String>,
     pub probable_topic: Option<String>,
     pub doc_type_guess: Option<String>,
     pub headings: Vec<String>,
@@ -1474,6 +1476,83 @@ impl MemoryIndex {
     ) -> Vec<SearchResult> {
         self.query_with_lexical_hits_timed(query, top_k, lexical_hits, None, false, None)
             .0
+    }
+
+    /// Query with exact-match field filtering. All supplied filter key-value pairs must match
+    /// a document's `filters` map for it to be included in results.
+    pub fn query_with_filters(
+        &self,
+        query: &str,
+        top_k: usize,
+        filters: &std::collections::BTreeMap<String, String>,
+    ) -> Vec<SearchResult> {
+        self.query_with_filters_and_lexical(query, top_k, filters, None)
+    }
+
+    pub fn query_with_filters_and_lexical(
+        &self,
+        query: &str,
+        top_k: usize,
+        filters: &std::collections::BTreeMap<String, String>,
+        lexical_hits: Option<&HashMap<String, f32>>,
+    ) -> Vec<SearchResult> {
+        if filters.is_empty() {
+            return self.query_with_lexical_hits(query, top_k, lexical_hits);
+        }
+        let allowed: HashSet<String> = self
+            .docs
+            .iter()
+            .filter(|(_, doc)| {
+                filters
+                    .iter()
+                    .all(|(k, v)| doc.filters.get(k).map(|dv| dv == v).unwrap_or(false))
+            })
+            .map(|(doc_id, _)| doc_id.clone())
+            .collect();
+        self.query_with_lexical_hits_timed(query, top_k, lexical_hits, None, false, Some(&allowed))
+            .0
+    }
+
+    /// Multi-term variant: builds the allowed-doc set once from `filters`, then scores each
+    /// query against it. At scale (thousands of docs) this avoids rescanning docs N times.
+    /// Returns one `Vec<SearchResult>` per input query, in the same order.
+    pub fn query_with_filters_multi(
+        &self,
+        queries: &[&str],
+        top_k: usize,
+        filters: &std::collections::BTreeMap<String, String>,
+        lexical_hits_per_query: &[HashMap<String, f32>],
+    ) -> Vec<Vec<SearchResult>> {
+        let allowed_opt: Option<HashSet<String>> = if filters.is_empty() {
+            None
+        } else {
+            Some(
+                self.docs
+                    .iter()
+                    .filter(|(_, doc)| {
+                        filters
+                            .iter()
+                            .all(|(k, v)| doc.filters.get(k).map(|dv| dv == v).unwrap_or(false))
+                    })
+                    .map(|(doc_id, _)| doc_id.clone())
+                    .collect(),
+            )
+        };
+        queries
+            .iter()
+            .zip(lexical_hits_per_query.iter())
+            .map(|(q, hits)| {
+                self.query_with_lexical_hits_timed(
+                    q,
+                    top_k,
+                    Some(hits),
+                    None,
+                    false,
+                    allowed_opt.as_ref(),
+                )
+                .0
+            })
+            .collect()
     }
 
     fn query_with_lexical_hits_timed(
@@ -3301,6 +3380,7 @@ mod tests {
             doc_length: 7,
             author_agent: None,
             group_id: None,
+            filters: std::collections::BTreeMap::new(),
             probable_topic: None,
             doc_type_guess: None,
             headings: vec!["Overview".to_string()],

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -158,6 +158,8 @@ struct PersistedDocRecord {
     doc_length: usize,
     author_agent: Option<String>,
     group_id: Option<String>,
+    #[serde(default)]
+    filters: std::collections::BTreeMap<String, String>,
     probable_topic: Option<String>,
     doc_type_guess: Option<String>,
     headings: Vec<String>,
@@ -182,6 +184,7 @@ impl From<DocRecord> for PersistedDocRecord {
             doc_length: record.doc_length,
             author_agent: record.author_agent,
             group_id: record.group_id,
+            filters: record.filters,
             probable_topic: record.probable_topic,
             doc_type_guess: record.doc_type_guess,
             headings: record.headings,
@@ -207,6 +210,7 @@ impl From<PersistedDocRecord> for DocRecord {
             doc_length: record.doc_length,
             author_agent: record.author_agent,
             group_id: record.group_id,
+            filters: record.filters,
             probable_topic: record.probable_topic,
             doc_type_guess: record.doc_type_guess,
             headings: record.headings,
@@ -647,6 +651,44 @@ impl IndexStore {
         Ok((results, timings, diagnostics))
     }
 
+    pub fn query_filtered(
+        &mut self,
+        query: &str,
+        top_k: usize,
+        filters: &std::collections::BTreeMap<String, String>,
+    ) -> Result<Vec<SearchResult>> {
+        self.refresh()?;
+        let lexical_hits = self.lexical.search(query, top_k.saturating_mul(5).max(20))?;
+        Ok(self
+            .snapshot
+            .as_ref()
+            .expect("snapshot should exist after refresh")
+            .query_with_filters_and_lexical(query, top_k, filters, Some(&lexical_hits)))
+    }
+
+    /// Multi-term variant: builds the allowed-doc set once from `filters`, then scores every
+    /// query. BM25 (tantivy) is still called once per term — that can't be collapsed — but the
+    /// filter scan over all docs happens only once regardless of how many queries are given.
+    /// Returns one `Vec<SearchResult>` per input query, in the same order.
+    pub fn query_filtered_multi(
+        &mut self,
+        queries: &[&str],
+        top_k: usize,
+        filters: &std::collections::BTreeMap<String, String>,
+    ) -> Result<Vec<Vec<SearchResult>>> {
+        self.refresh()?;
+        let candidate_k = top_k.saturating_mul(5).max(20);
+        let mut lexical_hits_per_query = Vec::with_capacity(queries.len());
+        for q in queries {
+            lexical_hits_per_query.push(self.lexical.search(q, candidate_k)?);
+        }
+        Ok(self
+            .snapshot
+            .as_ref()
+            .expect("snapshot should exist after refresh")
+            .query_with_filters_multi(queries, top_k, filters, &lexical_hits_per_query))
+    }
+
     fn prepare_pending_changes(&mut self) -> Result<()> {
         let dirty_doc_ids = self.dirty_docs.iter().cloned().collect::<Vec<String>>();
         for doc_id in &dirty_doc_ids {
@@ -937,6 +979,7 @@ fn source_document_from_record(record: &DocRecord) -> SourceDocument {
             .or_else(|| record.probable_topic.clone())
             .unwrap_or_else(|| record.doc_id.clone()),
         group_id: record.group_id.clone(),
+        filters: record.filters.clone(),
         headings: record.headings.clone(),
         links: record.doc_links.clone(),
         timestamp: record.timestamp.clone(),
@@ -1514,6 +1557,7 @@ fn assemble_doc_record(
         doc_length: source_doc.doc_length,
         author_agent: source_doc.author_agent.clone(),
         group_id: source_doc.group_id.clone(),
+        filters: source_doc.filters.clone(),
         probable_topic,
         doc_type_guess: guess_doc_type(&doc.headings, &doc.content),
         headings: doc.headings.clone(),

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::ids::stable_doc_id_from_source;
@@ -17,6 +19,8 @@ pub struct SourceDocument {
     pub timestamp: Option<String>,
     pub doc_length: usize,
     pub author_agent: Option<String>,
+    #[serde(default)]
+    pub filters: BTreeMap<String, String>,
 }
 
 impl SourceDocument {
@@ -43,6 +47,7 @@ impl SourceDocument {
             timestamp,
             doc_length,
             author_agent,
+            filters: BTreeMap::new(),
         }
     }
 }
@@ -126,5 +131,6 @@ mod tests {
         assert_eq!(decoded.timestamp, doc.timestamp);
         assert_eq!(decoded.doc_length, doc.doc_length);
         assert_eq!(decoded.author_agent, doc.author_agent);
+        assert_eq!(decoded.filters, doc.filters);
     }
 }


### PR DESCRIPTION
## Summary

- Added `filters: BTreeMap<String, String>` field to `SourceDocument`, `DocRecord`, and `PersistedDocRecord`
- Added `IndexStore::query_filtered` — single-term filtered search (BM25 first, then filter)
- Added `IndexStore::query_filtered_multi` — multi-term filtered search; builds allowed-doc set once across all queries
- Added `MemoryIndex::query_with_filters`, `query_with_filters_and_lexical`, and `query_with_filters_multi`
- Propagated `filters` through all serialization round-trips
- Bumped crate version from `0.1.7` to `0.1.8`
- Added release notes (`docs/releases/0.1.8.md`) and design doc (`docs/filtered-search.md`)

## Test plan

- [ ] `cargo test` passes
- [ ] `query_filtered` returns only documents matching all filter key-value pairs
- [ ] `query_filtered_multi` returns one result set per query term, consistent with calling `query_filtered` per term
- [ ] Documents with no `filters` field deserialize correctly (backward compat via `#[serde(default)]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)