### PR TITLE
Add segmented MemoryIndex diagnostics

### DIFF
--- a/docs/artifact-indexing.md
+++ b/docs/artifact-indexing.md
@@ -496,6 +496,8 @@ Remaining gaps:
 - richer concurrent publication model
   - current background refresh is internal-only and simple rather than a full
   multi-reader / multi-writer snapshot system
+  - see [IndexStore and MemoryIndex Concurrency](index-concurrency.md) for the
+    recommended large-corpus publication model
 - stronger freshness policy controls
   - current public API intentionally avoids exposing multiple refresh/query
     modes, and does not yet implement advanced scheduling or debouncing policies
@@ -558,6 +560,12 @@ If scale demands it, redesign internals for true incremental updates:
 
 This is a larger project and should only be pursued if performance data shows
 the current snapshot model is too expensive.
+
+Before that larger redesign, prefer the lighter concurrency path documented in
+[IndexStore and MemoryIndex Concurrency](index-concurrency.md): one published
+query generation plus at most one in-flight replacement generation per logical
+`IndexStore`. A generation may be one `MemoryIndex` today or a segmented set of
+`MemoryIndex` values in a future large-corpus design.
 
 ## Recommended Host Architecture
 

--- a/docs/index-concurrency.md
+++ b/docs/index-concurrency.md
@@ -1,0 +1,299 @@
+# IndexStore and MemoryIndex Concurrency
+
+This note captures the recommended concurrency model for large Lint-AI
+deployments.
+
+## Current Model
+
+`IndexStore` is the mutable owner of the corpus state:
+
+- source documents
+- derived `DocRecord`s
+- chunk lifecycle metadata
+- temporal facts
+- Tantivy lexical state
+- the current semantic `MemoryIndex` snapshot
+
+`MemoryIndex` is the immutable semantic query snapshot. It is optimized for
+batch construction and fast reads over compact global structures. It is not the
+right object to mutate incrementally in place.
+
+Today, public queries call `refresh()` before searching. That gives strongest
+freshness, but it also means the first query after a write can pay the full
+semantic rebuild cost.
+
+There is also a private background refresh scaffold. It preserves the old
+snapshot while building a newer one and publishes the result only if no newer
+write has advanced the store revision.
+
+## Recommended Rule
+
+There are two separate concurrency questions:
+
+- snapshot publication: how many replacements for the currently queryable
+  state should be built at the same time
+- segmentation: whether one logical corpus should be represented by many
+  smaller queryable `MemoryIndex` segments
+
+For snapshot publication, build at most one replacement generation at a time.
+
+In steady state, a store should have:
+
+- one published query generation used by readers
+- zero or one pending query generation for the next revision
+
+If the store is not segmented, a query generation is one `MemoryIndex`. If the
+store is segmented, a query generation is a set of `MemoryIndex` segments plus a
+router/merge layer.
+
+Avoid building many complete replacement generations for the same store. They
+duplicate most of the corpus in memory, compete for CPU, and usually finish with
+obsolete revisions when writes continue arriving.
+
+## Segmented MemoryIndex Sets
+
+For large corpora, the next useful architecture is likely an `IndexStore` that
+can publish many smaller `MemoryIndex` segments as one logical search surface.
+
+Examples:
+
+- docs corpus: one segment per folder, product area, or bounded chunk range
+- one giant document: split into chunks, then pack those chunks into bounded
+  segments
+- agent memory: one segment per session, or per session window, when session is
+  the natural routing unit
+
+This is different from creating many unrelated `IndexStore`s. The `IndexStore`
+can still be the persistent owner of records, lifecycle metadata, and lexical
+state, while the query layer owns a set of immutable segment snapshots.
+
+A reasonable segment policy is:
+
+- route-based segment when a stable key exists, such as folder, repo, session,
+  tenant, language, or time window
+- size-based segment when no stable key is small enough
+- configurable default chunk/document limit per segment
+- rebuild only the changed segment when possible
+- publish the new segment set atomically as one generation
+
+For a giant document split into chunks, the rough upper bound is:
+
+```text
+segment_count = ceil(total_chunks / memory_index_chunk_limit)
+```
+
+That segment count is not automatically the desired CPU concurrency. The build
+concurrency should be capped separately by available cores, memory headroom, and
+I/O pressure:
+
+```text
+build_parallelism = min(segment_count, configured_parallelism, resource_limit)
+```
+
+In other words, `memory_index_chunk_limit` controls segment size. A separate
+parallelism limit controls how many segment builds can run at once.
+
+The chunking/build pipeline is another level of parallelism. Its worker count
+should normally be a small CPU-bound limit, for example four workers by default,
+rather than the number of segments. That keeps the pipeline predictable:
+
+```text
+chunk_pipeline_workers = min(configured_workers, cpu_limit)
+```
+
+## Minimal Segmented Query Step
+
+The smallest useful change is not a full sharded indexing system. It is the
+ability to query one selected segment `MemoryIndex`, then compare its result
+against the existing global query path.
+
+Small units:
+
+1. Define `MemoryIndexSegment`.
+   - `segment_id`
+   - `boundary`, such as folder, session, language, time window, or chunk range
+   - `doc_ids`
+   - one inner `MemoryIndex`
+   - one compact `SegmentProfile`
+2. Build profiles for existing records without changing query behavior.
+3. Add a router that ranks segments for a query.
+4. Query only the top segment.
+5. Query the top N segments and merge top-k results.
+6. Rebuild only the segment touched by an upsert/remove.
+7. Publish the replacement segment set as one generation.
+
+This gives a small benchmarkable ladder. Each step can be compared against the
+current one-global-`MemoryIndex` baseline.
+
+## Segment Routing
+
+Routing should start with cheap sparse statistics that match the current
+implementation.
+
+`MemoryIndex` already derives:
+
+- important terms
+- key entities
+- topics
+- document type guesses
+- temporal metadata
+- group/session metadata
+- sparse postings
+
+A `SegmentProfile` can summarize these as normalized distributions:
+
+- term distribution
+- entity distribution
+- topic distribution
+- doc type distribution
+- optional time range
+- optional route keys, such as folder/session/language
+
+The first router can use sparse similarity:
+
+```text
+score(segment, query) =
+  lexical_overlap(query_terms, segment_terms)
+  + entity_overlap(query_entities, segment_entities)
+  + topic_match(query_topic, segment_topics)
+  + route_key_bonus
+  + temporal_window_bonus
+```
+
+For a more ML-style router, treat the query as a sparse distribution and compare
+it with each segment profile. KL divergence can work if smoothing is handled
+carefully:
+
+```text
+route_score = -KL(query_distribution || segment_distribution)
+```
+
+Jensen-Shannon divergence may be safer for early implementation because it is
+symmetric and bounded:
+
+```text
+route_score = 1 - JS(query_distribution, segment_distribution)
+```
+
+K-means is useful at segment construction time when there is no obvious boundary
+like folder or session. In that case, cluster chunks/documents by sparse
+term/entity vectors, then build one `MemoryIndex` per cluster. For docs and
+agent-memory corpora, explicit boundaries should be tried first because they are
+easier to explain and update incrementally.
+
+The router should keep recall safeguards:
+
+- query at least one fallback segment when routing confidence is low
+- query more segments for broad or ambiguous questions
+- preserve a `query_all_segments` debug mode
+- record segment routing diagnostics in benchmarks
+
+## Freshness Modes
+
+The useful public API shape is likely three query modes:
+
+- `Fresh`: synchronously refresh before query; best for correctness-sensitive
+  reads and small stores.
+- `LatestAvailable`: query the current snapshot immediately and start or poll a
+  background refresh when the store is dirty; best default for large stores.
+- `SnapshotOnly`: query the current snapshot without starting refresh work; best
+  for high-QPS serving paths where refresh is scheduled separately.
+
+The existing `query()` method behaves like `Fresh`.
+
+## When To Use Multiple IndexStores
+
+Use multiple `IndexStore`s only when there is a stable routing boundary that
+queries can exploit before search:
+
+- tenant or organization
+- product area
+- repository
+- project or workspace
+- time partition, if most queries target a known window
+- language, once multi-language support has separate analyzers or ranking rules
+
+Do not shard only because the corpus is large. Sharding helps when it reduces
+the candidate set for most queries. If every query must fan out to every shard,
+the system pays extra orchestration and merge cost while losing global ranking
+context.
+
+When the desired behavior is "one corpus, many searchable pieces," prefer
+segmented `MemoryIndex` sets inside one logical `IndexStore` before splitting
+into many independent stores.
+
+## Large Corpus Strategy
+
+For a huge corpus, prefer this order:
+
+1. Keep one `IndexStore` per routable corpus scope.
+2. Add `MemoryIndex` segmentation inside that store when the corpus is too large
+   for one snapshot.
+3. Publish one query generation at a time, where a generation may contain many
+   segments.
+4. Rebuild only changed segments when possible.
+5. Cap segment build parallelism separately from segment count.
+6. Debounce rebuilds when many writes arrive together.
+7. Add a scheduled refresh path for serving workloads.
+8. Split into multiple `IndexStore`s only after query routing data shows most
+   queries hit a subset.
+
+This model keeps memory bounded and avoids rebuilding obsolete snapshots.
+
+## Current Implementation Gap
+
+The current code does not yet implement segmented `MemoryIndex` sets.
+
+Current behavior:
+
+- `SourceDocument` is the canonical ingestion unit.
+- `build_doc_records()` processes source documents serially.
+- `assemble_doc_record()` chunks one source document into `section_chunks`.
+- `build_query_snapshot()` builds one `MemoryIndex` from all records passed to
+  that call.
+- `IndexStore::refresh()` rebuilds one semantic `MemoryIndex` snapshot from all
+  current records in the store.
+- group/session/folder identity is metadata, not a separate index boundary.
+
+For the scoped haystack benchmark in this checkout, each question builds a
+snapshot over that question's candidate sessions; each turn is a
+`SourceDocument`, and session identity is carried in `group_id`.
+
+## Implementation Direction
+
+The next implementation step should be routing over segmented query generations.
+Keep it smaller than a low-level incremental rewrite of `MemoryIndex`.
+
+Useful pieces:
+
+1. Add segment metadata/profile types without changing public query behavior.
+2. Build one `MemoryIndex` per explicit boundary, such as folder or session.
+3. Add a `SegmentRouter` that returns ranked segment ids plus diagnostics.
+4. Query the top one segment and benchmark recall/latency.
+5. Query top N segments and merge top-k results.
+6. Add low-confidence fallback to the global index or all segments.
+7. Add CPU-capped parallel segment builds.
+8. Add stale-while-refresh publication for segment generations.
+
+Useful controls:
+
+- `memory_index_chunk_limit`: maximum chunk/doc payload per size-based segment
+- `segment_build_workers`: CPU-capped worker count, usually defaulting near four
+- `segment_query_top_n`: number of routed segments to query
+- `segment_router_min_confidence`: threshold for broad fallback
+- `segment_strategy`: folder, session, language, time, chunk range, or cluster
+
+Useful metrics:
+
+- segment count
+- selected segment ids
+- router confidence
+- routed segment recall
+- top-N merge recall
+- segment build duration
+- skipped obsolete builds
+- snapshot age
+
+True incremental semantic postings updates are still a larger redesign. They
+should be driven by benchmark evidence that segmented rebuilds are still not
+enough.

