### PR TITLE
benchmark README and dataset helper

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,73 @@
 # Benchmark Suite
 
-This directory holds the retrieval benchmarks for `lint-ai`, including haystack-style corpora, LongMemEval-S runs, and the EverMemBench-Static setup.
+This directory holds the retrieval benchmarks for `lint-ai`, including haystack-style corpora and LongMemEval-S runs.
+
+## Benchmark Results
+
+Evaluated on **LongMemEval-S** (500 questions), a public benchmark for long-context agent memory retrieval over multi-session conversation corpora. The scoped variant is used: each query searches only the sessions attached to that question, matching the realistic setting where a system knows which sessions are candidates for a given user. No embedding vectors are used anywhere in the pipeline.
+
+The section below shows both the rust-bert POS/NER branch result and the default heuristic release result.
+
+### Rust-BERT POS/NER Branch
+
+**Aggregate (n=500):**
+
+| metric | value |
+|---|---|
+| recall@5 | 86.9% |
+| recall@10 | 93.8% |
+| recall@20 | 94.4% |
+| recall_any@5 | 94.8% |
+| recall_any@10 | 98.2% |
+| MRR | 87.1% |
+| NDCG@10 | 86.0% |
+| avg query latency | 5.1 ms |
+
+`recall@k` is fractional recall over all gold sessions. `recall_any@k` counts 1.0 if any gold session appears in the top k. Latency is measured on a single CPU core with no GPU.
+
+**By question type:**
+
+| question type | n | recall@5 | recall@10 | recall_any@5 | MRR | NDCG@10 |
+|---|---|---|---|---|---|---|
+| single-session-assistant | 56 | 100.0% | 100.0% | 100.0% | 99.1% | 99.3% |
+| single-session-user | 70 | 97.1% | 98.6% | 97.1% | 86.8% | 89.8% |
+| knowledge-update | 78 | 96.8% | 98.7% | 100.0% | 95.2% | 94.4% |
+| single-session-preference | 30 | 80.0% | 96.7% | 80.0% | 64.7% | 72.3% |
+| temporal-reasoning | 133 | 81.1% | 92.0% | 91.7% | 84.1% | 82.3% |
+| multi-session | 133 | 77.7% | 87.1% | 94.7% | 85.3% | 80.2% |
+
+Results file: `benchmark/data/lintai_longmemeval_scoped_results_0512.json`
+
+### Heuristic Release Backend
+
+**Aggregate (n=500):**
+
+| metric | value |
+|---|---|
+| recall@5 | 83.7% |
+| recall@10 | 89.6% |
+| recall@20 | 91.1% |
+| recall_any@5 | 92.4% |
+| recall_any@10 | 95.6% |
+| recall_any@20 | 97.0% |
+| MRR | 84.3% |
+| NDCG@10 | 81.9% |
+| avg query latency | 6.1 ms |
+
+`recall@k` is fractional recall over all gold sessions. `recall_any@k` counts 1.0 if any gold session appears in the top k. Latency is measured on a single CPU core with no GPU.
+
+**By question type:**
+
+| question type | n | recall@5 | recall@10 | recall_any@5 | MRR | NDCG@10 |
+|---|---|---|---|---|---|---|
+| single-session-assistant | 56 | 100.0% | 100.0% | 100.0% | 98.2% | 98.7% |
+| single-session-user | 70 | 94.3% | 98.6% | 94.3% | 77.4% | 82.6% |
+| knowledge-update | 78 | 94.2% | 96.8% | 98.7% | 94.6% | 92.4% |
+| single-session-preference | 30 | 80.0% | 93.3% | 80.0% | 65.8% | 72.2% |
+| temporal-reasoning | 133 | 77.0% | 85.7% | 86.5% | 81.8% | 78.2% |
+| multi-session | 133 | 72.5% | 79.3% | 93.2% | 82.7% | 74.3% |
+
+Results file: `benchmark/data/lintai_longmemeval_scoped_results.json`
 
 ## Dataset format
 
@@ -44,19 +111,7 @@ cargo run --bin haystack_benchmark -- \
   --out benchmark/results.json
 ```
 
-To run the academic LongMemEval-S corpus directly and index each session as turn-level chunks:
-
-```bash
-cargo run --bin haystack_benchmark -- \
-  --longmemeval benchmark/data/longmemeval_s_cleaned.json \
-  --limit 20 \
-  --k 5 --k 10 --k 20 \
-  --out benchmark/results.json
-```
-
-In LongMemEval mode, turn docs are grouped back to their parent session for scoring so you measure session retrieval quality while using finer-grained chunks for indexing.
-
-If you want the raw Hugging Face copy instead of the cleaned one, use:
+To run the academic LongMemEval-S corpus directly and index each session as turn-level chunks, use the raw Hugging Face copy:
 
 ```bash
 cargo run --bin haystack_benchmark -- \
@@ -65,81 +120,22 @@ cargo run --bin haystack_benchmark -- \
   --k 5 --k 10 --k 20 \
   --out benchmark/results.json
 ```
+
+To refresh that local raw file from Hugging Face, run `python3 benchmark/download_longmemeval_raw.py`.
+
+Note: the benchmark expects the raw LongMemEval-S source file at `benchmark/data/longmemeval_s_raw.json`. The helper script refreshes that file and verifies it against the published Hugging Face blob.
+Source: https://huggingface.co/datasets/xiaowu0162/longmemeval/resolve/main/longmemeval_s?download=true
 
 If you want question-scoped haystack retrieval, where each query only searches the sessions attached to that question:
 
 ```bash
-cargo run --bin haystack_scoped_benchmark -- \
+cargo run --release --bin haystack_scoped_benchmark -- \
   --longmemeval benchmark/data/longmemeval_s_raw.json \
-  --limit 20 \
   --k 5 --k 10 --k 20 \
-    --out benchmark/results.json
+  --out benchmark/data/lintai_longmemeval_scoped_results.json
 ```
 
 Scoped LongMemEval reporting includes both `recall@k` and `recall_any@k`. The any-hit metric matches the interpretation used by the current LongMemEval-S release notes and README.
-
-To prepare a reusable turn-based dataset file first, run:
-
-```bash
-python3 - <<'PY'
-import json
-from pathlib import Path
-
-src = Path('benchmark/data/longmemeval_s_cleaned.json')
-out = Path('benchmark/data/longmemeval_turn_full_for_lintai.json')
-raw = json.loads(src.read_text())
-
-abst = {
-    'single-session-user_abs',
-    'multi-session_abs',
-    'knowledge-update_abs',
-    'temporal-reasoning_abs',
-}
-
-entries = [e for e in raw if e.get('question_type') not in abst]
-documents = []
-queries = []
-seen_docs = set()
-
-for entry in entries:
-    session_turns = {
-        sid: turns
-        for sid, turns in zip(
-            entry.get('haystack_session_ids', []),
-            entry.get('haystack_sessions', []),
-        )
-    }
-    for session_id, turns in session_turns.items():
-        for turn_idx, turn in enumerate(turns):
-            doc_id = f'{session_id}::turn{turn_idx}'
-            if doc_id in seen_docs:
-                continue
-            seen_docs.add(doc_id)
-            documents.append({
-                'doc_id': doc_id,
-                'source': f'longmemeval/session/{session_id}/turn/{turn_idx}',
-                'content': f"{turn.get('role', 'unknown')}: {turn.get('content', '')}",
-                'concept': 'longmemeval-turn',
-                'headings': [f'session:{session_id}'],
-                'links': [],
-                'timestamp': entry.get('question_date'),
-                'author_agent': None,
-            })
-
-    queries.append({
-        'id': entry['question_id'],
-        'query': entry['question'],
-        'relevant_doc_ids': entry.get('answer_session_ids', []),
-        'relevant_chunk_ids': [],
-    })
-
-with out.open('w') as f:
-    json.dump({'documents': documents, 'queries': queries}, f)
-
-print(f'wrote {out}')
-print(f'documents={len(documents)} queries={len(queries)}')
-PY
-```
 
 ## Report Metrics
 

--- a/benchmark/download_longmemeval_raw.py
+++ b/benchmark/download_longmemeval_raw.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Download the raw LongMemEval-S JSON from Hugging Face.
+
+This fetches the exact source file used by the benchmark:
+https://huggingface.co/datasets/xiaowu0162/longmemeval/resolve/main/longmemeval_s?download=true
+
+The script writes the file to benchmark/data/longmemeval_s_raw.json by default
+and verifies the SHA-256 hash so the local copy stays byte-for-byte identical.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import urllib.request
+from pathlib import Path
+
+
+DEFAULT_URL = (
+    "https://huggingface.co/datasets/xiaowu0162/longmemeval/"
+    "resolve/main/longmemeval_s?download=true"
+)
+EXPECTED_SHA256 = "08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894"
+EXPECTED_RECORDS = 500
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download the raw LongMemEval-S dataset used by the benchmarks."
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_URL,
+        help="Dataset download URL. Defaults to the official Hugging Face raw file.",
+    )
+    parser.add_argument(
+        "--out",
+        default=Path("benchmark/data/longmemeval_s_raw.json"),
+        type=Path,
+        help="Output file path.",
+    )
+    parser.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="Skip SHA-256 and record-count verification.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"downloading {args.url}")
+    with urllib.request.urlopen(args.url) as response:
+        data = response.read()
+
+    args.out.write_bytes(data)
+    print(f"wrote {args.out} ({len(data)} bytes)")
+
+    if args.skip_verify:
+        return 0
+
+    sha256 = hashlib.sha256(data).hexdigest()
+    if sha256 != EXPECTED_SHA256:
+        print(
+            f"sha256 mismatch: expected {EXPECTED_SHA256}, got {sha256}",
+            file=sys.stderr,
+        )
+        return 1
+
+    import json
+
+    obj = json.loads(data)
+    if not isinstance(obj, list) or len(obj) != EXPECTED_RECORDS:
+        print(
+            f"record count mismatch: expected {EXPECTED_RECORDS}, got "
+            f"{len(obj) if isinstance(obj, list) else type(obj).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"verified sha256={sha256} records={len(obj)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed
- Moved the benchmark results section into `benchmark/README.md`
- Removed the stale turn-file regeneration snippet that referenced the cleaned dataset
- Added `benchmark/download_longmemeval_raw.py` to download and verify the exact Hugging Face raw LongMemEval-S file
- Added a short README note with the raw dataset URL and local file path

## Why
- Keep the benchmark docs aligned with the actual raw dataset used by the benchmark
- Provide a repeatable way to refresh `benchmark/data/longmemeval_s_raw.json`
- Reduce confusion around the cleaned vs raw LongMemEval-S variants

## Validation
- Ran `python3 -m py_compile benchmark/download_longmemeval_raw.py`
- Ran `python3 benchmark/download_longmemeval_raw.py` successfully and verified the SHA-256 and record count