--- a/src/bin/haystack_scoped_benchmark.rs
+++ b/src/bin/haystack_scoped_benchmark.rs
@@ -1,11 +1,13 @@
 use anyhow::{Context, Result};
-use clap::{ArgAction, Parser};
+use clap::{ArgAction, Parser, ValueEnum};
 use lint_ai::index::TemporalQueryHint;
 use lint_ai::{
     aggregation::{build_aggregate_output, AggregateOutput},
-    build_query_snapshot_from_source_documents,
+    build_index_store, build_query_snapshot_from_source_documents,
+    query_expansion::normalize_for_index,
     query_semantics::{analyze_query, QueryTimeHint},
-    ChunkStrategy, QueryDiagnostics, QueryTimings, SearchResult, SourceDocument,
+    segments::{SegmentQueryDiagnostics, SegmentRoutingStrategy, SegmentedMemoryIndex},
+    ChunkStrategy, PipelineOptions, QueryDiagnostics, QueryTimings, SearchResult, SourceDocument,
     TemporalQueryContext, Tier1NerProvider, Tier1TermRankerKind,
 };
 use serde::{Deserialize, Serialize};
@@ -45,6 +47,35 @@ struct Args {
     /// Enable LCS text reranking on the top rerank window.
     #[arg(long, action = ArgAction::SetTrue)]
     text_rerank_lcs: bool,
+
+    /// Include experimental segmented MemoryIndex comparison metrics.
+    #[arg(long, action = ArgAction::SetTrue)]
+    segment_compare: bool,
+
+    /// Number of routed segments to query for the top-N segmented variant.
+    #[arg(long, default_value_t = 3)]
+    segment_top_n: usize,
+
+    /// Segment routing strategy to use for segmented comparison modes.
+    #[arg(long, value_enum, default_value_t = SegmentRouterArg::Sparse)]
+    segment_router: SegmentRouterArg,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SegmentRouterArg {
+    Sparse,
+    Kl,
+    Local,
+}
+
+impl From<SegmentRouterArg> for SegmentRoutingStrategy {
+    fn from(value: SegmentRouterArg) -> Self {
+        match value {
+            SegmentRouterArg::Sparse => SegmentRoutingStrategy::SparseOverlap,
+            SegmentRouterArg::Kl => SegmentRoutingStrategy::KlDivergence,
+            SegmentRouterArg::Local => SegmentRoutingStrategy::LocalDistinctiveness,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -87,6 +118,66 @@ struct QueryMetrics {
     ndcg_at_10: f64,
     timings: QueryTimings,
     diagnostics: QueryDiagnostics,
+    segment_comparison: Option<SegmentComparisonMetrics>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SegmentComparisonMetrics {
+    segment_count: usize,
+    top_n: usize,
+    global: SegmentVariantMetrics,
+    top_1: SegmentVariantMetrics,
+    top_3_segments: SegmentVariantMetrics,
+    top_5_segments: SegmentVariantMetrics,
+    top_n_segments: SegmentVariantMetrics,
+    all_segments: SegmentVariantMetrics,
+    top_n_connection: MultiSessionConnectionDiagnostics,
+    top_n_rewrite_stability: QueryRewriteStability,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SegmentVariantMetrics {
+    latency_ms: f64,
+    retrieved_session_ids: Vec<String>,
+    recall_at_k: HashMap<usize, f64>,
+    recall_any_at_k: HashMap<usize, f64>,
+    mrr: f64,
+    ndcg_at_10: f64,
+    diagnostics: Option<SegmentQueryDiagnostics>,
+    router_miss: Option<bool>,
+    missing_relevant_segments: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MultiSessionConnectionDiagnostics {
+    selected_sessions: Vec<String>,
+    correct_sessions: Vec<String>,
+    correct_sessions_selected: Vec<String>,
+    shared_terms: Vec<String>,
+    shared_term_count: usize,
+    time_signal: bool,
+    connection_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryRewriteStability {
+    rewrites: Vec<QueryRewriteDiagnostics>,
+    average_selected_session_jaccard: f64,
+    average_local_memory_jaccard: f64,
+    stable_correct_session_coverage: bool,
+    stable_local_memory_evidence: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryRewriteDiagnostics {
+    rewrite: String,
+    selected_sessions: Vec<String>,
+    selected_session_jaccard_with_base: f64,
+    local_memory_jaccard_with_base: f64,
+    correct_sessions_selected: Vec<String>,
+    covered_query_terms: Vec<String>,
+    uncovered_query_terms: Vec<String>,
+    local_memory_terms: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -143,6 +234,9 @@ fn main() -> Result<()> {
         &ks,
         args.text_rerank_ngram,
         args.text_rerank_lcs,
+        args.segment_compare,
+        args.segment_top_n,
+        args.segment_router.into(),
     )?;
     let json = serde_json::to_string_pretty(&report)?;
 
@@ -164,6 +258,9 @@ fn run_scoped_benchmark(
     ks: &[usize],
     text_rerank_ngram: bool,
     text_rerank_lcs: bool,
+    segment_compare: bool,
+    segment_top_n: usize,
+    segment_router: SegmentRoutingStrategy,
 ) -> Result<BenchmarkReport> {
     let abstention_types = HashSet::from([
         "single-session-user_abs".to_string(),
@@ -198,18 +295,31 @@ fn run_scoped_benchmark(
         let query_text = analysis.augmented_query.clone();
         let candidate_session_ids = entry.haystack_session_ids.clone();
         let source_docs = build_scoped_source_docs(&entry);
-        let index = build_query_snapshot_from_source_documents(
-            &source_docs,
-            &Tier1NerProvider::Heuristic,
-            "en_core_web_sm",
-            &Tier1TermRankerKind::Yake,
-            &ChunkStrategy::Heading,
-            40,
-            10,
-            450,
-            800,
+        let options = PipelineOptions {
+            ner_provider: Tier1NerProvider::Heuristic,
+            spacy_model: "en_core_web_sm".to_string(),
+            term_ranker: Tier1TermRankerKind::Yake,
+            chunk_strategy: ChunkStrategy::Heading,
+            chunk_lines: 40,
+            chunk_overlap: 10,
+            chunk_target_tokens: 450,
+            chunk_max_tokens: 800,
             text_rerank_ngram,
             text_rerank_lcs,
+            ..PipelineOptions::default()
+        };
+        let index = build_query_snapshot_from_source_documents(
+            &source_docs,
+            &options.ner_provider,
+            &options.spacy_model,
+            &options.term_ranker,
+            &options.chunk_strategy,
+            options.chunk_lines,
+            options.chunk_overlap,
+            options.chunk_target_tokens,
+            options.chunk_max_tokens,
+            options.text_rerank_ngram,
+            options.text_rerank_lcs,
         )?;
         let temporal = TemporalQueryContext {
             starts_from: None,
@@ -231,6 +341,7 @@ fn run_scoped_benchmark(
         };
         let (results, timings, diagnostics) =
             index.query_with_temporal_context(&query_text, max_k, temporal);
+        let global_results = results.clone();
         let aggregation = build_aggregate_output(&index, &entry.question, &results, max_k);
         assert_group_diversity(&results, 2, &entry.question_id);
         let retrieved_session_ids = results
@@ -256,6 +367,22 @@ fn run_scoped_benchmark(
 
         let mrr = reciprocal_rank(&retrieved_session_ids, &relevant);
         let ndcg_at_10 = ndcg_at_k(&retrieved_session_ids, &relevant, 10);
+        let segment_comparison = if segment_compare {
+            Some(build_segment_comparison(
+                &source_docs,
+                &options,
+                &query_text,
+                max_k,
+                segment_top_n,
+                segment_router,
+                ks,
+                &relevant,
+                timings.total_ms,
+                &global_results,
+            )?)
+        } else {
+            None
+        };
 
         per_query.push(QueryMetrics {
             id: entry.question_id,
@@ -272,6 +399,7 @@ fn run_scoped_benchmark(
             ndcg_at_10,
             timings,
             diagnostics,
+            segment_comparison,
         });
 
         let last = per_query.last().expect("query metrics should exist");
@@ -336,6 +464,444 @@ fn build_scoped_source_docs(entry: &LongMemEvalEntry) -> Vec<SourceDocument> {
         }
     }
     docs
+}
+
+fn build_segment_comparison(
+    source_docs: &[SourceDocument],
+    options: &PipelineOptions,
+    query_text: &str,
+    max_k: usize,
+    segment_top_n: usize,
+    segment_router: SegmentRoutingStrategy,
+    ks: &[usize],
+    relevant: &HashSet<String>,
+    global_latency_ms: f64,
+    global_results: &[SearchResult],
+) -> Result<SegmentComparisonMetrics> {
+    let index_store = build_index_store(source_docs, options)?;
+    let records = index_store
+        .records()
+        .into_iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    let segmented = SegmentedMemoryIndex::from_records_by_group_id(&records);
+    let top_n = segment_top_n.max(1);
+
+    let top_1_start = Instant::now();
+    let top_1 = segmented.query_with_diagnostics_and_strategy(query_text, max_k, 1, segment_router);
+    let top_1_latency_ms = top_1_start.elapsed().as_secs_f64() * 1000.0;
+
+    let top_3_start = Instant::now();
+    let top_3_output =
+        segmented.query_with_diagnostics_and_strategy(query_text, max_k, 3, segment_router);
+    let top_3_latency_ms = top_3_start.elapsed().as_secs_f64() * 1000.0;
+
+    let top_5_start = Instant::now();
+    let top_5_output =
+        segmented.query_with_diagnostics_and_strategy(query_text, max_k, 5, segment_router);
+    let top_5_latency_ms = top_5_start.elapsed().as_secs_f64() * 1000.0;
+
+    let top_n_start = Instant::now();
+    let top_n_output =
+        segmented.query_with_diagnostics_and_strategy(query_text, max_k, top_n, segment_router);
+    let top_n_latency_ms = top_n_start.elapsed().as_secs_f64() * 1000.0;
+    let top_n_connection = connection_diagnostics(&records, &top_n_output.diagnostics, relevant);
+    let top_n_rewrite_stability = rewrite_stability_diagnostics(
+        &segmented,
+        query_text,
+        max_k,
+        top_n,
+        segment_router,
+        relevant,
+        &top_n_output.diagnostics,
+    );
+
+    let all_start = Instant::now();
+    let all_output = segmented.query_all_segments_with_diagnostics(query_text, max_k);
+    let all_latency_ms = all_start.elapsed().as_secs_f64() * 1000.0;
+
+    Ok(SegmentComparisonMetrics {
+        segment_count: segmented.len(),
+        top_n,
+        global: variant_metrics(global_results, global_latency_ms, ks, relevant, None),
+        top_1: variant_metrics(
+            &top_1.results,
+            top_1_latency_ms,
+            ks,
+            relevant,
+            Some(top_1.diagnostics),
+        ),
+        top_3_segments: variant_metrics(
+            &top_3_output.results,
+            top_3_latency_ms,
+            ks,
+            relevant,
+            Some(top_3_output.diagnostics),
+        ),
+        top_5_segments: variant_metrics(
+            &top_5_output.results,
+            top_5_latency_ms,
+            ks,
+            relevant,
+            Some(top_5_output.diagnostics),
+        ),
+        top_n_segments: variant_metrics(
+            &top_n_output.results,
+            top_n_latency_ms,
+            ks,
+            relevant,
+            Some(top_n_output.diagnostics),
+        ),
+        all_segments: variant_metrics(
+            &all_output.results,
+            all_latency_ms,
+            ks,
+            relevant,
+            Some(all_output.diagnostics),
+        ),
+        top_n_connection,
+        top_n_rewrite_stability,
+    })
+}
+
+fn variant_metrics(
+    results: &[SearchResult],
+    latency_ms: f64,
+    ks: &[usize],
+    relevant: &HashSet<String>,
+    diagnostics: Option<SegmentQueryDiagnostics>,
+) -> SegmentVariantMetrics {
+    let retrieved_session_ids = dedupe_preserve_order(
+        results
+            .iter()
+            .map(|result| evaluation_group_id(&result.doc_id))
+            .collect(),
+    );
+    let mut recall_at_k = HashMap::new();
+    let mut recall_any_at_k = HashMap::new();
+    for k in ks {
+        recall_at_k.insert(*k, recall_at_k_fn(&retrieved_session_ids, relevant, *k));
+        recall_any_at_k.insert(*k, recall_any_at_k_fn(&retrieved_session_ids, relevant, *k));
+    }
+    let missing_relevant_segments = diagnostics
+        .as_ref()
+        .map(|diagnostics| {
+            let selected = diagnostics
+                .selected_segments
+                .iter()
+                .map(|route| route.segment_id.as_str())
+                .collect::<HashSet<_>>();
+            let mut missing = relevant
+                .iter()
+                .filter(|segment_id| !selected.contains(segment_id.as_str()))
+                .cloned()
+                .collect::<Vec<_>>();
+            missing.sort();
+            missing
+        })
+        .unwrap_or_default();
+    let router_miss = diagnostics
+        .as_ref()
+        .map(|_| !relevant.is_empty() && !missing_relevant_segments.is_empty());
+
+    SegmentVariantMetrics {
+        latency_ms,
+        mrr: reciprocal_rank(&retrieved_session_ids, relevant),
+        ndcg_at_10: ndcg_at_k(&retrieved_session_ids, relevant, 10),
+        retrieved_session_ids,
+        recall_at_k,
+        recall_any_at_k,
+        diagnostics,
+        router_miss,
+        missing_relevant_segments,
+    }
+}
+
+fn connection_diagnostics(
+    records: &[lint_ai::index::DocRecord],
+    diagnostics: &SegmentQueryDiagnostics,
+    relevant: &HashSet<String>,
+) -> MultiSessionConnectionDiagnostics {
+    let selected_sessions = diagnostics
+        .selected_segments
+        .iter()
+        .map(|route| route.segment_id.clone())
+        .collect::<Vec<_>>();
+    let selected_set = selected_sessions.iter().cloned().collect::<HashSet<_>>();
+    let mut correct_sessions = relevant.iter().cloned().collect::<Vec<_>>();
+    correct_sessions.sort();
+    let mut correct_sessions_selected = correct_sessions
+        .iter()
+        .filter(|session_id| selected_set.contains(*session_id))
+        .cloned()
+        .collect::<Vec<_>>();
+    correct_sessions_selected.sort();
+
+    let mut term_session_counts: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut time_signal = false;
+    for record in records {
+        let Some(session_id) = record.group_id.as_ref() else {
+            continue;
+        };
+        if !selected_set.contains(session_id) {
+            continue;
+        }
+        if record.timestamp.is_some() || !record.temporal_terms.is_empty() {
+            time_signal = true;
+        }
+        for term in record_connection_terms(record) {
+            term_session_counts
+                .entry(term)
+                .or_default()
+                .insert(session_id.clone());
+        }
+    }
+
+    let mut shared_terms = term_session_counts
+        .into_iter()
+        .filter_map(|(term, sessions)| (sessions.len() >= 2).then_some(term))
+        .collect::<Vec<_>>();
+    shared_terms.sort();
+    let shared_term_count = shared_terms.len();
+    shared_terms.truncate(20);
+
+    let mut connection_types = Vec::new();
+    if selected_sessions.len() <= 1 {
+        connection_types.push("single_session".to_string());
+    }
+    if !shared_terms.is_empty() {
+        connection_types.push("shared_terms".to_string());
+    }
+    if time_signal {
+        connection_types.push("temporal_signal".to_string());
+    }
+    if !correct_sessions_selected.is_empty() {
+        connection_types.push("correct_session_overlap".to_string());
+    }
+    if connection_types.is_empty() {
+        connection_types.push("no_obvious_connection".to_string());
+    }
+
+    MultiSessionConnectionDiagnostics {
+        selected_sessions,
+        correct_sessions,
+        correct_sessions_selected,
+        shared_term_count,
+        shared_terms,
+        time_signal,
+        connection_types,
+    }
+}
+
+fn rewrite_stability_diagnostics(
+    segmented: &SegmentedMemoryIndex,
+    query_text: &str,
+    max_k: usize,
+    segment_limit: usize,
+    strategy: SegmentRoutingStrategy,
+    relevant: &HashSet<String>,
+    base_diagnostics: &SegmentQueryDiagnostics,
+) -> QueryRewriteStability {
+    let base_selected = base_diagnostics
+        .selected_segments
+        .iter()
+        .map(|route| route.segment_id.clone())
+        .collect::<Vec<_>>();
+    let base_selected_set = base_selected.iter().cloned().collect::<HashSet<_>>();
+    let base_correct = sorted_intersection(&base_selected_set, relevant);
+    let base_local_memory_terms = local_memory_terms(base_diagnostics)
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let rewrites = query_rewrites(query_text);
+    let mut rewrite_diagnostics = Vec::new();
+    for rewrite in rewrites {
+        let output =
+            segmented.query_with_diagnostics_and_strategy(&rewrite, max_k, segment_limit, strategy);
+        let selected_sessions = output
+            .diagnostics
+            .selected_segments
+            .iter()
+            .map(|route| route.segment_id.clone())
+            .collect::<Vec<_>>();
+        let selected_set = selected_sessions.iter().cloned().collect::<HashSet<_>>();
+        let local_memory_terms = local_memory_terms(&output.diagnostics);
+        let local_memory_set = local_memory_terms.iter().cloned().collect::<HashSet<_>>();
+        rewrite_diagnostics.push(QueryRewriteDiagnostics {
+            rewrite,
+            selected_session_jaccard_with_base: jaccard(&base_selected_set, &selected_set),
+            local_memory_jaccard_with_base: jaccard(&base_local_memory_terms, &local_memory_set),
+            correct_sessions_selected: sorted_intersection(&selected_set, relevant),
+            selected_sessions,
+            covered_query_terms: output.diagnostics.covered_query_terms,
+            uncovered_query_terms: output.diagnostics.uncovered_query_terms,
+            local_memory_terms,
+        });
+    }
+
+    let average_selected_session_jaccard = if rewrite_diagnostics.is_empty() {
+        1.0
+    } else {
+        rewrite_diagnostics
+            .iter()
+            .map(|rewrite| rewrite.selected_session_jaccard_with_base)
+            .sum::<f64>()
+            / rewrite_diagnostics.len() as f64
+    };
+    let average_local_memory_jaccard = if rewrite_diagnostics.is_empty() {
+        1.0
+    } else {
+        rewrite_diagnostics
+            .iter()
+            .map(|rewrite| rewrite.local_memory_jaccard_with_base)
+            .sum::<f64>()
+            / rewrite_diagnostics.len() as f64
+    };
+    let stable_correct_session_coverage = rewrite_diagnostics
+        .iter()
+        .all(|rewrite| rewrite.correct_sessions_selected == base_correct);
+    let stable_local_memory_evidence = rewrite_diagnostics
+        .iter()
+        .all(|rewrite| rewrite.local_memory_jaccard_with_base >= 0.5);
+
+    QueryRewriteStability {
+        rewrites: rewrite_diagnostics,
+        average_selected_session_jaccard,
+        average_local_memory_jaccard,
+        stable_correct_session_coverage,
+        stable_local_memory_evidence,
+    }
+}
+
+fn local_memory_terms(diagnostics: &SegmentQueryDiagnostics) -> Vec<String> {
+    let mut terms = diagnostics
+        .local_evidence
+        .iter()
+        .flat_map(|segment| segment.differentiators.iter())
+        .filter(|differentiator| {
+            differentiator
+                .evidence_types
+                .iter()
+                .any(|evidence_type| evidence_type == "local_memory")
+        })
+        .map(|differentiator| differentiator.term.clone())
+        .collect::<Vec<_>>();
+    terms.sort();
+    terms.dedup();
+    terms
+}
+
+fn record_connection_terms(record: &lint_ai::index::DocRecord) -> HashSet<String> {
+    let mut terms = HashSet::new();
+    for term in &record.important_terms {
+        terms.extend(normalized_tokens(&term.term));
+    }
+    for entity in &record.key_entities {
+        terms.extend(normalized_tokens(&entity.text));
+    }
+    if let Some(topic) = &record.probable_topic {
+        terms.extend(normalized_tokens(topic));
+    }
+    for temporal in &record.temporal_terms {
+        terms.extend(normalized_tokens(temporal));
+    }
+    terms
+}
+
+fn query_rewrites(query: &str) -> Vec<String> {
+    let mut rewrites = Vec::new();
+    push_unique_rewrite(&mut rewrites, query.trim().to_string());
+
+    let keyword_terms = raw_query_terms(query);
+    let keyword_rewrite = keyword_terms.join(" ");
+    push_unique_rewrite(&mut rewrites, keyword_rewrite);
+
+    let mut dropped_one = keyword_terms;
+    if dropped_one.len() > 2 {
+        dropped_one.pop();
+        push_unique_rewrite(&mut rewrites, dropped_one.join(" "));
+    }
+
+    rewrites
+}
+
+fn push_unique_rewrite(rewrites: &mut Vec<String>, rewrite: String) {
+    if !rewrite.is_empty() && !rewrites.iter().any(|existing| existing == &rewrite) {
+        rewrites.push(rewrite);
+    }
+}
+
+fn normalized_tokens(text: &str) -> HashSet<String> {
+    text.split(|ch: char| !ch.is_alphanumeric())
+        .map(normalize_for_index)
+        .filter(|token| token.len() > 1)
+        .filter(|token| !is_query_stopword(token))
+        .collect()
+}
+
+fn raw_query_terms(text: &str) -> Vec<String> {
+    let mut terms = text
+        .split(|ch: char| !ch.is_alphanumeric())
+        .map(|token| token.to_lowercase())
+        .filter(|token| token.len() > 1)
+        .filter(|token| !is_query_stopword(token))
+        .collect::<Vec<_>>();
+    terms.sort();
+    terms.dedup();
+    terms
+}
+
+fn is_query_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "a" | "an"
+            | "and"
+            | "are"
+            | "can"
+            | "did"
+            | "do"
+            | "does"
+            | "for"
+            | "from"
+            | "i"
+            | "in"
+            | "is"
+            | "it"
+            | "me"
+            | "my"
+            | "of"
+            | "on"
+            | "or"
+            | "that"
+            | "the"
+            | "to"
+            | "was"
+            | "what"
+            | "when"
+            | "where"
+            | "which"
+            | "who"
+            | "with"
+            | "you"
+    )
+}
+
+fn sorted_intersection(left: &HashSet<String>, right: &HashSet<String>) -> Vec<String> {
+    let mut out = left.intersection(right).cloned().collect::<Vec<String>>();
+    out.sort();
+    out
+}
+
+fn jaccard(left: &HashSet<String>, right: &HashSet<String>) -> f64 {
+    if left.is_empty() && right.is_empty() {
+        return 1.0;
+    }
+    let intersection = left.intersection(right).count();
+    let union = left.union(right).count();
+    if union == 0 {
+        1.0
+    } else {
+        intersection as f64 / union as f64
+    }
 }
 
 fn evaluation_group_id(doc_id: &str) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod query_semantics;
 pub mod report;
 pub mod review;
 pub mod rules;
+pub mod segments;
 pub mod source;
 pub mod symbols;
 pub mod temporal;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -727,13 +727,14 @@ impl IndexStore {
         let semantic_aggregate = self.semantic_aggregate.clone();
         let text_rerank_ngram = self.options.text_rerank_ngram;
         let text_rerank_lcs = self.options.text_rerank_lcs;
+        let claim_extraction = self.options.claim_extraction;
         thread::spawn(move || {
             let _ = sender.send(Ok(MemoryIndex::from_records_with_semantic_aggregate(
                 records,
                 semantic_aggregate,
                 text_rerank_ngram,
                 text_rerank_lcs,
-                false,
+                claim_extraction,
             )));
         });
         self.background_refresh = Some(BackgroundRefresh {

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -1,0 +1,1099 @@
+use crate::index::{DocRecord, MemoryIndex, SearchResult};
+use crate::query_expansion::normalize_for_index;
+use serde::Serialize;
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+
+const KL_SMOOTHING: f32 = 1.0e-6;
+const LOCAL_IDF_FLOOR: f32 = 1.0;
+const LOCAL_MEMORY_DECAY: f32 = 0.82;
+const LOCAL_MEMORY_PRUNE_BELOW: f32 = 0.015;
+const LOCAL_MEMORY_BASE_SIGNAL: f32 = 0.04;
+const LOCAL_MEMORY_IMPORTANT_TERM_WEIGHT: f32 = 1.0;
+const LOCAL_MEMORY_ENTITY_WEIGHT: f32 = 1.4;
+const LOCAL_MEMORY_TOPIC_WEIGHT: f32 = 0.8;
+const LOCAL_MEMORY_NEARBY_REINFORCEMENT: f32 = 0.08;
+const LOCAL_MEMORY_PROFILE_WEIGHT: f32 = 0.35;
+const LOCAL_MEMORY_RECORD_TERM_LIMIT: usize = 24;
+const LOCAL_MEMORY_SEGMENT_TERM_LIMIT: usize = 96;
+
+pub struct MemoryIndexSegment {
+    pub segment_id: String,
+    pub doc_ids: Vec<String>,
+    pub profile: SegmentProfile,
+    pub index: MemoryIndex,
+}
+
+pub struct SegmentedMemoryIndex {
+    pub segments: Vec<MemoryIndexSegment>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SegmentProfile {
+    pub terms: HashMap<String, f32>,
+    pub entities: HashMap<String, f32>,
+    pub topics: HashMap<String, f32>,
+    pub local_memory: HashMap<String, f32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SegmentRoute {
+    pub segment_id: String,
+    pub score: f32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SegmentLocalEvidence {
+    pub segment_id: String,
+    pub differentiators: Vec<LocalDifferentiator>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LocalDifferentiator {
+    pub term: String,
+    pub weight: f32,
+    pub evidence_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SegmentQueryDiagnostics {
+    pub selected_segments: Vec<SegmentRoute>,
+    pub local_evidence: Vec<SegmentLocalEvidence>,
+    pub queried_segment_count: usize,
+    pub per_segment_result_counts: HashMap<String, usize>,
+    pub merged_result_count: usize,
+    pub final_result_count: usize,
+    pub query_terms: Vec<String>,
+    pub covered_query_terms: Vec<String>,
+    pub uncovered_query_terms: Vec<String>,
+    pub segments_with_results: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SegmentQueryOutput {
+    pub results: Vec<SearchResult>,
+    pub diagnostics: SegmentQueryDiagnostics,
+}
+
+impl SegmentedMemoryIndex {
+    pub fn from_segments(segments: Vec<MemoryIndexSegment>) -> Self {
+        Self { segments }
+    }
+
+    pub fn from_records_by_group_id(records: &[DocRecord]) -> Self {
+        Self {
+            segments: build_segments_by_group_id(records),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.segments.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    pub fn route(&self, query: &str) -> Vec<SegmentRoute> {
+        route_segments(query, &self.segments)
+    }
+
+    pub fn route_with_strategy(
+        &self,
+        query: &str,
+        strategy: SegmentRoutingStrategy,
+    ) -> Vec<SegmentRoute> {
+        route_segments_with_strategy(query, &self.segments, strategy)
+    }
+
+    pub fn query(&self, query: &str, top_k: usize, segment_limit: usize) -> Vec<SearchResult> {
+        self.query_with_diagnostics(query, top_k, segment_limit)
+            .results
+    }
+
+    pub fn query_with_diagnostics(
+        &self,
+        query: &str,
+        top_k: usize,
+        segment_limit: usize,
+    ) -> SegmentQueryOutput {
+        query_top_segments_with_diagnostics(query, top_k, &self.segments, segment_limit)
+    }
+
+    pub fn query_with_diagnostics_and_strategy(
+        &self,
+        query: &str,
+        top_k: usize,
+        segment_limit: usize,
+        strategy: SegmentRoutingStrategy,
+    ) -> SegmentQueryOutput {
+        query_top_segments_with_diagnostics_and_strategy(
+            query,
+            top_k,
+            &self.segments,
+            segment_limit,
+            strategy,
+        )
+    }
+
+    pub fn query_all_segments(&self, query: &str, top_k: usize) -> Vec<SearchResult> {
+        self.query_all_segments_with_diagnostics(query, top_k)
+            .results
+    }
+
+    pub fn query_all_segments_with_diagnostics(
+        &self,
+        query: &str,
+        top_k: usize,
+    ) -> SegmentQueryOutput {
+        query_all_segments_with_diagnostics(query, top_k, &self.segments)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SegmentRoutingStrategy {
+    SparseOverlap,
+    KlDivergence,
+    LocalDistinctiveness,
+}
+
+pub fn build_segments_by_group_id(records: &[DocRecord]) -> Vec<MemoryIndexSegment> {
+    let mut grouped: HashMap<String, Vec<DocRecord>> = HashMap::new();
+    for record in records {
+        let segment_id = record
+            .group_id
+            .clone()
+            .unwrap_or_else(|| "ungrouped".to_string());
+        grouped.entry(segment_id).or_default().push(record.clone());
+    }
+
+    let mut segments = grouped
+        .into_iter()
+        .map(|(segment_id, mut segment_records)| {
+            segment_records.sort_by(|a, b| a.doc_id.cmp(&b.doc_id));
+            let doc_ids = segment_records
+                .iter()
+                .map(|record| record.doc_id.clone())
+                .collect::<Vec<_>>();
+            let profile = SegmentProfile::from_records(&segment_records);
+            let index = MemoryIndex::from_records(segment_records);
+            MemoryIndexSegment {
+                segment_id,
+                doc_ids,
+                profile,
+                index,
+            }
+        })
+        .collect::<Vec<_>>();
+    segments.sort_by(|a, b| a.segment_id.cmp(&b.segment_id));
+    segments
+}
+
+pub fn route_segments(query: &str, segments: &[MemoryIndexSegment]) -> Vec<SegmentRoute> {
+    route_segments_with_strategy(query, segments, SegmentRoutingStrategy::SparseOverlap)
+}
+
+pub fn route_segments_with_strategy(
+    query: &str,
+    segments: &[MemoryIndexSegment],
+    strategy: SegmentRoutingStrategy,
+) -> Vec<SegmentRoute> {
+    let query_terms = query_tokens(query);
+    let corpus_stats = SegmentCorpusStats::from_segments(segments);
+    let mut routes = segments
+        .iter()
+        .map(|segment| SegmentRoute {
+            segment_id: segment.segment_id.clone(),
+            score: segment.profile.score_query_terms_with_strategy(
+                &query_terms,
+                strategy,
+                &corpus_stats,
+            ),
+        })
+        .collect::<Vec<_>>();
+    routes.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.segment_id.cmp(&b.segment_id))
+    });
+    routes
+}
+
+pub fn query_top_segment(
+    query: &str,
+    top_k: usize,
+    segments: &[MemoryIndexSegment],
+) -> Vec<SearchResult> {
+    query_top_segments(query, top_k, segments, 1)
+}
+
+pub fn query_top_segments(
+    query: &str,
+    top_k: usize,
+    segments: &[MemoryIndexSegment],
+    segment_limit: usize,
+) -> Vec<SearchResult> {
+    query_top_segments_with_diagnostics(query, top_k, segments, segment_limit).results
+}
+
+pub fn query_all_segments(
+    query: &str,
+    top_k: usize,
+    segments: &[MemoryIndexSegment],
+) -> Vec<SearchResult> {
+    query_top_segments(query, top_k, segments, segments.len())
+}
+
+pub fn query_top_segments_with_diagnostics(
+    query: &str,
+    top_k: usize,
+    segments: &[MemoryIndexSegment],
+    segment_limit: usize,
+) -> SegmentQueryOutput {
+    query_top_segments_with_diagnostics_and_strategy(
+        query,
+        top_k,
+        segments,
+        segment_limit,
+        SegmentRoutingStrategy::SparseOverlap,
+    )
+}
+
+pub fn query_top_segments_with_diagnostics_and_strategy(
+    query: &str,
+    top_k: usize,
+    segments: &[MemoryIndexSegment],
+    segment_limit: usize,
+    strategy: SegmentRoutingStrategy,
+) -> SegmentQueryOutput {
+    let query_terms = query_tokens(query);
+    if top_k == 0 || segment_limit == 0 {
+        return SegmentQueryOutput {
+            results: Vec::new(),
+            diagnostics: SegmentQueryDiagnostics {
+                query_terms: sorted_terms(&query_terms),
+                uncovered_query_terms: sorted_terms(&query_terms),
+                ..SegmentQueryDiagnostics::default()
+            },
+        };
+    }
+
+    let routes = route_segments_with_strategy(query, segments, strategy);
+    let selected_segments = routes
+        .iter()
+        .take(segment_limit)
+        .cloned()
+        .collect::<Vec<_>>();
+    let local_evidence = selected_segments
+        .iter()
+        .filter_map(|route| {
+            segments
+                .iter()
+                .find(|segment| segment.segment_id == route.segment_id)
+                .map(|segment| segment.local_evidence(&query_terms, segments))
+        })
+        .collect::<Vec<_>>();
+    let mut merged = Vec::new();
+    let mut seen_doc_ids = HashSet::new();
+    let mut per_segment_result_counts = HashMap::new();
+    let mut queried_segment_count = 0usize;
+    let mut segments_with_results = Vec::new();
+    let mut covered_query_terms = HashSet::new();
+    for route in selected_segments.iter() {
+        let Some(segment) = segments
+            .iter()
+            .find(|segment| segment.segment_id == route.segment_id)
+        else {
+            continue;
+        };
+        queried_segment_count += 1;
+        for term in &query_terms {
+            if segment.profile.covers_term(term) {
+                covered_query_terms.insert(term.clone());
+            }
+        }
+        let mut segment_results = 0usize;
+        for result in segment.index.query(query, top_k) {
+            if seen_doc_ids.insert(result.doc_id.clone()) {
+                segment_results += 1;
+                merged.push(result);
+            }
+        }
+        if segment_results > 0 {
+            segments_with_results.push(segment.segment_id.clone());
+        }
+        per_segment_result_counts.insert(segment.segment_id.clone(), segment_results);
+    }
+
+    merged.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.doc_id.cmp(&b.doc_id))
+    });
+    let merged_result_count = merged.len();
+    merged.truncate(top_k);
+    let final_result_count = merged.len();
+    let uncovered_query_terms = query_terms
+        .difference(&covered_query_terms)
+        .cloned()
+        .collect::<HashSet<_>>();
+    SegmentQueryOutput {
+        results: merged,
+        diagnostics: SegmentQueryDiagnostics {
+            selected_segments,
+            local_evidence,
+            queried_segment_count,
+            per_segment_result_counts,
+            merged_result_count,
+            final_result_count,
+            query_terms: sorted_terms(&query_terms),
+            covered_query_terms: sorted_terms(&covered_query_terms),
+            uncovered_query_terms: sorted_terms(&uncovered_query_terms),
+            segments_with_results,
+        },
+    }
+}
+
+pub fn query_all_segments_with_diagnostics(
+    query: &str,
+    top_k: usize,
+    segments: &[MemoryIndexSegment],
+) -> SegmentQueryOutput {
+    query_top_segments_with_diagnostics(query, top_k, segments, segments.len())
+}
+
+impl SegmentProfile {
+    pub fn from_records(records: &[DocRecord]) -> Self {
+        let mut profile = Self::default();
+        for record in records {
+            for term in &record.important_terms {
+                add_weight(&mut profile.terms, &term.term, term.score.max(0.1));
+            }
+            for entity in &record.key_entities {
+                add_weight(
+                    &mut profile.entities,
+                    &entity.text,
+                    entity.score.unwrap_or(1.0),
+                );
+            }
+            if let Some(topic) = &record.probable_topic {
+                add_weight(&mut profile.topics, topic, 1.0);
+            }
+            merge_distribution(
+                &mut profile.local_memory,
+                &gated_local_memory_profile(record),
+                LOCAL_MEMORY_PROFILE_WEIGHT,
+            );
+        }
+        normalize_distribution(&mut profile.terms);
+        normalize_distribution(&mut profile.entities);
+        normalize_distribution(&mut profile.topics);
+        normalize_distribution(&mut profile.local_memory);
+        retain_top_terms(&mut profile.local_memory, LOCAL_MEMORY_SEGMENT_TERM_LIMIT);
+        normalize_distribution(&mut profile.local_memory);
+        profile
+    }
+
+    fn score_query_terms_with_strategy(
+        &self,
+        query_terms: &HashSet<String>,
+        strategy: SegmentRoutingStrategy,
+        corpus_stats: &SegmentCorpusStats,
+    ) -> f32 {
+        match strategy {
+            SegmentRoutingStrategy::SparseOverlap => self.sparse_overlap_score(query_terms),
+            SegmentRoutingStrategy::KlDivergence => self.kl_divergence_score(query_terms),
+            SegmentRoutingStrategy::LocalDistinctiveness => {
+                self.local_distinctiveness_score(query_terms, corpus_stats)
+            }
+        }
+    }
+
+    fn sparse_overlap_score(&self, query_terms: &HashSet<String>) -> f32 {
+        if query_terms.is_empty() {
+            return 0.0;
+        }
+        let term_score = overlap_score(query_terms, &self.terms);
+        let entity_score = overlap_score(query_terms, &self.entities);
+        let topic_score = overlap_score(query_terms, &self.topics);
+        term_score + (1.3 * entity_score) + (0.7 * topic_score)
+    }
+
+    fn kl_divergence_score(&self, query_terms: &HashSet<String>) -> f32 {
+        if query_terms.is_empty() {
+            return 0.0;
+        }
+
+        let segment_distribution = self.combined_distribution();
+        if segment_distribution.is_empty() {
+            return -f32::INFINITY;
+        }
+
+        let query_probability = 1.0 / query_terms.len() as f32;
+        let divergence = query_terms
+            .iter()
+            .map(|term| {
+                let segment_probability = segment_distribution
+                    .get(term)
+                    .copied()
+                    .unwrap_or(KL_SMOOTHING)
+                    .max(KL_SMOOTHING);
+                query_probability * (query_probability / segment_probability).ln()
+            })
+            .sum::<f32>();
+
+        -divergence
+    }
+
+    fn local_distinctiveness_score(
+        &self,
+        query_terms: &HashSet<String>,
+        corpus_stats: &SegmentCorpusStats,
+    ) -> f32 {
+        if query_terms.is_empty() {
+            return 0.0;
+        }
+
+        let mut score = 0.0;
+        for term in query_terms {
+            let local_weight = self.local_term_weight(term);
+            if local_weight <= 0.0 {
+                continue;
+            }
+            score += local_weight * corpus_stats.idf(term);
+        }
+        score
+    }
+
+    fn combined_distribution(&self) -> HashMap<String, f32> {
+        let mut combined = HashMap::new();
+        merge_distribution(&mut combined, &self.terms, 1.0);
+        merge_distribution(&mut combined, &self.entities, 1.3);
+        merge_distribution(&mut combined, &self.topics, 0.7);
+        merge_distribution(&mut combined, &self.local_memory, 0.5);
+        normalize_distribution(&mut combined);
+        combined
+    }
+
+    fn covers_term(&self, term: &str) -> bool {
+        self.terms.contains_key(term)
+            || self.entities.contains_key(term)
+            || self.topics.contains_key(term)
+            || self.local_memory.contains_key(term)
+    }
+
+    fn local_term_weight(&self, term: &str) -> f32 {
+        let term_weight = self.terms.get(term).copied().unwrap_or_default();
+        let entity_weight = self.entities.get(term).copied().unwrap_or_default() * 1.8;
+        let topic_weight = self.topics.get(term).copied().unwrap_or_default() * 1.2;
+        let local_memory_weight = self.local_memory.get(term).copied().unwrap_or_default() * 1.5;
+        term_weight + entity_weight + topic_weight + local_memory_weight
+    }
+
+    fn evidence_types_for_term(&self, term: &str) -> Vec<String> {
+        let mut evidence_types = Vec::new();
+        if self.entities.contains_key(term) {
+            evidence_types.push("entity".to_string());
+        }
+        if self.terms.contains_key(term) {
+            evidence_types.push("term".to_string());
+        }
+        if self.topics.contains_key(term) {
+            evidence_types.push("topic".to_string());
+        }
+        if self.local_memory.contains_key(term) {
+            evidence_types.push("local_memory".to_string());
+        }
+        evidence_types
+    }
+}
+
+impl MemoryIndexSegment {
+    fn local_evidence(
+        &self,
+        query_terms: &HashSet<String>,
+        segments: &[MemoryIndexSegment],
+    ) -> SegmentLocalEvidence {
+        let corpus_stats = SegmentCorpusStats::from_segments(segments);
+        let mut differentiators = query_terms
+            .iter()
+            .filter_map(|term| {
+                let local_weight = self.profile.local_term_weight(term);
+                (local_weight > 0.0).then(|| LocalDifferentiator {
+                    term: term.clone(),
+                    weight: local_weight * corpus_stats.idf(term),
+                    evidence_types: self.profile.evidence_types_for_term(term),
+                })
+            })
+            .collect::<Vec<_>>();
+        differentiators.sort_by(|a, b| {
+            b.weight
+                .partial_cmp(&a.weight)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.term.cmp(&b.term))
+        });
+        differentiators.truncate(8);
+        SegmentLocalEvidence {
+            segment_id: self.segment_id.clone(),
+            differentiators,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SegmentCorpusStats {
+    segment_count: usize,
+    term_segment_counts: HashMap<String, usize>,
+}
+
+impl SegmentCorpusStats {
+    fn from_segments(segments: &[MemoryIndexSegment]) -> Self {
+        let mut term_segment_counts = HashMap::new();
+        for segment in segments {
+            let mut segment_terms = HashSet::new();
+            segment_terms.extend(segment.profile.terms.keys().cloned());
+            segment_terms.extend(segment.profile.entities.keys().cloned());
+            segment_terms.extend(segment.profile.topics.keys().cloned());
+            segment_terms.extend(segment.profile.local_memory.keys().cloned());
+            for term in segment_terms {
+                *term_segment_counts.entry(term).or_default() += 1;
+            }
+        }
+        Self {
+            segment_count: segments.len(),
+            term_segment_counts,
+        }
+    }
+
+    fn idf(&self, term: &str) -> f32 {
+        let segment_count = self.segment_count as f32;
+        if segment_count <= 0.0 {
+            return LOCAL_IDF_FLOOR;
+        }
+        let containing_segments = self
+            .term_segment_counts
+            .get(term)
+            .copied()
+            .unwrap_or_default() as f32;
+        ((segment_count + 1.0) / (containing_segments + 1.0)).ln() + LOCAL_IDF_FLOOR
+    }
+}
+
+fn query_tokens(query: &str) -> HashSet<String> {
+    query
+        .split(|ch: char| !ch.is_alphanumeric())
+        .map(normalize_for_index)
+        .filter(|token| token.len() > 1)
+        .filter(|token| !is_routing_stopword(token))
+        .collect()
+}
+
+fn add_weight(distribution: &mut HashMap<String, f32>, text: &str, weight: f32) {
+    for token in query_tokens(text) {
+        *distribution.entry(token).or_default() += weight;
+    }
+}
+
+fn gated_local_memory_profile(record: &DocRecord) -> HashMap<String, f32> {
+    let important_terms = weighted_terms(
+        record
+            .important_terms
+            .iter()
+            .map(|term| (term.term.as_str(), term.score.max(0.1))),
+    );
+    let entity_terms = weighted_terms(
+        record
+            .key_entities
+            .iter()
+            .map(|entity| (entity.text.as_str(), entity.score.unwrap_or(1.0))),
+    );
+    let topic_terms = record
+        .probable_topic
+        .as_deref()
+        .map(|topic| weighted_terms(std::iter::once((topic, 1.0))))
+        .unwrap_or_default();
+
+    let mut active_memory: HashMap<String, f32> = HashMap::new();
+    let mut retained_memory: HashMap<String, f32> = HashMap::new();
+    for token in ordered_tokens(&record.content) {
+        for value in active_memory.values_mut() {
+            *value *= LOCAL_MEMORY_DECAY;
+        }
+        active_memory.retain(|_, value| *value >= LOCAL_MEMORY_PRUNE_BELOW);
+
+        let importance = LOCAL_MEMORY_BASE_SIGNAL
+            + important_terms.get(&token).copied().unwrap_or_default()
+                * LOCAL_MEMORY_IMPORTANT_TERM_WEIGHT
+            + entity_terms.get(&token).copied().unwrap_or_default() * LOCAL_MEMORY_ENTITY_WEIGHT
+            + topic_terms.get(&token).copied().unwrap_or_default() * LOCAL_MEMORY_TOPIC_WEIGHT;
+
+        if importance > LOCAL_MEMORY_BASE_SIGNAL {
+            for value in active_memory.values_mut() {
+                *value += importance * LOCAL_MEMORY_NEARBY_REINFORCEMENT;
+            }
+        }
+
+        *active_memory.entry(token).or_default() += importance;
+        for (active_token, value) in &active_memory {
+            *retained_memory.entry(active_token.clone()).or_default() += *value;
+        }
+    }
+
+    normalize_distribution(&mut retained_memory);
+    retain_top_terms(&mut retained_memory, LOCAL_MEMORY_RECORD_TERM_LIMIT);
+    normalize_distribution(&mut retained_memory);
+    retained_memory
+}
+
+fn weighted_terms<'a>(terms: impl Iterator<Item = (&'a str, f32)>) -> HashMap<String, f32> {
+    let mut weights = HashMap::new();
+    for (text, weight) in terms {
+        for token in query_tokens(text) {
+            *weights.entry(token).or_default() += weight;
+        }
+    }
+    weights
+}
+
+fn ordered_tokens(text: &str) -> Vec<String> {
+    text.split(|ch: char| !ch.is_alphanumeric())
+        .map(normalize_for_index)
+        .filter(|token| token.len() > 1)
+        .filter(|token| !is_routing_stopword(token))
+        .collect()
+}
+
+fn normalize_distribution(distribution: &mut HashMap<String, f32>) {
+    let total = distribution.values().copied().sum::<f32>();
+    if total <= f32::EPSILON {
+        return;
+    }
+    for value in distribution.values_mut() {
+        *value /= total;
+    }
+}
+
+fn retain_top_terms(distribution: &mut HashMap<String, f32>, limit: usize) {
+    if distribution.len() <= limit {
+        return;
+    }
+    let mut ranked = distribution
+        .iter()
+        .map(|(term, weight)| (term.clone(), *weight))
+        .collect::<Vec<_>>();
+    ranked.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+    let keep = ranked
+        .into_iter()
+        .take(limit)
+        .map(|(term, _)| term)
+        .collect::<HashSet<_>>();
+    distribution.retain(|term, _| keep.contains(term));
+}
+
+fn overlap_score(query_terms: &HashSet<String>, distribution: &HashMap<String, f32>) -> f32 {
+    query_terms
+        .iter()
+        .filter_map(|term| distribution.get(term))
+        .copied()
+        .sum()
+}
+
+fn merge_distribution(
+    target: &mut HashMap<String, f32>,
+    source: &HashMap<String, f32>,
+    weight: f32,
+) {
+    for (term, value) in source {
+        *target.entry(term.clone()).or_default() += value * weight;
+    }
+}
+
+fn sorted_terms(terms: &HashSet<String>) -> Vec<String> {
+    let mut out = terms.iter().cloned().collect::<Vec<_>>();
+    out.sort();
+    out
+}
+
+fn is_routing_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "a" | "an"
+            | "and"
+            | "are"
+            | "can"
+            | "did"
+            | "do"
+            | "doe"
+            | "for"
+            | "from"
+            | "had"
+            | "have"
+            | "how"
+            | "i"
+            | "in"
+            | "is"
+            | "it"
+            | "many"
+            | "mani"
+            | "me"
+            | "my"
+            | "of"
+            | "on"
+            | "or"
+            | "that"
+            | "the"
+            | "thi"
+            | "this"
+            | "to"
+            | "wa"
+            | "what"
+            | "when"
+            | "where"
+            | "which"
+            | "who"
+            | "with"
+            | "you"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::{DocRecord, Provenance};
+    use crate::tier1::{RankedTerm, Tier1Entity};
+
+    fn record(doc_id: &str, group_id: &str, content: &str, terms: &[&str]) -> DocRecord {
+        DocRecord {
+            doc_id: doc_id.to_string(),
+            source: format!("memory://{doc_id}"),
+            content: content.to_string(),
+            timestamp: None,
+            doc_length: content.len(),
+            author_agent: None,
+            group_id: Some(group_id.to_string()),
+            filters: std::collections::BTreeMap::new(),
+            probable_topic: terms.first().map(|term| (*term).to_string()),
+            doc_type_guess: None,
+            headings: vec![group_id.to_string()],
+            doc_links: vec![],
+            temporal_terms: vec![],
+            key_entities: terms
+                .iter()
+                .map(|term| Tier1Entity {
+                    text: (*term).to_string(),
+                    label: "KEY".to_string(),
+                    start: 0,
+                    end: term.len(),
+                    score: Some(1.0),
+                    source: "test".to_string(),
+                })
+                .collect(),
+            important_terms: terms
+                .iter()
+                .map(|term| RankedTerm {
+                    term: (*term).to_string(),
+                    score: 1.0,
+                    source: "test".to_string(),
+                })
+                .collect(),
+            section_chunks: vec![],
+            embedding: None,
+            top_claims: vec![],
+            provenance: Provenance {
+                source: "test".to_string(),
+                timestamp: None,
+                ner_provider: "test".to_string(),
+                term_ranker: "test".to_string(),
+                index_version: "test".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn routes_and_queries_one_group_segment() {
+        let records = vec![
+            record(
+                "doc-a",
+                "session-a",
+                "docker install guide for linux",
+                &["docker", "install", "linux"],
+            ),
+            record(
+                "doc-b",
+                "session-b",
+                "kubernetes cluster operations",
+                &["kubernetes", "cluster"],
+            ),
+        ];
+        let segments = build_segments_by_group_id(&records);
+
+        assert_eq!(segments.len(), 2);
+        let routes = route_segments("docker install", &segments);
+        assert_eq!(routes[0].segment_id, "session-a");
+
+        let results = query_top_segment("docker install", 5, &segments);
+        assert!(!results.is_empty());
+        assert_eq!(results[0].doc_id, "doc-a");
+    }
+
+    #[test]
+    fn queries_top_n_segments_and_merges_results() {
+        let records = vec![
+            record(
+                "doc-a",
+                "session-a",
+                "docker install guide for linux",
+                &["docker", "install", "linux"],
+            ),
+            record(
+                "doc-b",
+                "session-b",
+                "docker compose troubleshooting",
+                &["docker", "compose", "troubleshooting"],
+            ),
+            record(
+                "doc-c",
+                "session-c",
+                "kubernetes cluster operations",
+                &["kubernetes", "cluster"],
+            ),
+        ];
+        let segments = build_segments_by_group_id(&records);
+
+        let one_segment = query_top_segments("docker", 5, &segments, 1);
+        assert_eq!(one_segment.len(), 1);
+
+        let two_segments = query_top_segments("docker", 5, &segments, 2);
+        let doc_ids = two_segments
+            .iter()
+            .map(|result| result.doc_id.as_str())
+            .collect::<HashSet<_>>();
+        assert_eq!(two_segments.len(), 2);
+        assert!(doc_ids.contains("doc-a"));
+        assert!(doc_ids.contains("doc-b"));
+        assert!(!doc_ids.contains("doc-c"));
+    }
+
+    #[test]
+    fn segmented_memory_index_returns_diagnostics() {
+        let records = vec![
+            record(
+                "doc-a",
+                "session-a",
+                "docker install guide for linux",
+                &["docker", "install", "linux"],
+            ),
+            record(
+                "doc-b",
+                "session-b",
+                "kubernetes cluster operations",
+                &["kubernetes", "cluster"],
+            ),
+        ];
+        let segmented = SegmentedMemoryIndex::from_records_by_group_id(&records);
+
+        assert_eq!(segmented.len(), 2);
+        let routes = segmented.route("docker install");
+        assert_eq!(routes[0].segment_id, "session-a");
+
+        let output = segmented.query_with_diagnostics("docker install", 5, 1);
+        assert_eq!(output.diagnostics.queried_segment_count, 1);
+        assert_eq!(
+            output.diagnostics.selected_segments[0].segment_id,
+            "session-a"
+        );
+        assert_eq!(output.diagnostics.final_result_count, output.results.len());
+        assert!(output.diagnostics.merged_result_count >= output.diagnostics.final_result_count);
+        assert_eq!(
+            output
+                .diagnostics
+                .per_segment_result_counts
+                .get("session-a")
+                .copied(),
+            Some(output.results.len())
+        );
+        assert_eq!(
+            output.diagnostics.query_terms,
+            vec!["docker".to_string(), "instal".to_string()]
+        );
+        assert_eq!(
+            output.diagnostics.covered_query_terms,
+            vec!["docker".to_string(), "instal".to_string()]
+        );
+        assert!(output.diagnostics.uncovered_query_terms.is_empty());
+        assert_eq!(
+            output.diagnostics.segments_with_results,
+            vec!["session-a".to_string()]
+        );
+    }
+
+    #[test]
+    fn diagnostics_report_query_coverage_across_more_segments() {
+        let records = vec![
+            record("doc-a", "session-a", "docker install guide", &["docker"]),
+            record(
+                "doc-b",
+                "session-b",
+                "compose troubleshooting guide",
+                &["compose"],
+            ),
+            record(
+                "doc-c",
+                "session-c",
+                "kubernetes cluster operations",
+                &["kubernetes"],
+            ),
+        ];
+        let segmented = SegmentedMemoryIndex::from_records_by_group_id(&records);
+
+        let top_one = segmented.query_with_diagnostics("docker compose", 5, 1);
+        assert_eq!(
+            top_one.diagnostics.covered_query_terms,
+            vec!["docker".to_string()]
+        );
+        assert_eq!(
+            top_one.diagnostics.uncovered_query_terms,
+            vec!["compos".to_string()]
+        );
+        assert_eq!(
+            top_one.diagnostics.segments_with_results,
+            vec!["session-a".to_string()]
+        );
+
+        let top_two = segmented.query_with_diagnostics("docker compose", 5, 2);
+        assert_eq!(
+            top_two.diagnostics.covered_query_terms,
+            vec!["compos".to_string(), "docker".to_string()]
+        );
+        assert!(top_two.diagnostics.uncovered_query_terms.is_empty());
+        assert_eq!(
+            top_two.diagnostics.segments_with_results,
+            vec!["session-a".to_string(), "session-b".to_string()]
+        );
+    }
+
+    #[test]
+    fn kl_router_prefers_closest_segment_distribution() {
+        let records = vec![
+            record(
+                "doc-a",
+                "session-a",
+                "docker compose install troubleshooting",
+                &["docker", "compose", "install"],
+            ),
+            record(
+                "doc-b",
+                "session-b",
+                "kubernetes cluster node scheduling",
+                &["kubernetes", "cluster", "node"],
+            ),
+        ];
+        let segments = build_segments_by_group_id(&records);
+
+        let routes = route_segments_with_strategy(
+            "docker compose",
+            &segments,
+            SegmentRoutingStrategy::KlDivergence,
+        );
+
+        assert_eq!(routes[0].segment_id, "session-a");
+        assert!(routes[0].score > routes[1].score);
+    }
+
+    #[test]
+    fn local_router_prefers_segment_specific_differentiators() {
+        let records = vec![
+            record(
+                "doc-a",
+                "session-a",
+                "general study planning notes",
+                &["study", "notes", "planning"],
+            ),
+            record(
+                "doc-b",
+                "session-b",
+                "undergraduate graduate GPA transcript",
+                &["study", "undergraduate", "graduate", "GPA"],
+            ),
+            record(
+                "doc-c",
+                "session-c",
+                "study schedule and reading list",
+                &["study", "schedule", "reading"],
+            ),
+        ];
+        let segmented = SegmentedMemoryIndex::from_records_by_group_id(&records);
+
+        let output = segmented.query_with_diagnostics_and_strategy(
+            "what is my average GPA from undergraduate and graduate studies",
+            5,
+            1,
+            SegmentRoutingStrategy::LocalDistinctiveness,
+        );
+
+        assert_eq!(
+            output.diagnostics.selected_segments[0].segment_id,
+            "session-b"
+        );
+        let local_terms = output.diagnostics.local_evidence[0]
+            .differentiators
+            .iter()
+            .map(|differentiator| differentiator.term.as_str())
+            .collect::<HashSet<_>>();
+        assert!(local_terms.contains("gpa"));
+        assert!(local_terms.contains("undergradu"));
+        assert!(local_terms.contains("graduat"));
+        assert!(!output.diagnostics.query_terms.contains(&"what".to_string()));
+        assert!(!output.diagnostics.query_terms.contains(&"my".to_string()));
+    }
+
+    #[test]
+    fn local_memory_router_uses_rolling_content_window() {
+        let records = vec![
+            record(
+                "doc-a",
+                "session-a",
+                "the day before my doctor appointment I went to bed early",
+                &["appointment"],
+            ),
+            record(
+                "doc-b",
+                "session-b",
+                "appointment calendar reminder and scheduling notes",
+                &["appointment"],
+            ),
+        ];
+        let segmented = SegmentedMemoryIndex::from_records_by_group_id(&records);
+
+        let output = segmented.query_with_diagnostics_and_strategy(
+            "what time did I go to bed on the day before the doctor appointment",
+            5,
+            1,
+            SegmentRoutingStrategy::LocalDistinctiveness,
+        );
+
+        assert_eq!(
+            output.diagnostics.selected_segments[0].segment_id,
+            "session-a"
+        );
+        let local_evidence = &output.diagnostics.local_evidence[0].differentiators;
+        assert!(local_evidence
+            .iter()
+            .any(|differentiator| differentiator.term == "bed"
+                && differentiator
+                    .evidence_types
+                    .contains(&"local_memory".to_string())));
+        assert!(local_evidence
+            .iter()
+            .any(|differentiator| differentiator.term == "doctor"
+                && differentiator
+                    .evidence_types
+                    .contains(&"local_memory".to_string())));
+    }
+}


### PR DESCRIPTION
## Summary
- Add experimental segmented MemoryIndex support with sparse, KL, and local-distinctiveness routing.
- Add gated local-memory evidence profiles and diagnostics for selected segments.
- Extend the LongMemEval scoped benchmark with global/top-1/top-N/all-segment comparisons, multi-session connection diagnostics, and query-rewrite/local-memory stability diagnostics.
- Document the recommended IndexStore/MemoryIndex concurrency model and preserve claim_extraction in async refresh.

## Benchmark Notes
- Multi-session local-memory top-5 segmented recall@5/10: ~79.07%.
- Global MemoryIndex recall@5: ~72.51%; recall@10: ~73.77% in the same benchmark run.
- Local-memory top-5 segmented latency: ~11.69ms, under the 40ms target discussed.

## Validation
- cargo test segments::tests
- cargo test --bin haystack_scoped_benchmark
- release benchmark smoke/full local-memory comparison runs

## PR Hygiene
- Generated benchmark data under benchmark/data/ is intentionally not included.
- Local patches/ directory is intentionally not included.