### PR TITLE
Add Claude Code and Codex session recording controls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,3 @@ heuristic-query-semantics = []
 claude-code = []
 codex = []
 python = ["dep:pyo3"]
-
-[dev-dependencies]
-lru = "0.16.3"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,99 @@ Results file: `benchmark/data/lintai_longmemeval_scoped_results.json`
 
 See [docs/quickstart.md](docs/quickstart.md) for the shortest path to build, run, query, and use the crate from Rust.
 
+## Claude Code and Codex integrations
+
+Lint-AI provides provider-specific integrations for Claude Code and Codex. Each
+integration is opt-in at build time and combines lifecycle hooks with a
+project-scoped MCP server:
+
+| Feature | Claude Code | Codex |
+|---|---:|---:|
+| Project-scoped MCP server | Yes | Yes |
+| Lifecycle memory retrieval and capture | Yes | Yes |
+| Segmented persistent memory | Yes | Yes |
+| `search` and `info` MCP tools | Yes | Yes |
+| `record_session` control | Yes | Yes |
+| Enable/disable Lint-AI at runtime | Yes | Yes |
+| Session status reporting | Native status line plus MCP | MCP plus terminal status line |
+| Replay with Lint-AI enabled or disabled | Yes | Yes |
+| Session import into provider memory | Yes | Yes |
+
+Build and install both integrations:
+
+```bash
+cargo build --release --features claude-code,codex
+./lint-ai --claude-code-install /path/to/project
+./lint-ai --codex-install /path/to/project
+```
+
+Provider memory remains isolated:
+
+```text
+/path/to/project/.lint-ai/claude-memory/
+/path/to/project/.lint-ai/codex-memory/
+```
+
+The MCP controls are available inside either client:
+
+```text
+mcp__lint-ai__record_session       {"action":"start|stop|status"}
+mcp__lint-ai__enable_lint_ai       {}
+mcp__lint-ai__disable_lint_ai      {}
+mcp__lint-ai__lint_ai_status        {}
+```
+
+Enabling Lint-AI enables recording by default. Recording can then be stopped
+independently, so memory retrieval and full session capture remain separate
+choices. Recording is local, bounded, redacted, and capture-only; it does not
+inject memory by itself.
+
+For a baseline/replay A/B comparison:
+
+```bash
+./lint-ai --replay-session <session-id> \
+  --session-provider codex \
+  --replay-disable-lint-ai
+./lint-ai --replay-session <session-id> \
+  --session-provider codex \
+  --replay-enable-lint-ai
+```
+
+Each replay receives a new `replay-*` session ID and a separate archive. The
+comparison workflow measures task quality, token usage, latency, tool
+activity, memory retrieval, and recording completeness.
+
+### Integration benchmark
+
+These are the latest validated smoke-run measurements for the segmented-routing
+scenario: one repetition, continuation phase only. They are diagnostic results
+for the stated run, not universal performance guarantees.
+
+| Provider / arm | Continuation | Input tokens | Cached input | Output tokens | Tool calls | Recall | Hook time |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Claude native memory | 22.47 s | 123,536 | 123,526 | 1,239 | 4 | 2/3 | 0 ms |
+| Claude Lint-AI only | 7.05 s | 15,914 | 15,912 | 376 | 0 | 3/3 | 1.40 s |
+| Claude both layers | 7.17 s | 15,914 | 15,912 | 271 | 0 | 3/3 | 1.36 s |
+| Codex native memory | 38.13 s | 151,000 | 99,840 | 1,505 | 5 | 2/3 | 0 ms |
+| Codex Lint-AI only | 18.53 s | 62,478 | 43,264 | 604 | 2 | 2/3 | 1.33 s |
+| Codex both layers | 13.98 s | 31,684 | 25,088 | 454 | 1 | 2/3 | 1.39 s |
+
+The corresponding reports and run conditions are documented in the [Claude
+Code performance tests](docs/claude-code-performance-tests.md) and [Codex
+performance tests](docs/codex-performance-tests.md). Both documents describe
+the one-run limitation and the provider/model/repository versions used.
+
+MCP-path smoke validation measured 47.09 s for Claude MCP-only and 9.38 s for
+Codex with Lint-AI MCP. The Codex run recorded 13,246 input tokens, 77 output
+tokens, 2/3 recall, and 1.35 s hook time; the Claude run recorded 189,022
+input tokens, 3,678 output tokens, and one Lint-AI MCP call. A separate direct
+Claude MCP search check returned results in approximately 220 ms; it did not
+measure agent search-selection behavior.
+
+More detail: [Claude Code integration](docs/claude-code.md), [Codex
+integration](docs/codex.md), [shared integration architecture](src/integrations/README.md),
+and [session metrics](metrics/README.md).
+
 ## How It Works
 
 Lint-AI ingests sessions, notes, traces, documents, and code-oriented artifacts, builds a lexical index plus sparse entity/term tables, and overlays graph structure for links, symbols, ownership, and co-occurrence. Queries are analyzed for intent, entities, and temporal hints, then scored with a blend of lexical, semantic, claim, topic, timestamp, and graph signals. The same corpus analysis also powers misalignment checks such as missing cross-refs, orphan pages, low-confidence claims, and review-oriented packet generation.

--- a/benchmark/claude_code/scenarios/index-store-segmented-routing.json
+++ b/benchmark/claude_code/scenarios/index-store-segmented-routing.json
@@ -16,7 +16,7 @@
     {
       "id": "index-store-owner",
       "description": "IndexStore owns the memory snapshot and adapter operations.",
-      "match_any": ["IndexStore owns", "use IndexStore", "IndexStore::query"]
+      "match_any": ["IndexStore owns", "use IndexStore", "uses IndexStore", "using IndexStore", "IndexStore::query", "IndexStore::at_path"]
     },
     {
       "id": "local-distinctiveness",
@@ -33,7 +33,7 @@
     {
       "id": "bare-memory-index",
       "description": "The adapter should not own a bare MemoryIndex.",
-      "match_any": ["construct MemoryIndex directly", "use a bare MemoryIndex"]
+      "match_any": ["use a bare MemoryIndex", "should construct MemoryIndex", "construct a MemoryIndex directly", "own a MemoryIndex directly"]
     }
   ],
   "validators": [
@@ -43,7 +43,7 @@
     }
   ],
   "limits": {
-    "timeout_seconds": 300,
+    "timeout_seconds": 600,
     "max_turns": 4,
     "max_budget_usd": 1.0,
     "max_injected_context_bytes": 8000

--- a/benchmark/claude_code/scripts/run_benchmark.py
+++ b/benchmark/claude_code/scripts/run_benchmark.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -85,14 +86,47 @@ def main() -> None:
     temp_root = Path(tempfile.mkdtemp(prefix="lint-ai-claude-perf."))
     binary = repo_root / "target" / "debug" / "lint-ai"
     runner = repo_root / "benchmark" / "codex_code" / "src" / "runner.py"
+    cargo_bin = Path.home() / ".cargo" / "bin"
+    base_path = f"{cargo_bin}:{os.environ.get('PATH', '')}"
     reports: dict[str, dict[str, object]] = {}
     try:
         print("step: build Claude-enabled binary", flush=True)
         subprocess.run(
             ["cargo", "+stable", "build", "--features", "claude-code", "--quiet"],
             cwd=repo_root,
+            env={**os.environ, "PATH": base_path},
             check=True,
         )
+        # Read auth fields from the user's global settings so isolated arms can authenticate.
+        user_settings_path = Path.home() / ".claude" / "settings.json"
+        user_settings: dict = {}
+        if user_settings_path.exists():
+            try:
+                user_settings = json.loads(user_settings_path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        auth_fields: dict = {}
+        if "apiKeyHelper" in user_settings:
+            auth_fields["apiKeyHelper"] = user_settings["apiKeyHelper"]
+        if "apiKeyHelperTTLMs" in user_settings:
+            auth_fields["apiKeyHelperTTLMs"] = user_settings["apiKeyHelperTTLMs"]
+        if "sandbox" in user_settings:
+            auth_fields["sandbox"] = user_settings["sandbox"]
+        # Carry through auth-related env vars (e.g. Apple TTL and custom headers).
+        auth_env_keys = {
+            "CLAUDE_CODE_API_KEY_HELPER_TTL_MS",
+            "ANTHROPIC_CUSTOM_HEADERS",
+            "CLAUDE_CODE_DISABLE_SANDBOX",
+        }
+        user_env = user_settings.get("env", {})
+        if isinstance(user_env, dict):
+            auth_fields.setdefault("env", {})
+            for key in auth_env_keys:
+                if key in user_env:
+                    auth_fields["env"][key] = user_env[key]
+        if not auth_fields.get("env"):
+            auth_fields.pop("env", None)
+
         for arm in args.arms:
             arm_root = temp_root / arm
             claude_home = Path.home()
@@ -103,24 +137,34 @@ def main() -> None:
             auto_memory_dir = arm_root / "auto-memory"
             claude_config_dir.mkdir(parents=True, exist_ok=True)
             write_json(claude_config, {})
-            write_json(
-                settings_path,
-                {"autoMemoryDirectory": str(auto_memory_dir)}
-                if arm in ("claude-native", "claude-both")
-                else {"autoMemoryEnabled": False},
-            )
+            arm_settings = {
+                **(
+                    {"autoMemoryDirectory": str(auto_memory_dir)}
+                    if arm in ("claude-native", "claude-both")
+                    else {"autoMemoryEnabled": False}
+                ),
+                **auth_fields,
+            }
+            write_json(settings_path, arm_settings)
             env = os.environ.copy()
+            # Propagate sandbox and auth env vars from user settings into the process env.
+            # sandbox_apply runs before Claude Code reads settings, so these must be real env vars.
+            for key in auth_env_keys:
+                if key in user_env:
+                    env[key] = user_env[key]
             env.update({
                 "HOME": str(claude_home),
+                "CLAUDE_CONFIG_DIR": str(claude_config_dir),
                 "LINT_AI_CLAUDE_SETTINGS": str(settings_path),
                 "LINT_AI_CLAUDE_MODEL": args.model,
                 "LINT_AI_CLAUDE_MCP_CONFIG": str(mcp_config_path),
                 "LINT_AI_BENCHMARK_SKILL_PATH": str(
                     repo_root / "src" / "integrations" / "claude_code" / "skill.md"
                 ),
-                "PATH": f"{repo_root / 'target' / 'debug'}:{env.get('PATH', '')}",
+                "PATH": f"{repo_root / 'target' / 'debug'}:{base_path}",
             })
             env.pop("CLAUDE_CODE_DISABLE_AUTO_MEMORY", None)
+            env.pop("CLAUDE_CODE_SHELL_PREFIX", None)  # Apple sandbox wrapper causes sandbox_apply failure
             if arm == "claude-lint-ai":
                 env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
             if arm != "claude-native":
@@ -159,12 +203,12 @@ def main() -> None:
             wrapper.write_text(
                 "#!/usr/bin/env bash\n"
                 "set -euo pipefail\n"
-                "exec claude --print --verbose --output-format stream-json --include-hook-events "
+                f"exec claude --print --verbose --output-format stream-json --include-hook-events "
                 "--model \"$LINT_AI_CLAUDE_MODEL\" "
                 "--dangerously-skip-permissions "
-                "--permission-mode bypassPermissions --setting-sources local "
-                "--strict-mcp-config --mcp-config \"$LINT_AI_CLAUDE_MCP_CONFIG\" "
-                "--settings \"$LINT_AI_CLAUDE_SETTINGS\" -\n",
+                "--permission-mode bypassPermissions "
+                f"--strict-mcp-config --mcp-config {shlex.quote(str(mcp_config_path))} "
+                "-- -\n",
                 encoding="utf-8",
             )
             wrapper.chmod(0o755)

--- a/benchmark/codex_code/scenarios/codex-index-store-segmented-routing.json
+++ b/benchmark/codex_code/scenarios/codex-index-store-segmented-routing.json
@@ -16,7 +16,7 @@
     {
       "id": "index-store-owner",
       "description": "IndexStore owns the memory snapshot and adapter operations.",
-      "match_any": ["IndexStore owns", "use IndexStore", "IndexStore::query"]
+      "match_any": ["IndexStore owns", "use IndexStore", "uses IndexStore", "using IndexStore", "IndexStore::query", "IndexStore::at_path"]
     },
     {
       "id": "local-distinctiveness",
@@ -33,7 +33,7 @@
     {
       "id": "bare-memory-index",
       "description": "The adapter should not own a bare MemoryIndex.",
-      "match_any": ["construct MemoryIndex directly", "use a bare MemoryIndex"]
+      "match_any": ["use a bare MemoryIndex", "should construct MemoryIndex", "construct a MemoryIndex directly", "own a MemoryIndex directly"]
     }
   ],
   "validators": [

--- a/benchmark/codex_code/src/scorer.py
+++ b/benchmark/codex_code/src/scorer.py
@@ -21,14 +21,15 @@ class ScenarioScore:
 
 
 def _match_fact_ids(facts: list[dict[str, Any]], text: str) -> list[str]:
-    text_lower = text.lower()
+    # Strip Markdown code backticks so patterns like "use IndexStore" match "uses `IndexStore`"
+    text_lower = text.lower().replace("`", "")
     matched: list[str] = []
     for fact in facts:
         fact_id = str(fact.get("id", ""))
         match_any = fact.get("match_any", [])
         if not fact_id or not isinstance(match_any, list):
             continue
-        if any(str(pattern).lower() in text_lower for pattern in match_any):
+        if any(str(pattern).lower().replace("`", "") in text_lower for pattern in match_any):
             matched.append(fact_id)
     return matched
 

--- a/docs/claude-code-hooks-design.md
+++ b/docs/claude-code-hooks-design.md
@@ -2,13 +2,17 @@
 
 ## Status
 
-This document defines the Claude Code hook integration. The first implementation
-supports the six hooks described below, persistent segmented session memory,
-bounded transcript capture, context injection, and settings installation.
+This document defines the Claude Code hook integration. The current
+implementation supports ten hooks: the original six (`SessionStart`,
+`UserPromptSubmit`, `UserPromptExpansion`, `PreCompact`, `Stop`, `SessionEnd`)
+plus four added in the second release (`PreToolUse`, `PostToolUse`,
+`SubagentStart`, `SubagentStop`). It also provides persistent segmented session
+memory, bounded transcript capture, context injection, and settings
+installation.
 
 Structured semantic summarization, configurable budgets, stronger secret
-classification, cross-process MCP memory sharing, and the deferred hooks remain
-future work.
+classification, cross-process MCP memory sharing, `PostToolUseFailure` capture,
+and a subagent parent/child segment split remain future work.
 
 The design deliberately keeps Claude-specific protocol types at the integration
 boundary. Lint-AI's public ingestion and query APIs remain `SourceDocument`,
@@ -330,13 +334,70 @@ using the query and the index's matched terms, keeps up to three matching lines,
 and limits each excerpt to 800 UTF-8 bytes. Records with no matching line use a
 small bounded leading excerpt.
 
+### SubagentStart
+
+Purpose: retrieve memory relevant to a delegated subagent's task before it
+begins.
+
+Operation:
+
+1. Use the subagent's prompt as the retrieval query.
+2. Route through the segmented store using the parent session's context.
+3. Return bounded `additionalContext`.
+
+The subagent runs in the same session segment as its parent. A parent/child
+segment split is deferred pending evidence that it improves retrieval precision.
+
+This hook does not create a `SourceDocument`.
+
+### SubagentStop
+
+Purpose: capture the durable outcome after a subagent finishes.
+
+The adapter captures the subagent's completed work as an `Outcome` document in
+the current session segment. This follows the same pattern as the `Stop` hook.
+The subagent does not check the `stop_hook_active` recursion guard because
+`SubagentStop` is only delivered to the parent hook process, not re-entered.
+
+### PostToolUse
+
+Purpose: retrieve memory relevant to a tool result, so Claude has past context
+about this tool or related paths before acting on the output.
+
+Operation:
+
+1. Build a retrieval query from `tool_name`, `tool_input`, `tool_response`,
+   `turn_id`, `agent_id`, and `agent_type` fields.
+2. Truncate large `tool_input` and `tool_response` values to `MAX_EXCERPT_BYTES`
+   before forming the query string.
+3. Route through the segmented store.
+4. Return bounded `additionalContext`.
+
+This hook performs retrieval only. Capture on tool events is deferred because
+raw tool output is high-volume and requires stronger filtering before
+committing to the memory store.
+
+### PreToolUse
+
+Purpose: retrieve memory relevant to a tool call before Claude executes it.
+
+The adapter builds a query from the available tool name, input, turn, agent,
+and response metadata and returns bounded `additionalContext`. Unlike
+`PostToolUse`, this hook does not require a minimum query-term threshold because
+the pre-tool event is the earliest opportunity to provide context for the
+planned action.
+
+This hook performs retrieval only. It does not approve, deny, or modify the
+tool call; tool policy remains Claude Code's responsibility.
+
 ## Hooks Deferred From The First Release
 
-- `PostToolUse`: potentially useful for artifact changes, but raw tool events
-  are high-volume and require stronger capture filtering.
-- `PostToolUseFailure`: useful only after failure deduplication is defined.
-- `SubagentStart` and `SubagentStop`: require a parent/child segment policy.
-- `PreToolUse` and `PermissionRequest`: policy hooks rather than memory hooks.
+- `PostToolUseFailure`: useful after failure deduplication is defined. The
+  failure case is currently not distinguishable without additional filtering.
+- `SubagentStart`/`SubagentStop` parent/child segment split: subagents
+  currently write into the parent session segment. A dedicated child segment
+  and cross-segment retrieval policy is deferred pending benchmark evidence.
+- `PermissionRequest`: a policy hook rather than a memory hook.
 - notification and configuration hooks: do not add durable memory value yet.
 
 ## Hook Response
@@ -410,9 +471,13 @@ Installed hook command shape:
 lint-ai --claude-code-hook session-start /path/to/project
 lint-ai --claude-code-hook user-prompt-submit /path/to/project
 lint-ai --claude-code-hook user-prompt-expansion /path/to/project
+lint-ai --claude-code-hook pre-tool-use /path/to/project
+lint-ai --claude-code-hook post-tool-use /path/to/project
 lint-ai --claude-code-hook pre-compact /path/to/project
 lint-ai --claude-code-hook stop /path/to/project
 lint-ai --claude-code-hook session-end /path/to/project
+lint-ai --claude-code-hook subagent-start /path/to/project
+lint-ai --claude-code-hook subagent-stop /path/to/project
 ```
 
 Each command reads one Claude hook payload from stdin and writes one hook
@@ -421,13 +486,14 @@ response to stdout.
 ## Remaining Work
 
 1. Add benchmark coverage for retrieval quality, hook latency, and injected
-   token usage.
+   token usage — including the three new hooks added in this release.
 2. Replace deterministic bounded transcript extraction with optional structured
    summarization after its quality and cost are measured.
 3. Add configurable context budgets, routing thresholds, and retention.
 4. Define cross-process locking and snapshot reload semantics before sharing the
    hook memory store with the long-running MCP server.
-5. Evaluate the deferred hooks using benchmark evidence.
+5. Evaluate `PostToolUseFailure` capture after failure deduplication is defined.
+6. Evaluate a parent/child segment split for subagents using benchmark evidence.
 
 ## Acceptance Criteria
 
@@ -441,3 +507,7 @@ response to stdout.
 - hook failures do not interrupt normal Claude use by default
 - installation preserves unrelated Claude configuration
 - tests cover every supported hook payload and response shape
+- `PostToolUse` retrieval uses tool name and truncated input/response as query
+- `PreToolUse` retrieval uses the planned tool call as query
+- `SubagentStart` retrieval uses the subagent prompt
+- `SubagentStop` capture is idempotent and stores an `outcome` document type

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -57,6 +57,74 @@ exact, ancestor, diverged, or unknown revision status.
 Retrieval injects at most one preferred document per session and uses bounded
 query-relevant excerpts instead of complete records.
 
+## Runtime controls and session recording
+
+The MCP server exposes independent controls for memory behavior and recording:
+
+| Tool | Purpose |
+|---|---|
+| `record_session` | Start, stop, or inspect local capture-only recording |
+| `enable_lint_ai` | Enable memory retrieval/capture and recording by default |
+| `disable_lint_ai` | Disable Lint-AI memory behavior while preserving recording state |
+| `lint_ai_status` | Return `Lint-AI:ON/OFF` and `Record:ON/OFF` |
+
+Call `mcp__lint-ai__record_session` from Claude Code with one of:
+
+```json
+{"action":"start"}
+{"action":"stop"}
+{"action":"status"}
+```
+
+Recording is project- and provider-scoped, independent from memory injection,
+and does not automatically promote a session into durable memory. Claude's
+installed status line displays the same state when no user status line already
+exists:
+
+```text
+Lint-AI:ON | Record:ON
+```
+
+## Replay and A/B comparison
+
+Replay a recorded Claude session with memory disabled or enabled:
+
+```bash
+lint-ai --replay-session <session-id> \
+  --session-provider claude \
+  --replay-disable-lint-ai
+
+lint-ai --replay-session <session-id> \
+  --session-provider claude \
+  --replay-enable-lint-ai
+```
+
+Replay always creates a new recorded `replay-*` session. Claude print mode
+runs each recorded prompt as a fresh non-interactive process because Claude
+does not expose a portable resume API. The baseline archive remains unchanged.
+
+Generate a report from a session archive, or compare baseline and replay:
+
+```bash
+python3 metrics/generate_session_metric_report.py \
+  --session .lint-ai/claude-sessions/<session-id> \
+  --compare-session .lint-ai/claude-sessions/<replay-id> \
+  --output metrics/reports/claude-comparison.json
+```
+
+Reports separate quality from efficiency and include task status, token usage
+when Claude exposes it, duration, time to first response, hook latency,
+recording completeness, memory events, and baseline/replay deltas.
+
+## Performance expectations
+
+The Claude integration benchmark measures task success, retrieved-fact
+accuracy, parent and all-model token usage, end-to-end latency, hook latency,
+MCP synchronization, context bytes, and repeated exploration. Results are
+specific to the provider/model/repository/revision under test. See [Claude Code
+Performance Test Design](claude-code-performance-tests.md) for the controlled
+A/B protocol and measured run artifacts.
+
 ## Inspect Memory
 
 Inspect the persisted store summary:

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -29,6 +29,14 @@ By default this should:
   lifecycle events
 - preserve unrelated MCP servers, hooks, and settings
 
+Codex's built-in TUI status line currently accepts only Codex-defined item
+identifiers, so installation does not inject an unsupported custom item. The
+Lint-AI state is available inside Codex through
+`mcp__lint-ai__lint_ai_status`, which returns both memory and recording state
+plus compact display text such as `Lint-AI:ON | Record:OFF`. External
+terminal/status-bar integrations can use the provider-owned
+`--codex-statusline` command.
+
 Codex project memory should be persisted under:
 
 ```text
@@ -62,6 +70,77 @@ revisions and an exact, ancestor, diverged, or unknown revision status.
 
 Retrieval should inject at most one preferred document per session and use
 bounded query-relevant excerpts instead of complete records.
+
+## Runtime controls and session recording
+
+The Codex MCP server exposes the same provider-neutral control tools as the
+Claude integration:
+
+| Tool | Purpose |
+|---|---|
+| `record_session` | Start, stop, or inspect local capture-only recording |
+| `enable_lint_ai` | Enable memory retrieval/capture and recording by default |
+| `disable_lint_ai` | Disable Lint-AI memory behavior without changing recording |
+| `lint_ai_status` | Return `Lint-AI:ON/OFF` and `Record:ON/OFF` |
+
+Inside Codex, call `mcp__lint-ai__record_session` with `start`, `stop`, or
+`status`:
+
+```json
+{"action":"start"}
+```
+
+Recording is independent from retrieval, remains local to the current project,
+and is not promoted into durable memory automatically. Codex does not
+currently provide an arbitrary custom TUI status-line item. The state is
+available through `mcp__lint-ai__lint_ai_status` and the external renderer:
+
+```bash
+lint-ai --codex-statusline
+```
+
+## Replay and A/B comparison
+
+Run the same recorded Codex prompts with Lint-AI disabled and enabled:
+
+```bash
+lint-ai --replay-session <session-id> \
+  --session-provider codex \
+  --replay-disable-lint-ai
+
+lint-ai --replay-session <session-id> \
+  --session-provider codex \
+  --replay-enable-lint-ai
+```
+
+Each replay creates a fresh recorded `replay-*` session. Codex starts a new
+conversation for the first prompt and resumes it for subsequent prompts. The
+baseline archive is not modified. Use `--promote-session` to load selected
+recorded events into `.lint-ai/codex-memory/`.
+
+Generate a report from a session archive, or compare baseline and replay:
+
+```bash
+python3 metrics/generate_session_metric_report.py \
+  --session .lint-ai/codex-sessions/<session-id> \
+  --compare-session .lint-ai/codex-sessions/<replay-id> \
+  --output metrics/reports/codex-comparison.json
+```
+
+The report covers quality, token usage, duration, time to first response,
+tool calls, repeated exploration, hook/MCP overhead, memory retrieval, and
+recording completeness. Baseline/replay reports also expose token, latency,
+and quality deltas.
+
+## Performance expectations
+
+The Codex benchmark measures task success, expected-fact accuracy, parent and
+all-model token usage, end-to-end latency, hook and MCP latency, context bytes,
+tool activity, and subagent usage. Results are specific to the
+provider/model/repository/revision under test. Missing Codex usage telemetry
+is represented as unavailable, not zero. See [Codex Performance Test
+Design](codex-performance-tests.md) for the controlled comparison matrix and
+measured run artifacts.
 
 ## Inspect Memory
 

--- a/docs/session-recording-design.md
+++ b/docs/session-recording-design.md
@@ -1,0 +1,791 @@
+# Session Recording Design
+
+## Status
+
+Proposed.
+
+This document defines an explicit, opt-in session recorder for Claude Code and
+Codex integrations. It is intentionally separate from Lint-AI memory
+retrieval: a user can record a session without allowing Lint-AI to inject
+context into that session.
+
+## Motivation
+
+Lint-AI currently captures bounded, structured memories from lifecycle hooks.
+Those memories are optimized for future retrieval and are not a complete audit
+of what happened during a session.
+
+Users need a safe way to:
+
+- record one Claude or Codex session;
+- inspect or export what was recorded;
+- run a clean A/B comparison against native memory;
+- collect a session for debugging or evaluation without changing agent
+  behavior; and
+- decide later whether selected material should become durable Lint-AI memory.
+
+## Goals
+
+- Support Claude Code and Codex through one provider-neutral recording model.
+- Make recording project-scoped, defaulting on when the user explicitly enables
+  Lint-AI while preserving an independent recording override.
+- Preserve ordered session events as append-only JSONL.
+- Record prompts, assistant output, tool calls, tool results, and lifecycle
+  metadata when the provider exposes them.
+- Redact common credentials and sensitive key material before persistence.
+- Keep recording independent from retrieval, MCP, and memory injection.
+- Make interrupted sessions readable and recoverable.
+- Support reproducible A/B experiments with isolated settings and storage.
+
+## Non-goals
+
+- Recording sessions globally without explicit user configuration.
+- Treating every recorded event as durable memory automatically.
+- Reconstructing provider-internal state that is not present in hook payloads.
+- Capturing arbitrary filesystem contents or environment variables.
+- Replacing the provider's own transcript, audit, or observability systems.
+- Guaranteeing that a provider exposes every event for every client version.
+
+## User-facing modes
+
+Recording and retrieval are independent controls.
+
+| Mode | Record events | Retrieve/inject Lint-AI memory | Native provider memory |
+| --- | --- | --- | --- |
+| `off` | No | No change | No change |
+| `capture-only` | Yes | No | No change |
+| `assist` | Yes | Yes | Configurable |
+| `ab` | Yes, isolated per arm | Configurable per arm | Configurable per arm |
+
+The default remains `off` until the user explicitly enables Lint-AI or starts
+recording. Enabling Lint-AI turns recording on by default; `capture-only` is
+the recommended first-run mode.
+
+An A/B run must use fresh sessions and separate recording/memory directories.
+The primary comparison is:
+
+- Arm A: native provider memory only;
+- Arm B: Lint-AI recording and/or retrieval with native memory disabled; and
+- optional Arm C: both layers enabled.
+
+The same prompt, repository revision, model, and tool permissions should be
+used for each arm.
+
+## User-facing visualization
+
+The user should be able to understand the recorder without reading the event
+schema. The primary visualization is a short lifecycle with two independent
+branches: recording goes to the session archive, while retrieval is optional
+and goes to the agent context.
+
+```mermaid
+flowchart LR
+    U[User enables record-session] --> C[Choose provider, mode, and scope]
+    C --> S[Claude or Codex session]
+    S --> H[Provider lifecycle hooks]
+    H --> R[Normalize, redact, and bound]
+    R --> A[(Session archive)]
+    S -. optional retrieval .-> M[Lint-AI memory]
+    M -. optional context .-> S
+    A --> I[Inspect or export]
+    I --> P[Optional promote selected events]
+    P --> M
+```
+
+The enablement view should make these choices visible before the session
+starts:
+
+```text
+Record session
+
+Provider       Claude Code
+Mode           Capture only
+Project        /work/project
+Session root   .lint-ai/claude-sessions
+Retrieval      Off
+Native memory  Unchanged
+Redaction      Default policy
+
+[Start recording]    [Cancel]
+```
+
+During the session, the interface should show a quiet, non-blocking indicator
+such as `Recording: Claude · capture-only`. It should not display every event
+or interrupt the agent. A detailed event stream belongs in the inspection
+view.
+
+The Claude Code integration implements this through Claude's native persistent
+`statusLine`: when no user-defined status line exists, installation adds a
+command that renders `Lint-AI:ON | Record:OFF` (or the corresponding states).
+The command reads the active project from Claude's status-line JSON input, so
+the indicator remains project-scoped, and existing Claude status lines are
+preserved. Codex does not currently expose an equivalent arbitrary command
+status-line hook. The Codex integration still exposes the same compact status
+through `mcp__lint-ai__lint_ai_status` and the hidden
+`--codex-statusline` renderer for external terminal/status-bar integrations.
+
+After the session, show one compact result with clear next actions:
+
+```text
+Session recorded
+
+Claude · capture-only · 12m 08s
+47 events · 38.2 KB · 6 redactions · complete
+Saved to .lint-ai/claude-sessions/claude-abc123/
+
+[Inspect]  [Export]  [Promote to memory]  [Delete]
+```
+
+For A/B testing, the visualization should make isolation explicit rather than
+presenting one blended timeline:
+
+```text
+                         Same task
+                            |
+             +--------------+--------------+
+             |                             |
+       Arm A: native                 Arm B: Lint-AI
+       native memory                 capture/retrieval
+       archive A                     archive B
+             |                             |
+             +--------------+--------------+
+                            |
+                    Compare results
+```
+
+The comparison view should report only decision-relevant measures: answer
+quality, latency, token usage, injected-context bytes, recorded event count,
+and redaction count. It should always label the provider, model, repository
+revision, settings root, and session root for each arm.
+
+## Replay sessions
+
+A replay is always a new, recorded provider session. Replay recording is
+mandatory because the comparison needs an observable record of the replay's
+prompts, tool calls, outputs, usage, and timing.
+
+```text
+baseline session A                    replay session B
+Lint-AI disabled                      Lint-AI enabled
+recorded archive                      recorded archive
+        |                                      |
+        +----------- compare A and B ----------+
+```
+
+The replay must:
+
+1. create a fresh provider `session_id`;
+2. create a fresh Lint-AI recording directory;
+3. run with isolated provider settings and memory roots;
+4. associate the new session with `replay_of_session_id`;
+5. record the replay regardless of whether Lint-AI retrieval is enabled; and
+6. leave the baseline archive and memory segment unchanged.
+
+Replay should be implemented by an orchestrator that starts a new provider
+process. Hooks observe and record the new session, but hooks do not themselves
+replay a conversation. A Claude session fork is not equivalent to a clean
+replay because it copies the existing conversation history. A clean replay
+must start from the original task/prompt with a new session identity.
+
+The replay manifest includes relationship and experiment metadata:
+
+```json
+{
+  "session_id": "replay-b",
+  "replay_of_session_id": "baseline-a",
+  "run_type": "replay",
+  "arm": "claude-lint-ai",
+  "lint_ai_enabled": true,
+  "recording_enabled": true
+}
+```
+
+The baseline manifest is immutable. Multiple replay attempts may reference the
+same baseline, each with a distinct provider session ID and recording archive.
+
+The implemented command surface is:
+
+```text
+lint-ai --replay-session baseline-a \
+  --session-provider claude \
+  --replay-enable-lint-ai
+```
+
+For the no-memory arm, use `--replay-disable-lint-ai`. It is also the default
+when neither replay toggle is supplied.
+
+The command extracts all recorded user prompts. For Codex, it launches a
+fresh non-interactive provider process (`codex exec`) for the first prompt and
+resumes that provider conversation for subsequent prompts. Claude print mode
+currently runs each prompt as a fresh non-interactive process because it does
+not expose a portable resume API. The command creates a new `replay-*`
+session ID and records provider hooks and replay output in that archive by
+passing the replay ID through the hook environment. It restores the prior
+memory and recording toggles after the provider exits and returns the replay
+session ID and archive path for later comparison.
+
+## Load a recorded session into a scenario
+
+A recorded session can be promoted into a benchmark scenario for structured
+review. The session remains the immutable evidence source; the scenario adds
+the review contract. This avoids putting expectations, validators, or grading
+decisions into the raw event archive.
+
+```text
+recorded session
+  | import/reference
+  v
+scenario fixture
+  | add expected facts, validators, and performance limits
+  v
+scenario runner
+  | evaluate baseline, replay, or both
+  v
+review report
+```
+
+The scenario should reference the source session instead of copying its full
+event log:
+
+```json
+{
+  "schema_version": 1,
+  "id": "review-session-abc123",
+  "category": "session-review",
+  "source_session": {
+    "provider": "claude",
+    "session_id": "abc123",
+    "archive": ".lint-ai/claude-sessions/abc123",
+    "repository_revision": "abc123"
+  },
+  "setup_messages": [
+    {"prompt": "...", "establishes_fact_ids": []}
+  ],
+  "continuation_prompt": "...",
+  "expected_facts": [],
+  "validators": [],
+  "limits": {
+    "max_duration_seconds": 600,
+    "max_output_tokens": 4000
+  }
+}
+```
+
+Loading a session into a scenario should derive the initial
+`setup_messages` and continuation prompt from recorded user-prompt events,
+retain the source session metadata, and leave `expected_facts`, `validators`,
+and `limits` editable. The user can then add facts such as “the answer names
+IndexStore” or validators such as a test command before running the review.
+
+The existing scenario fields remain the evaluation interface:
+
+- `expected_facts` checks whether the final response contains required facts;
+- `forbidden_facts` checks for regressions or disallowed claims;
+- `validators` runs repository or artifact checks; and
+- `limits` evaluates duration, token usage, injected context, and other
+  performance budgets.
+
+The scenario runner may evaluate the original recorded output, a replay
+output, or both. A comparison report should identify the source session and
+replay session while keeping the same scenario expectations and validators for
+each arm. Evaluation results belong in a separate result artifact and must not
+modify either the session archive or the scenario definition.
+
+An eventual import command can be exposed as:
+
+```text
+lint-ai --scenario-from-session abc123 \
+  --session-provider claude \
+  --scenario-out benchmark/claude_code/scenarios/review-session-abc123.json
+```
+
+### Activation inside Claude or Codex
+
+After the provider integration is installed, recording remains dormant until
+the user explicitly enables Lint-AI or starts it from the active provider
+session through the Lint-AI MCP control tool:
+
+```json
+{"action":"start"}
+```
+
+The tool is named `mcp__lint-ai__record_session` in the client. Stopping uses
+`{"action":"stop"}`, and checking the state uses `{"action":"status"}`.
+
+The provider skill and tool description must make these rules explicit:
+
+- enabling Lint-AI starts recording by default, or recording can be started
+  directly with `record_session`;
+- starting recording is capture-only and does not inject memory;
+- recording is scoped to the current project and provider; and
+- the user can stop recording without disabling memory or reinstalling hooks.
+
+The agent must never start recording as a side effect of a normal search,
+memory lookup, or repository task. If the MCP server is unavailable, the user
+can use the equivalent local state command in a future CLI surface; the first
+implementation does not silently fall back to recording.
+
+## `record-session` process
+
+The recorder is a local event sink attached to the provider's lifecycle hooks.
+It does not become an agent, proxy, MCP server, or tool-policy decision maker.
+Its normal operation is:
+
+```text
+enable recording
+      |
+      v
+open or recover session
+      |
+      v
+receive provider hook --> normalize --> redact --> bound --> append event
+      |                                      |
+      |                                      +--> fail open if recording fails
+      v
+finalize on session end
+      |
+      v
+inspect/export later
+      |
+      v
+optional explicit promotion into memory
+```
+
+### 1. Enable recording
+
+Recording is enabled before the provider session starts. Installation writes
+only the selected provider's hooks into the selected settings scope and stores
+the recording mode and session root in the generated configuration.
+
+The command must report:
+
+- provider and project scope;
+- recording mode;
+- session root;
+- whether retrieval/injection is enabled; and
+- the redaction and size-limit policy.
+
+The command must require confirmation for a non-temporary session root unless
+the user has supplied an explicit non-interactive flag. `capture-only` should
+be the default when `--record-session` is used without a retrieval mode.
+
+### 2. Open or recover the session
+
+On the first lifecycle event, the provider adapter derives a session identity
+from the provider session/thread identifier. If the provider identifier is
+missing, the adapter creates a random local identifier and records that the
+identity is locally assigned.
+
+The recorder then:
+
+1. resolves the configured project root without following an unsafe path;
+2. creates the provider-specific session directory;
+3. creates `manifest.json` with status `active`;
+4. opens or creates `events.jsonl`; and
+5. acquires the session writer lock.
+
+If an existing active session has the same identity, the recorder treats the
+event as a retry or continuation. It does not silently merge unrelated
+sessions with similar prompts or repository paths.
+
+### 3. Normalize the provider event
+
+Each Claude or Codex hook adapter maps its payload into one normalized event.
+The adapter must preserve provider identifiers such as session, thread, turn,
+rollout, tool, and agent IDs when available.
+
+The adapter should record the smallest useful payload for the event:
+
+- prompt events retain prompt text and prompt metadata;
+- assistant events retain assistant text and message metadata;
+- tool calls retain tool name and bounded input;
+- tool results retain tool name, bounded result, and success/failure state;
+- compaction events retain compaction metadata and any bounded summary; and
+- lifecycle events retain timestamps, reason, and status.
+
+The adapter must not copy a provider's entire opaque payload by default.
+Unknown fields are retained only under the bounded `provider_event` policy.
+
+### Usage metadata
+
+Usage is recorded opportunistically and must carry its provenance. Claude Code
+currently exposes detailed usage for completed `Agent` subagent calls in the
+`PostToolUse` tool response, including `totalTokens` and input/output/cache
+breakdowns. The recorder normalizes those fields into the event envelope as
+`usage` with source `hook-payload`.
+
+Claude's ordinary lifecycle hook payloads do not provide a general per-turn
+usage object, but the hook input includes `transcript_path`. At `Stop`, the
+adapter reads the latest usage object from that transcript and appends a
+`turn_usage` event with source `claude-transcript` when available.
+
+Codex's exact token usage is exposed by its app-server as the
+`thread/tokenUsage/updated` notification, not by the lifecycle hook payload.
+The hook adapter therefore uses transcript-derived usage when the Codex
+transcript exposes it. The planned app-server adapter will subscribe to the
+notification and append the same `turn_usage` event shape with source
+`codex-app-server`.
+
+Comparison tools must label usage as `hook-payload`, `claude-transcript`,
+`codex-transcript`, `codex-app-server`, or `unavailable`.
+
+### 4. Redact and bound the event
+
+Redaction happens before size measurement and before any serialization to disk.
+The pipeline is:
+
+```text
+provider payload
+  -> extract supported fields
+  -> recursively redact sensitive keys and values
+  -> truncate strings and arrays to policy limits
+  -> enforce maximum event bytes
+  -> serialize normalized envelope
+```
+
+If the event still exceeds the maximum size after field-level truncation, the
+recorder drops the lowest-priority optional fields and records the omitted
+field names in the envelope. It must never write an unredacted fallback.
+
+### 5. Append the event
+
+The recorder obtains the per-session writer lock, checks the event ID for
+deduplication, assigns the next sequence number, appends one JSON object plus a
+newline, flushes the writer, and releases the lock.
+
+The append operation is the durability boundary. A hook may return after the
+event has been flushed or after the configured short write deadline expires.
+The provider session must continue even if the deadline is exceeded.
+
+The recorder updates lightweight manifest counters after a successful append.
+Counter updates are advisory; `events.jsonl` is the source of truth and can be
+rescanned by inspection or recovery.
+
+### 6. Finalize the session
+
+The first terminal event (`session_end`, or the provider's equivalent) causes
+the recorder to:
+
+1. append the terminal event;
+2. flush and close the event writer;
+3. compute event count, byte count, and optional checksum metadata;
+4. set `ended_at` and terminal status in the manifest; and
+5. release the writer lock.
+
+Terminal hooks are idempotent. A retry must not append a second terminal event
+with a new sequence number unless the retry contains a distinct event ID and
+new provider state.
+
+If a provider emits `Stop` but not `SessionEnd`, `Stop` is recorded as a normal
+event and the session remains active until recovery or explicit finalization.
+The inspection command may mark such a session `incomplete`; it must not
+rewrite the event history.
+
+### 7. Recover interrupted sessions
+
+Recovery runs when a session is opened, listed, inspected, or explicitly
+repaired. It:
+
+1. acquires the writer lock;
+2. scans `events.jsonl` in order;
+3. keeps complete valid lines;
+4. removes only an incomplete final line caused by an interrupted write;
+5. detects duplicate or non-monotonic sequence numbers;
+6. rebuilds advisory manifest counters; and
+7. marks an active session `incomplete` if its process ended without a terminal
+   event.
+
+Recovery must not discard a valid event because a later event is malformed.
+Malformed non-final lines are reported in inspection output and preserved in a
+separate recovery diagnostic rather than silently rewritten.
+
+### 8. Inspect and export
+
+Inspection is read-only and never changes an active session. It reports the
+manifest, event summary, redaction count, truncation count, incomplete-line
+status, and provider capabilities.
+
+Export reads the manifest and valid event envelopes in sequence order. It can
+produce JSONL or a human-readable Markdown summary, but both formats must use
+the already-redacted data. Export must not re-read provider transcripts to
+recover data that was intentionally omitted during recording.
+
+### 9. Promote selected material into memory
+
+Recording does not automatically create Lint-AI memory records. Promotion is a
+separate user action:
+
+1. select a session or event range;
+2. show a redacted preview;
+3. allow the user to exclude events or fields;
+4. convert the selection through the existing Claude/Codex document adapter;
+5. write durable memory with a source link to the recorded session; and
+6. report the created document IDs.
+
+Promotion must be idempotent for the same session ID, event range, and memory
+schema version. Deleting a recording must not delete promoted memory unless a
+future explicit cascade policy is enabled.
+
+## Configuration
+
+The exact CLI surface may evolve, but the configuration needs equivalent
+controls to the following:
+
+```text
+lint-ai --claude-code-install /path/to/project \
+  --session-recording capture-only \
+  --session-root /path/to/project/.lint-ai/claude-sessions
+
+lint-ai --codex-install /path/to/project \
+  --session-recording capture-only \
+  --session-root /path/to/project/.lint-ai/codex-sessions
+```
+
+For experiments, settings and storage must be supplied explicitly or created
+under a disposable directory:
+
+```text
+lint-ai --claude-code-install /path/to/project \
+  --session-recording ab \
+  --experiment-root /tmp/lint-ai-experiment/run-1
+```
+
+Installation must not silently overwrite global provider settings. It should
+prefer project-local settings or require an explicit settings path. Existing
+unrelated hooks, MCP servers, and settings remain untouched.
+
+## Storage layout
+
+Each provider and project has an independent session root:
+
+```text
+.lint-ai/
+  claude-sessions/
+    <session-id>/
+      manifest.json
+      events.jsonl
+      checksums.json
+  codex-sessions/
+    <session-id>/
+      manifest.json
+      events.jsonl
+      checksums.json
+```
+
+Session roots should be ignored by Git by default. A user may explicitly
+export a session into a tracked or external location.
+
+### Manifest
+
+`manifest.json` contains stable metadata and lifecycle state:
+
+```json
+{
+  "schema_version": 1,
+  "session_id": "claude:abc123",
+  "provider": "claude",
+  "project_root": "/work/project",
+  "started_at": "2026-08-08T12:00:00Z",
+  "ended_at": null,
+  "status": "active",
+  "recording_mode": "capture-only",
+  "repository_revision": "abc123",
+  "repository_branch": "main",
+  "event_count": 4,
+  "redaction_policy": "default-v1"
+}
+```
+
+The recorder updates the manifest atomically when possible. A missing or
+stale `ended_at` does not invalidate the event log; interrupted sessions have
+status `incomplete` after recovery or inspection.
+
+### Event log
+
+`events.jsonl` contains one envelope per event. The envelope is provider
+neutral, while `payload` retains only the normalized fields needed for replay,
+inspection, and analysis.
+
+```json
+{
+  "schema_version": 1,
+  "sequence": 7,
+  "event_id": "evt-7",
+  "timestamp": "2026-08-08T12:01:03Z",
+  "kind": "tool_result",
+  "provider": "claude",
+  "session_id": "claude:abc123",
+  "turn_id": "turn-42",
+  "payload": {
+    "tool_name": "Bash",
+    "input": {"command": "cargo test"},
+    "response": {"output": "test result: ok"}
+  },
+  "redactions": ["payload.response.output.secret"]
+}
+```
+
+Supported normalized event kinds are:
+
+- `session_start`;
+- `user_prompt`;
+- `assistant_message`;
+- `tool_call`;
+- `tool_result`;
+- `tool_error`;
+- `compaction`;
+- `subagent_start`;
+- `subagent_stop`; and
+- `session_end`.
+
+Unknown provider events are recorded as `provider_event` only when their
+payload passes the redaction and size limits. Unknown fields must not prevent
+the session from being recorded.
+
+## Provider adapters
+
+The recorder owns the normalized event model. Provider integrations only map
+their hook payloads into events.
+
+### Claude Code
+
+The Claude adapter maps lifecycle hooks as follows:
+
+| Hook | Recording behavior |
+| --- | --- |
+| `SessionStart` | Open or recover the session manifest |
+| `UserPromptSubmit` | Append `user_prompt` |
+| `UserPromptExpansion` | Append the expanded prompt metadata |
+| `PreToolUse` | Append `tool_call` when available |
+| `PostToolUse` | Append `tool_result` |
+| `PostToolUseFailure` | Append `tool_error` when available |
+| `PreCompact` | Append `compaction` |
+| `SubagentStart` | Append `subagent_start` |
+| `SubagentStop` | Append `subagent_stop` |
+| `Stop` | Append final assistant/session state |
+| `SessionEnd` | Append `session_end` and finalize the manifest |
+
+`Stop` and `SessionEnd` must be idempotent because providers may retry hooks.
+
+### Codex
+
+The Codex adapter maps the corresponding rollout and hook payloads into the
+same event kinds. It must preserve the provider's turn, thread, rollout, and
+agent identifiers when present so events can be correlated without storing
+provider-specific state in the core recorder.
+
+If a provider does not expose a particular event, the recorder does not infer
+it from unrelated fields. The manifest records provider capability information
+for accurate interpretation.
+
+## Privacy and safety
+
+Recording is potentially sensitive and must be treated as user data.
+
+Before an event is written:
+
+- redact API keys, bearer tokens, private-key blocks, passwords, cookies, and
+  common secret environment-variable values;
+- omit raw environment dumps and process tables;
+- cap individual strings, nested JSON values, event size, and total session
+  size;
+- preserve a redaction marker rather than silently changing the event shape;
+- never log the unredacted payload on errors; and
+- fail open for the agent session: recorder failures must not block Claude or
+  Codex.
+
+The default retention policy is local storage with no upload. Cleanup and
+export commands must make the destination explicit. The CLI should display a
+warning before enabling recording and provide a clear way to disable it.
+
+## Reliability and concurrency
+
+- Append events with one writer per session where possible.
+- Use a lock or atomic claim file when multiple hook processes can write the
+  same session.
+- Assign sequence numbers under the same lock as the append.
+- Flush each event before acknowledging the hook when practical.
+- Recover by scanning valid JSONL lines and truncating only an incomplete final
+  line.
+- Treat duplicate `event_id` values as replays and ignore them.
+- Keep hook latency bounded; large payloads are truncated before serialization.
+
+The recorder should expose timing counters so A/B runs can measure recording
+overhead separately from retrieval and MCP startup.
+
+## Inspection and export
+
+Provide read-only commands for local review:
+
+```text
+lint-ai --list-sessions /path/to/project
+lint-ai --inspect-session <session-id> --session-root .lint-ai/claude-sessions
+lint-ai --export-session <session-id> --format jsonl --out session.jsonl
+```
+
+Inspection should show event counts, duration, provider, recording mode,
+redaction count, completion status, and storage path without printing secrets.
+Export should preserve the normalized event order and include the manifest.
+
+Converting a recorded event into durable memory is a separate, explicit
+operation. The first version should support selecting a session or event
+range, applying the same redaction and bounded-content rules, and importing
+through the existing provider document adapters.
+
+## A/B experiment workflow
+
+1. Create two disposable settings roots and two session/memory roots.
+2. Run the same setup session in each arm, or seed each arm identically.
+3. Start fresh continuation sessions.
+4. Run the identical task prompt.
+5. Collect the event logs, hook timings, injected-context bytes, latency, token
+   usage, and task-quality scores.
+6. Compare results without merging the memory stores.
+7. Delete temporary roots after exporting the artifacts needed for analysis.
+
+The benchmark runner should use this workflow rather than modifying the
+developer's global Claude or Codex configuration.
+
+## Implementation phases
+
+### Phase 1: recorder core
+
+- Add the normalized event envelope and manifest types.
+- Add append-only JSONL writing, size limits, locking, recovery, and redaction.
+- Add inspection tests for replay, duplicate events, truncation, and crash
+  recovery.
+
+### Phase 2: provider adapters
+
+- Add Claude lifecycle mapping, including tool and subagent events.
+- Add Codex lifecycle mapping.
+- Keep capture-only mode independent from retrieval.
+- Add provider capability metadata.
+
+### Phase 3: CLI and experiments
+
+- Add explicit recording configuration and session-root selection.
+- Add list/inspect/export commands.
+- Update benchmark arms to use isolated settings and recorder roots.
+- Add end-to-end A/B fixtures.
+
+### Phase 4: memory promotion
+
+- Add explicit session-to-memory import.
+- Reuse provider document normalization and secret filtering.
+- Measure whether promoted records improve retrieval without increasing noise.
+
+## Acceptance criteria
+
+- Recording is off unless explicitly enabled.
+- A user can record one Claude or Codex session without memory injection.
+- A replay always creates a fresh provider session ID and records it.
+- A replay manifest links back to its immutable baseline session.
+- Claude and Codex events use the same normalized event schema.
+- Replayed stop/end hooks do not duplicate events or memory records.
+- Interrupted sessions remain inspectable.
+- Secrets and private-key blocks are redacted before disk persistence.
+- Recording failures do not interrupt the provider session.
+- A/B runs do not modify global provider settings or share memory roots.
+- Inspection and export never emit the original unredacted payload.
+- Session recording and durable-memory promotion are separate operations.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,15 +21,25 @@ pub enum GraphLevel {
     Entity,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum SessionProvider {
+    Claude,
+    Codex,
+}
+
 #[cfg(feature = "claude-code")]
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ClaudeCodeHook {
     SessionStart,
     UserPromptSubmit,
     UserPromptExpansion,
+    PreToolUse,
+    PostToolUse,
     PreCompact,
     Stop,
     SessionEnd,
+    SubagentStart,
+    SubagentStop,
 }
 
 #[cfg(feature = "codex")]
@@ -139,6 +149,9 @@ pub struct Args {
     #[arg(long)]
     #[cfg(feature = "claude-code")]
     pub claude_code_serve: bool,
+    #[arg(long, hide = true)]
+    #[cfg(feature = "claude-code")]
+    pub claude_code_statusline: bool,
     #[arg(long)]
     pub claude_code_verify_mcp: bool,
     #[arg(long, value_enum)]
@@ -156,6 +169,9 @@ pub struct Args {
     #[arg(long)]
     #[cfg(feature = "codex")]
     pub codex_serve: bool,
+    #[arg(long, hide = true)]
+    #[cfg(feature = "codex")]
+    pub codex_statusline: bool,
     #[arg(long)]
     pub codex_verify_mcp: bool,
     #[arg(long, value_enum)]
@@ -169,6 +185,18 @@ pub struct Args {
     pub codex_settings: Option<String>,
     #[arg(long)]
     pub inspect_index: Option<String>,
+    #[arg(long)]
+    pub promote_session: Option<String>,
+    #[arg(long)]
+    pub replay_session: Option<String>,
+    #[arg(long)]
+    pub replay_enable_lint_ai: bool,
+    #[arg(long, conflicts_with = "replay_enable_lint_ai")]
+    pub replay_disable_lint_ai: bool,
+    #[arg(long, value_enum, default_value = "claude")]
+    pub session_provider: SessionProvider,
+    #[arg(long)]
+    pub session_root: Option<String>,
     #[arg(long, value_enum, default_value = "summary")]
     pub inspect_view: IndexInspectView,
     #[arg(long, default_value_t = 2_000_000)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -8,7 +8,7 @@ use crate::index::{DocRecord, MemoryIndex, SectionChunk, TemporalQueryContext, T
 use crate::integrations::claude_code::hooks::{run_hook, ClaudeHookKind};
 #[cfg(feature = "claude-code")]
 use crate::integrations::claude_code::{
-    install_hook_settings, install_memory_skill, install_user_config, run_server,
+    install_hook_settings, install_memory_skill, install_user_config, run_server, run_status_line,
     ClaudeCodeServerOptions,
 };
 #[cfg(feature = "codex")]
@@ -17,7 +17,7 @@ use crate::integrations::codex::hooks::{run_hook as run_codex_hook, CodexHookKin
 use crate::integrations::codex::{
     install_hook_settings as install_codex_hook_settings,
     install_user_config as install_codex_user_config, run_server as run_codex_server,
-    CodexServerOptions,
+    run_status_line as run_codex_status_line, CodexServerOptions,
 };
 use crate::pipeline::{
     source_documents_to_tier1_inputs, ChunkStrategy, IndexStore, MemoryIndexLayout,
@@ -2010,17 +2010,86 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         return inspect_index_store(Path::new(index_path), args.inspect_view);
     }
 
+    if args.promote_session.is_some() {
+        #[cfg(any(feature = "claude-code", feature = "codex"))]
+        {
+            let session_id = args.promote_session.as_deref().expect("checked above");
+            let provider = match args.session_provider {
+                crate::cli::SessionProvider::Claude => {
+                    crate::integrations::session_recording::RecordingProvider::Claude
+                }
+                crate::cli::SessionProvider::Codex => {
+                    crate::integrations::session_recording::RecordingProvider::Codex
+                }
+            };
+            let report = crate::integrations::session_recording::promote_recorded_session(
+                provider,
+                Path::new(&args.path),
+                args.session_root.as_deref().map(Path::new),
+                session_id,
+            )?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            return Ok(());
+        }
+        #[cfg(not(any(feature = "claude-code", feature = "codex")))]
+        {
+            anyhow::bail!("session promotion requires the Claude Code or Codex feature");
+        }
+    }
+
+    if args.replay_session.is_some() {
+        #[cfg(any(feature = "claude-code", feature = "codex"))]
+        {
+            let session_id = args.replay_session.as_deref().expect("checked above");
+            let provider = match args.session_provider {
+                crate::cli::SessionProvider::Claude => {
+                    crate::integrations::session_recording::RecordingProvider::Claude
+                }
+                crate::cli::SessionProvider::Codex => {
+                    crate::integrations::session_recording::RecordingProvider::Codex
+                }
+            };
+            let report = crate::integrations::session_recording::replay_recorded_session(
+                provider,
+                Path::new(&args.path),
+                args.session_root.as_deref().map(Path::new),
+                session_id,
+                args.replay_enable_lint_ai,
+            )?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            return Ok(());
+        }
+        #[cfg(not(any(feature = "claude-code", feature = "codex")))]
+        {
+            anyhow::bail!("session replay requires the Claude Code or Codex feature");
+        }
+    }
+
+    #[cfg(feature = "claude-code")]
+    if args.claude_code_statusline {
+        return run_status_line();
+    }
+
     #[cfg(feature = "claude-code")]
     if let Some(hook) = args.claude_code_hook {
         let kind = match hook {
             crate::cli::ClaudeCodeHook::SessionStart => ClaudeHookKind::SessionStart,
             crate::cli::ClaudeCodeHook::UserPromptSubmit => ClaudeHookKind::UserPromptSubmit,
             crate::cli::ClaudeCodeHook::UserPromptExpansion => ClaudeHookKind::UserPromptExpansion,
+            crate::cli::ClaudeCodeHook::PreToolUse => ClaudeHookKind::PreToolUse,
+            crate::cli::ClaudeCodeHook::PostToolUse => ClaudeHookKind::PostToolUse,
             crate::cli::ClaudeCodeHook::PreCompact => ClaudeHookKind::PreCompact,
             crate::cli::ClaudeCodeHook::Stop => ClaudeHookKind::Stop,
             crate::cli::ClaudeCodeHook::SessionEnd => ClaudeHookKind::SessionEnd,
+            crate::cli::ClaudeCodeHook::SubagentStart => ClaudeHookKind::SubagentStart,
+            crate::cli::ClaudeCodeHook::SubagentStop => ClaudeHookKind::SubagentStop,
         };
         return run_hook(kind, Path::new(&args.path));
+    }
+
+    #[cfg(feature = "codex")]
+    if args.codex_statusline {
+        return run_codex_status_line();
     }
 
     #[cfg(feature = "codex")]

--- a/src/integrations/README.md
+++ b/src/integrations/README.md
@@ -170,6 +170,37 @@ The stores are separate because Claude and Codex capture different lifecycle
 payloads and document schemas. They use the same indexing and retrieval
 implementation and can be queried through the same MCP tool contract.
 
+## Session recording and controls
+
+Both integrations expose the same MCP control surface:
+
+```text
+record_session       { action: start | stop | status }
+enable_lint_ai       {}
+disable_lint_ai      {}
+lint_ai_status       {}
+```
+
+Recording is an independent, capture-only event archive. It can be enabled
+without memory retrieval, and enabling Lint-AI turns recording on by default.
+Users can stop recording without disabling memory. Archives are stored under
+provider-specific session roots and can be promoted into the corresponding
+segmented memory store later.
+
+Replay is an orchestrated new provider session rather than a conversation
+fork. It always records a new `replay-*` archive, supports explicit
+`--replay-enable-lint-ai` and `--replay-disable-lint-ai` arms, and preserves the
+baseline archive. Codex resumes the provider conversation after its first
+prompt; Claude runs prompts independently because it lacks a portable resume
+API.
+
+Session reports are generated separately from immutable archives. They measure
+quality and efficiency independently, including task outcome, token usage,
+duration, time to first response, hook/MCP latency, tool calls, repeated
+exploration, retrieved memory, and recording completeness. Values are reported
+for the exact provider, model, repository, and benchmark revision being run;
+the integration README does not claim universal thresholds.
+
 ## Claude Code
 
 Build with the Claude feature:

--- a/src/integrations/claude_code/hooks/mod.rs
+++ b/src/integrations/claude_code/hooks/mod.rs
@@ -1,6 +1,10 @@
 mod protocol;
 
 use super::document::{ClaudeCodeDocument, ClaudeCodeDocumentType};
+use crate::integrations::session_recording::{
+    lint_ai_enabled, record_event_if_enabled, record_transcript_usage_if_available,
+    RecordingProvider,
+};
 use crate::pipeline::{IndexStore, MemoryIndexLayout, PipelineOptions};
 use crate::segments::SegmentRoutingStrategy;
 use anyhow::{Context, Result};
@@ -19,15 +23,20 @@ const MAX_TRANSCRIPT_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_CAPTURED_MESSAGES: usize = 6;
 const MAX_MEMORY_FIELD_BYTES: usize = 1_500;
 const MAX_EXCERPT_BYTES: usize = 800;
+const MIN_TOOL_QUERY_TERMS: usize = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClaudeHookKind {
     SessionStart,
     UserPromptSubmit,
     UserPromptExpansion,
+    PreToolUse,
+    PostToolUse,
     PreCompact,
     Stop,
     SessionEnd,
+    SubagentStart,
+    SubagentStop,
 }
 
 impl ClaudeHookKind {
@@ -36,16 +45,60 @@ impl ClaudeHookKind {
             Self::SessionStart => "SessionStart",
             Self::UserPromptSubmit => "UserPromptSubmit",
             Self::UserPromptExpansion => "UserPromptExpansion",
+            Self::PreToolUse => "PreToolUse",
+            Self::PostToolUse => "PostToolUse",
             Self::PreCompact => "PreCompact",
             Self::Stop => "Stop",
             Self::SessionEnd => "SessionEnd",
+            Self::SubagentStart => "SubagentStart",
+            Self::SubagentStop => "SubagentStop",
         }
     }
 }
 
 pub fn run_hook(kind: ClaudeHookKind, fallback_root: &Path) -> Result<()> {
-    let input: ClaudeHookInput = serde_json::from_reader(std::io::stdin().lock())
+    let raw: Value = serde_json::from_reader(std::io::stdin().lock())
         .context("failed to parse Claude hook input")?;
+    let input: ClaudeHookInput =
+        serde_json::from_value(raw).context("failed to decode Claude hook input")?;
+    let root = resolve_root(&input.cwd, fallback_root)?;
+    let payload = serde_json::json!({
+        "hook_event_name": input.hook_event_name,
+        "prompt": input.prompt,
+        "tool_name": input.tool_name,
+        "tool_input": input.tool_input,
+        "tool_response": input.tool_response,
+        "transcript_path": input.transcript_path,
+        "agent_id": input.agent_id,
+        "agent_type": input.agent_type,
+        "turn_id": input.turn_id,
+        "expansion_type": input.expansion_type,
+        "command_name": input.command_name,
+        "command_args": input.command_args,
+        "command_source": input.command_source,
+        "extra": input.extra,
+    });
+    if let Err(error) = record_event_if_enabled(
+        RecordingProvider::Claude,
+        &root,
+        &input.session_id,
+        kind.event_name(),
+        payload,
+    ) {
+        eprintln!("warning: Lint-AI session recording failed open: {error:#}");
+    }
+    if matches!(kind, ClaudeHookKind::Stop) && !input.stop_hook_active {
+        if let Err(error) = record_transcript_usage_if_available(
+            RecordingProvider::Claude,
+            &root,
+            &input.session_id,
+            input.transcript_path.as_deref(),
+            input.turn_id.as_deref(),
+            "claude-transcript",
+        ) {
+            eprintln!("warning: Claude transcript usage capture failed open: {error:#}");
+        }
+    }
     let started = Instant::now();
     let output = match handle_hook(kind, input, fallback_root) {
         Ok(output) => output,
@@ -67,10 +120,14 @@ fn write_timing_record(kind: ClaudeHookKind, elapsed_ms: f64, output: &ClaudeHoo
     let operation = match kind {
         ClaudeHookKind::SessionStart
         | ClaudeHookKind::UserPromptSubmit
-        | ClaudeHookKind::UserPromptExpansion => "retrieve",
-        ClaudeHookKind::PreCompact | ClaudeHookKind::Stop | ClaudeHookKind::SessionEnd => {
-            "capture"
-        }
+        | ClaudeHookKind::UserPromptExpansion
+        | ClaudeHookKind::PreToolUse
+        | ClaudeHookKind::PostToolUse
+        | ClaudeHookKind::SubagentStart => "retrieve",
+        ClaudeHookKind::PreCompact
+        | ClaudeHookKind::Stop
+        | ClaudeHookKind::SessionEnd
+        | ClaudeHookKind::SubagentStop => "capture",
     };
     let context_bytes = output
         .hook_specific_output
@@ -105,6 +162,9 @@ fn handle_hook(
         );
     }
     let root = resolve_root(&input.cwd, fallback_root)?;
+    if !lint_ai_enabled(RecordingProvider::Claude, &root)? {
+        return Ok(ClaudeHookOutput::default());
+    }
     match kind {
         ClaudeHookKind::SessionStart => retrieve(
             &root,
@@ -130,10 +190,24 @@ fn handle_hook(
             .join(" ");
             retrieve(&root, kind.event_name(), &query)
         }
+        ClaudeHookKind::PostToolUse => {
+            let query = tool_query(&input);
+            if query_terms(&query).len() < MIN_TOOL_QUERY_TERMS {
+                return Ok(ClaudeHookOutput::default());
+            }
+            retrieve(&root, kind.event_name(), &query)
+        }
+        ClaudeHookKind::PreToolUse => retrieve(&root, kind.event_name(), &tool_query(&input)),
         ClaudeHookKind::PreCompact => capture(&root, input, ClaudeCodeDocumentType::Checkpoint),
         ClaudeHookKind::Stop if input.stop_hook_active => Ok(ClaudeHookOutput::default()),
         ClaudeHookKind::Stop => capture(&root, input, ClaudeCodeDocumentType::Outcome),
         ClaudeHookKind::SessionEnd => capture(&root, input, ClaudeCodeDocumentType::SessionSummary),
+        ClaudeHookKind::SubagentStart => retrieve(
+            &root,
+            kind.event_name(),
+            input.prompt.as_deref().unwrap_or_default(),
+        ),
+        ClaudeHookKind::SubagentStop => capture(&root, input, ClaudeCodeDocumentType::Outcome),
     }
 }
 
@@ -373,17 +447,26 @@ fn memory_root(root: &Path) -> PathBuf {
 }
 
 fn resolve_root(cwd: &Path, fallback_root: &Path) -> Result<PathBuf> {
-    let candidate = if cwd.as_os_str().is_empty() {
-        fallback_root
-    } else {
-        cwd
-    };
-    candidate.canonicalize().with_context(|| {
+    let fallback = fallback_root.canonicalize().with_context(|| {
         format!(
-            "failed to resolve Claude project root {}",
-            candidate.display()
+            "failed to resolve Claude fallback project root {}",
+            fallback_root.display()
         )
-    })
+    })?;
+    let candidate = if cwd.as_os_str().is_empty() {
+        fallback.clone()
+    } else {
+        cwd.canonicalize()
+            .with_context(|| format!("failed to resolve Claude project root {}", cwd.display()))?
+    };
+    if !candidate.starts_with(&fallback) {
+        anyhow::bail!(
+            "Claude hook cwd {} is outside configured project root {}",
+            candidate.display(),
+            fallback.display()
+        );
+    }
+    Ok(candidate)
 }
 
 #[derive(Debug, Clone)]
@@ -590,6 +673,45 @@ fn affected_paths(extra: &serde_json::Map<String, Value>) -> Vec<String> {
         .collect()
 }
 
+fn tool_query(input: &ClaudeHookInput) -> String {
+    let mut parts = Vec::new();
+    if let Some(value) = input
+        .turn_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        parts.push(value.to_string());
+    }
+    if let Some(value) = input
+        .agent_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        parts.push(value.to_string());
+    }
+    if let Some(value) = input
+        .agent_type
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        parts.push(value.to_string());
+    }
+    if let Some(value) = input
+        .tool_name
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        parts.push(value.to_string());
+    }
+    if let Some(value) = input.tool_input.as_ref() {
+        parts.push(truncate_utf8(&value.to_string(), MAX_EXCERPT_BYTES));
+    }
+    if let Some(value) = input.tool_response.as_ref() {
+        parts.push(truncate_utf8(&value.to_string(), MAX_EXCERPT_BYTES));
+    }
+    parts.join(" ")
+}
+
 fn git_value(root: &Path, args: &[&str]) -> Option<String> {
     let output = std::process::Command::new("git")
         .args(args)
@@ -616,6 +738,7 @@ fn current_timestamp() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::integrations::session_recording::set_lint_ai_state;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -665,6 +788,18 @@ mod tests {
         .unwrap();
         assert!(output.hook_specific_output.is_none());
         assert!(!memory_root(&root).exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn disabled_memory_skips_retrieval_without_affecting_hook_success() {
+        let root = temp_dir("memory-disabled");
+        set_lint_ai_state(RecordingProvider::Claude, &root, false).unwrap();
+        let mut prompt = input(&root, None, "UserPromptSubmit");
+        prompt.prompt = Some("retrieve prior routing decision".to_string());
+        let output = handle_hook(ClaudeHookKind::UserPromptSubmit, prompt, &root).unwrap();
+        assert!(output.hook_specific_output.is_none());
+        assert!(!memory_root(&root).join("index.json").exists());
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -864,6 +999,102 @@ mod tests {
             .additional_context;
         assert_eq!(context.matches("- Source:").count(), 1);
         assert!(context.contains("Type: session-summary"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn post_tool_use_retrieves_relevant_memory_by_tool_name() {
+        let root = temp_dir("post-tool-use");
+        let transcript = root.join("transcript.jsonl");
+        fs::write(
+            &transcript,
+            concat!(
+                r#"{"type":"user","message":{"role":"user","content":"Run the search tests"}}"#,
+                "\n",
+                r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Completed search index integration tests"}]}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        handle_hook(
+            ClaudeHookKind::Stop,
+            input(&root, Some(transcript), "Stop"),
+            &root,
+        )
+        .unwrap();
+
+        let mut post_tool = input(&root, None, "PostToolUse");
+        post_tool.tool_name = Some("Bash".to_string());
+        post_tool.tool_input = Some(serde_json::json!({"command": "cargo test search"}));
+        let output = handle_hook(ClaudeHookKind::PostToolUse, post_tool, &root).unwrap();
+        assert!(output.hook_specific_output.is_some());
+        let context = output.hook_specific_output.unwrap().additional_context;
+        assert!(context.contains("search"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn subagent_start_retrieves_memory_by_prompt() {
+        let root = temp_dir("subagent-start");
+        let transcript = root.join("transcript.jsonl");
+        fs::write(
+            &transcript,
+            concat!(
+                r#"{"type":"user","message":{"role":"user","content":"Review the auth module"}}"#,
+                "\n",
+                r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Auth module uses JWT with RS256 signing"}]}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        handle_hook(
+            ClaudeHookKind::Stop,
+            input(&root, Some(transcript), "Stop"),
+            &root,
+        )
+        .unwrap();
+
+        let mut subagent = input(&root, None, "SubagentStart");
+        subagent.prompt = Some("auth module JWT signing".to_string());
+        let output = handle_hook(ClaudeHookKind::SubagentStart, subagent, &root).unwrap();
+        let context = output
+            .hook_specific_output
+            .expect("relevant memory should be retrieved")
+            .additional_context;
+        assert!(context.contains("JWT"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn subagent_stop_captures_outcome_and_is_idempotent() {
+        let root = temp_dir("subagent-stop");
+        let transcript = root.join("transcript.jsonl");
+        fs::write(
+            &transcript,
+            concat!(
+                r#"{"type":"assistant","message":{"role":"assistant","content":"Delegated auth review complete"}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        let stop_input = input(&root, Some(transcript.clone()), "SubagentStop");
+        handle_hook(ClaudeHookKind::SubagentStop, stop_input.clone(), &root).unwrap();
+        handle_hook(ClaudeHookKind::SubagentStop, stop_input, &root).unwrap();
+
+        let store = open_store(&root).unwrap();
+        assert_eq!(
+            store.records().len(),
+            1,
+            "replayed subagent-stop must be idempotent"
+        );
+        let doc_type = store
+            .records()
+            .into_iter()
+            .find_map(|r| r.filters.get("document_type").cloned());
+        assert_eq!(doc_type.as_deref(), Some("outcome"));
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/integrations/claude_code/hooks/protocol.rs
+++ b/src/integrations/claude_code/hooks/protocol.rs
@@ -13,6 +13,18 @@ pub struct ClaudeHookInput {
     #[serde(default)]
     pub prompt: Option<String>,
     #[serde(default)]
+    pub tool_name: Option<String>,
+    #[serde(default)]
+    pub tool_input: Option<Value>,
+    #[serde(default)]
+    pub tool_response: Option<Value>,
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    #[serde(default)]
+    pub agent_type: Option<String>,
+    #[serde(default)]
+    pub turn_id: Option<String>,
+    #[serde(default)]
     pub expansion_type: Option<String>,
     #[serde(default)]
     pub command_name: Option<String>,
@@ -94,5 +106,41 @@ mod tests {
         }))
         .unwrap();
         assert!(input.cwd.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn parses_post_tool_use_fields() {
+        let input: ClaudeHookInput = serde_json::from_value(serde_json::json!({
+            "session_id": "session-1",
+            "cwd": "/tmp",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "cargo test"},
+            "tool_response": {"output": "test result: ok"},
+            "turn_id": "turn-42"
+        }))
+        .unwrap();
+
+        assert_eq!(input.tool_name.as_deref(), Some("Bash"));
+        assert_eq!(input.turn_id.as_deref(), Some("turn-42"));
+        assert!(input.tool_input.is_some());
+        assert!(input.tool_response.is_some());
+    }
+
+    #[test]
+    fn parses_subagent_fields() {
+        let input: ClaudeHookInput = serde_json::from_value(serde_json::json!({
+            "session_id": "session-1",
+            "cwd": "/tmp",
+            "hook_event_name": "SubagentStart",
+            "agent_id": "agent-7",
+            "agent_type": "claude",
+            "prompt": "review the auth module"
+        }))
+        .unwrap();
+
+        assert_eq!(input.agent_id.as_deref(), Some("agent-7"));
+        assert_eq!(input.agent_type.as_deref(), Some("claude"));
+        assert_eq!(input.prompt.as_deref(), Some("review the auth module"));
     }
 }

--- a/src/integrations/claude_code/mod.rs
+++ b/src/integrations/claude_code/mod.rs
@@ -2,12 +2,15 @@ pub mod document;
 pub mod hooks;
 
 use crate::config::normalize_list;
+use crate::graph::{Graph, Tier0Record};
 use crate::integrations::mcp_index;
 use crate::integrations::mcp_transport;
 use crate::integrations::mcp_transport::{
     JsonRpcError, JsonRpcRequest, JsonRpcResponse, ToolDefinition,
 };
-use crate::graph::{Graph, Tier0Record};
+use crate::integrations::session_recording::{
+    lint_ai_enabled, recording_state, set_lint_ai_state, set_recording_state, RecordingProvider,
+};
 use crate::pipeline::{IndexStore, MemoryIndexLayout, PipelineOptions};
 use crate::segments::SegmentRoutingStrategy;
 use crate::source::SourceDocument;
@@ -17,7 +20,7 @@ use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::env;
 use std::fs;
-use std::io::{self, BufReader};
+use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
@@ -29,9 +32,13 @@ const HOOK_EVENTS: &[(&str, &str)] = &[
     ("SessionStart", "session-start"),
     ("UserPromptSubmit", "user-prompt-submit"),
     ("UserPromptExpansion", "user-prompt-expansion"),
+    ("PreToolUse", "pre-tool-use"),
+    ("PostToolUse", "post-tool-use"),
     ("PreCompact", "pre-compact"),
     ("Stop", "stop"),
     ("SessionEnd", "session-end"),
+    ("SubagentStart", "subagent-start"),
+    ("SubagentStop", "subagent-stop"),
 ];
 
 #[derive(Debug, Clone)]
@@ -69,6 +76,10 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
     let root = root
         .canonicalize()
         .with_context(|| format!("failed to canonicalize {}", root.display()))?;
+    let executable = env::current_exe()
+        .context("failed to locate lint-ai executable; refusing PATH-based installation")?
+        .to_string_lossy()
+        .into_owned();
     let mut config = read_claude_config(&config_path)?;
     let entry = config
         .mcp_servers
@@ -77,7 +88,7 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
     let entry = entry
         .as_object_mut()
         .context("Claude MCP server entry must be a JSON object")?;
-    entry.insert("command".to_string(), json!("lint-ai"));
+    entry.insert("command".to_string(), json!(executable));
     entry.insert(
         "args".to_string(),
         json!(["--claude-code-serve", root.to_string_lossy().into_owned()]),
@@ -98,6 +109,17 @@ pub fn install_memory_skill(root: &Path) -> Result<PathBuf> {
     if let Some(parent) = skill_path.parent() {
         fs::create_dir_all(parent)?;
     }
+    if skill_path.exists() {
+        let existing = fs::read_to_string(&skill_path)
+            .with_context(|| format!("failed to read existing skill {}", skill_path.display()))?;
+        if existing != include_str!("skill.md") {
+            anyhow::bail!(
+                "refusing to overwrite existing Claude skill {}; remove it or back it up first",
+                skill_path.display()
+            );
+        }
+        return Ok(skill_path);
+    }
     fs::write(&skill_path, include_str!("skill.md"))?;
     Ok(skill_path)
 }
@@ -111,9 +133,9 @@ pub fn install_hook_settings(root: &Path, settings_path: Option<&Path>) -> Resul
         .canonicalize()
         .with_context(|| format!("failed to canonicalize {}", root.display()))?;
     let executable = env::current_exe()
-        .ok()
-        .map(|path| path.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "lint-ai".to_string());
+        .context("failed to locate lint-ai executable; refusing PATH-based installation")?
+        .to_string_lossy()
+        .into_owned();
     let mut settings = read_json_object(&settings_path)?;
     let hooks = settings
         .entry("hooks".to_string())
@@ -138,8 +160,47 @@ pub fn install_hook_settings(root: &Path, settings_path: Option<&Path>) -> Resul
         }));
     }
 
+    // Claude supports a custom persistent status line. Preserve an existing
+    // user status line and only install ours when no status line is configured.
+    if !settings.contains_key("statusLine") {
+        settings.insert(
+            "statusLine".to_string(),
+            json!({
+                "type": "command",
+                "command": format!("{} --claude-code-statusline", shell_quote(&executable)),
+                "refreshInterval": 2
+            }),
+        );
+    }
+
     write_json_object(&settings_path, &settings)?;
     Ok(settings_path)
+}
+
+/// Render the compact state indicator consumed by Claude Code's status line.
+/// Claude sends session metadata as JSON on stdin, including the active cwd.
+pub fn run_status_line() -> Result<()> {
+    let mut input = String::new();
+    io::stdin().lock().read_to_string(&mut input)?;
+    let payload: Value = serde_json::from_str(&input).unwrap_or_default();
+    let cwd = payload
+        .get("workspace")
+        .and_then(|workspace| workspace.get("current_dir"))
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("cwd").and_then(Value::as_str))
+        .unwrap_or(".");
+    let root = Path::new(cwd);
+    let memory_on = lint_ai_enabled(RecordingProvider::Claude, root)?;
+    let recording_on = recording_state(RecordingProvider::Claude, root)
+        .ok()
+        .and_then(|state| state.get("enabled").and_then(Value::as_bool))
+        .unwrap_or(false);
+    println!(
+        "Lint-AI:{} | Record:{}",
+        if memory_on { "ON" } else { "OFF" },
+        if recording_on { "ON" } else { "OFF" }
+    );
+    Ok(())
 }
 
 pub fn run_server(root: &Path, options: ClaudeCodeServerOptions<'_>) -> Result<()> {
@@ -388,6 +449,87 @@ impl ClaudeMcp {
                     error: None,
                 })
             }
+            "enable_lint_ai" => {
+                if let Some(name) = unknown_argument(&arguments, &[]) {
+                    return Ok(error_response(
+                        id,
+                        -32602,
+                        &format!("unknown argument: {name}"),
+                    ));
+                }
+                let state = set_lint_ai_state(RecordingProvider::Claude, &self.root, true)?;
+                set_recording_state(RecordingProvider::Claude, &self.root, true)?;
+                Ok(text_response(id, &serde_json::to_string_pretty(&state)?))
+            }
+            "disable_lint_ai" => {
+                if let Some(name) = unknown_argument(&arguments, &[]) {
+                    return Ok(error_response(
+                        id,
+                        -32602,
+                        &format!("unknown argument: {name}"),
+                    ));
+                }
+                let state = set_lint_ai_state(RecordingProvider::Claude, &self.root, false)?;
+                Ok(text_response(id, &serde_json::to_string_pretty(&state)?))
+            }
+            "lint_ai_status" => {
+                if let Some(name) = unknown_argument(&arguments, &[]) {
+                    return Ok(error_response(
+                        id,
+                        -32602,
+                        &format!("unknown argument: {name}"),
+                    ));
+                }
+                let memory_on = lint_ai_enabled(RecordingProvider::Claude, &self.root)?;
+                let recording_on = recording_state(RecordingProvider::Claude, &self.root)?
+                    .get("enabled")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let state = json!({
+                    "provider": "claude",
+                    "enabled": memory_on,
+                    "recording_enabled": recording_on,
+                    "display": format!(
+                        "Lint-AI:{} | Record:{}",
+                        if memory_on { "ON" } else { "OFF" },
+                        if recording_on { "ON" } else { "OFF" }
+                    )
+                });
+                Ok(text_response(id, &serde_json::to_string_pretty(&state)?))
+            }
+            "record_session" => {
+                if let Some(name) = unknown_argument(&arguments, &["action"]) {
+                    return Ok(error_response(
+                        id,
+                        -32602,
+                        &format!("unknown record_session argument: {name}"),
+                    ));
+                }
+                let action = arguments
+                    .get("action")
+                    .and_then(Value::as_str)
+                    .unwrap_or("status");
+                let state = match action {
+                    "start" => set_recording_state(RecordingProvider::Claude, &self.root, true)?,
+                    "stop" => set_recording_state(RecordingProvider::Claude, &self.root, false)?,
+                    "status" => recording_state(RecordingProvider::Claude, &self.root)?,
+                    _ => {
+                        return Ok(error_response(
+                            id,
+                            -32602,
+                            "action must be start, stop, or status",
+                        ))
+                    }
+                };
+                Ok(JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: Some(json!({
+                        "content": [{"type": "text", "text": serde_json::to_string_pretty(&state)?}]
+                    })),
+                    error: None,
+                })
+            }
             "info" => {
                 if let Some(name) = unknown_argument(&arguments, &[]) {
                     return Ok(error_response(
@@ -445,6 +587,32 @@ impl ClaudeMcp {
                     "additionalProperties": false
                 }),
             },
+            ToolDefinition {
+                name: "record_session".to_string(),
+                description: "Start, stop, or inspect opt-in local session recording. Recording is capture-only and does not inject memory.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "action": {"type": "string", "enum": ["start", "stop", "status"], "default": "status"}
+                    },
+                    "additionalProperties": false
+                }),
+            },
+            ToolDefinition {
+                name: "enable_lint_ai".to_string(),
+                description: "Enable Lint-AI memory retrieval and capture for future hook events. This also turns on session recording by default; use record_session stop to override recording independently.".to_string(),
+                input_schema: json!({"type":"object","properties":{},"additionalProperties":false}),
+            },
+            ToolDefinition {
+                name: "disable_lint_ai".to_string(),
+                description: "Disable Lint-AI memory retrieval and capture for future hook events. Session recording remains unchanged and can be controlled with record_session.".to_string(),
+                input_schema: json!({"type":"object","properties":{},"additionalProperties":false}),
+            },
+            ToolDefinition {
+                name: "lint_ai_status".to_string(),
+                description: "Report whether Lint-AI memory behavior is enabled for this project.".to_string(),
+                input_schema: json!({"type":"object","properties":{},"additionalProperties":false}),
+            },
         ]
     }
 }
@@ -476,6 +644,15 @@ fn error_response(id: Option<Value>, code: i64, message: &str) -> JsonRpcRespons
             code,
             message: message.to_string(),
         }),
+    }
+}
+
+fn text_response(id: Option<Value>, text: &str) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: Some(json!({"content": [{"type": "text", "text": text}]})),
+        error: None,
     }
 }
 
@@ -593,6 +770,21 @@ mod tests {
         }
     }
 
+    fn call_tool(mcp: &ClaudeMcp, name: &str, arguments: Value) -> Value {
+        let response = mcp
+            .handle_request(JsonRpcRequest {
+                id: Some(json!(1)),
+                method: "tools/call".to_string(),
+                params: Some(json!({"name": name, "arguments": arguments})),
+            })
+            .unwrap();
+        let text = response.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        serde_json::from_str(&text).unwrap()
+    }
+
     #[test]
     fn install_user_config_merges_existing_servers() {
         let config_path = temp_path("claude-config");
@@ -617,7 +809,10 @@ mod tests {
             parsed.mcp_servers["lint-ai"]["env"]["KEEP"].as_str(),
             Some("yes")
         );
-        assert_eq!(parsed.mcp_servers["lint-ai"]["command"].as_str(), Some("lint-ai"));
+        assert_eq!(
+            parsed.mcp_servers["lint-ai"]["command"].as_str(),
+            Some(env::current_exe().unwrap().to_string_lossy().as_ref())
+        );
         assert_eq!(
             parsed.mcp_servers["lint-ai"]["args"]
                 .as_array()
@@ -653,6 +848,11 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("--claude-code-hook stop"));
+        assert_eq!(settings["statusLine"]["type"], "command");
+        assert!(settings["statusLine"]["command"]
+            .as_str()
+            .unwrap()
+            .contains("--claude-code-statusline"));
         assert_eq!(
             settings["hooks"]["UserPromptExpansion"]
                 .as_array()
@@ -664,7 +864,7 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_exposes_search_and_info() {
+    fn tools_list_exposes_search_info_and_recording() {
         let root = temp_dir("mcp-tools");
         let mcp = test_mcp(root.clone(), vec![]);
         let response = mcp
@@ -681,7 +881,67 @@ mod tests {
             .iter()
             .map(|tool| tool["name"].as_str().unwrap().to_string())
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["search".to_string(), "info".to_string()]);
+        assert_eq!(
+            names,
+            vec![
+                "search".to_string(),
+                "info".to_string(),
+                "record_session".to_string(),
+                "enable_lint_ai".to_string(),
+                "disable_lint_ai".to_string(),
+                "lint_ai_status".to_string()
+            ]
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn control_tools_cover_recording_and_memory_matrix() {
+        let root = temp_dir("control-matrix");
+        let mcp = test_mcp(root.clone(), vec![]);
+
+        assert_eq!(
+            call_tool(&mcp, "record_session", json!({"action": "status"}))["enabled"],
+            false
+        );
+        assert_eq!(
+            call_tool(&mcp, "enable_lint_ai", json!({}))["enabled"],
+            true
+        );
+        let status = call_tool(&mcp, "lint_ai_status", json!({}));
+        assert_eq!(status["enabled"], true);
+        assert_eq!(status["recording_enabled"], true);
+        assert_eq!(status["display"], "Lint-AI:ON | Record:ON");
+        assert_eq!(
+            call_tool(&mcp, "record_session", json!({"action": "stop"}))["enabled"],
+            false
+        );
+        let status = call_tool(&mcp, "lint_ai_status", json!({}));
+        assert_eq!(status["enabled"], true);
+        assert_eq!(status["recording_enabled"], false);
+        assert_eq!(status["display"], "Lint-AI:ON | Record:OFF");
+        assert_eq!(
+            call_tool(&mcp, "disable_lint_ai", json!({}))["enabled"],
+            false
+        );
+        assert_eq!(
+            call_tool(&mcp, "record_session", json!({"action": "start"}))["enabled"],
+            true
+        );
+        let status = call_tool(&mcp, "lint_ai_status", json!({}));
+        assert_eq!(status["enabled"], false);
+        assert_eq!(status["recording_enabled"], true);
+        assert_eq!(status["display"], "Lint-AI:OFF | Record:ON");
+        assert_eq!(
+            call_tool(&mcp, "enable_lint_ai", json!({}))["enabled"],
+            true
+        );
+        assert_eq!(
+            call_tool(&mcp, "record_session", json!({"action": "stop"}))["enabled"],
+            false
+        );
+        let status = call_tool(&mcp, "lint_ai_status", json!({}));
+        assert_eq!(status["display"], "Lint-AI:ON | Record:OFF");
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -809,5 +1069,4 @@ mod tests {
         assert_eq!(payload["results"][0]["doc_id"], "memory-1");
         fs::remove_dir_all(root).unwrap();
     }
-
 }

--- a/src/integrations/claude_code/skill.md
+++ b/src/integrations/claude_code/skill.md
@@ -26,6 +26,39 @@ Use this sequence:
 Use `mcp__lint-ai__info` only to check MCP workspace status or diagnose the
 server. It is not a memory search and should not replace `search`.
 
+## Explicit session recording
+
+Session recording is off by default until the user enables Lint-AI. Enabling
+Lint-AI also starts recording by default. Users can explicitly override this
+with `mcp__lint-ai__record_session` and `{"action":"stop"}`. Recording is
+capture-only: it records redacted lifecycle events locally and does not inject
+memory into the session.
+
+When the user asks to stop recording, call the same tool with
+`{"action":"stop"}`. Use `{"action":"status"}` only when the user asks
+whether recording is active. Never start recording implicitly for ordinary
+memory searches or project work.
+
+## Lint-AI memory controls
+
+When the user explicitly asks to turn Lint-AI memory off, call
+`mcp__lint-ai__disable_lint_ai`. When the user asks to turn it back on, call
+`mcp__lint-ai__enable_lint_ai`. These controls affect future Lint-AI retrieval
+and memory capture. Enabling memory also starts recording by default, while
+disabling memory leaves the recording choice unchanged. Use
+`mcp__lint-ai__lint_ai_status` when the user asks whether memory behavior is
+enabled. Do not toggle memory implicitly during a task.
+
+When installed, Claude Code may show `Lint-AI:ON | Record:OFF` in its native
+persistent status line. This is informational only; use the MCP control tools
+to change either state. Preserve any user-defined Claude status line.
+
+Replay is a separate CLI operation, not an automatic MCP action. Use
+`lint-ai --replay-session <session-id> --session-provider claude
+--replay-enable-lint-ai` when the user explicitly asks to rerun a recorded
+prompt with Claude. Replay always records its output and creates a new session
+ID; it does not modify the baseline archive.
+
 For requests that are exclusively about the current contents of a file or
 current command output, repository tools may be used directly. Do not claim
 that MCP was searched when the call was unavailable or returned no results.

--- a/src/integrations/codex/hooks/mod.rs
+++ b/src/integrations/codex/hooks/mod.rs
@@ -1,6 +1,10 @@
 mod protocol;
 
 use super::document::{CodexDocument, CodexDocumentType};
+use crate::integrations::session_recording::{
+    lint_ai_enabled, record_event_if_enabled, record_transcript_usage_if_available,
+    RecordingProvider,
+};
 use crate::pipeline::{IndexStore, MemoryIndexLayout, PipelineOptions};
 use crate::segments::SegmentRoutingStrategy;
 use anyhow::{Context, Result};
@@ -19,6 +23,7 @@ const MAX_TRANSCRIPT_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_CAPTURED_MESSAGES: usize = 6;
 const MAX_MEMORY_FIELD_BYTES: usize = 1_500;
 const MAX_EXCERPT_BYTES: usize = 800;
+const MIN_TOOL_QUERY_TERMS: usize = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodexHookKind {
@@ -56,8 +61,51 @@ impl CodexHookKind {
 }
 
 pub fn run_hook(kind: CodexHookKind, fallback_root: &Path) -> Result<()> {
-    let input: CodexHookInput = serde_json::from_reader(std::io::stdin().lock())
+    let raw: Value = serde_json::from_reader(std::io::stdin().lock())
         .context("failed to parse Codex hook input")?;
+    let input: CodexHookInput =
+        serde_json::from_value(raw).context("failed to decode Codex hook input")?;
+    let root = resolve_root(&input.cwd, fallback_root)?;
+    let payload = serde_json::json!({
+        "hook_event_name": input.hook_event_name,
+        "prompt": input.prompt,
+        "tool_name": input.tool_name,
+        "tool_input": input.tool_input,
+        "tool_response": input.tool_response,
+        "transcript_path": input.transcript_path,
+        "agent_id": input.agent_id,
+        "agent_type": input.agent_type,
+        "turn_id": input.turn_id,
+        "expansion_type": input.expansion_type,
+        "command_name": input.command_name,
+        "command_args": input.command_args,
+        "command_source": input.command_source,
+        "permission_mode": input.permission_mode,
+        "trigger": input.trigger,
+        "reason": input.reason,
+        "extra": input.extra,
+    });
+    if let Err(error) = record_event_if_enabled(
+        RecordingProvider::Codex,
+        &root,
+        &input.session_id,
+        kind.event_name(),
+        payload,
+    ) {
+        eprintln!("warning: Lint-AI session recording failed open: {error:#}");
+    }
+    if matches!(kind, CodexHookKind::Stop) && !input.stop_hook_active {
+        if let Err(error) = record_transcript_usage_if_available(
+            RecordingProvider::Codex,
+            &root,
+            &input.session_id,
+            input.transcript_path.as_deref(),
+            input.turn_id.as_deref(),
+            "codex-transcript",
+        ) {
+            eprintln!("warning: Codex transcript usage capture failed open: {error:#}");
+        }
+    }
     let started = Instant::now();
     let output = match handle_hook(kind, input, fallback_root) {
         Ok(output) => output,
@@ -123,6 +171,9 @@ fn handle_hook(
         );
     }
     let root = resolve_root(&input.cwd, fallback_root)?;
+    if !lint_ai_enabled(RecordingProvider::Codex, &root)? {
+        return Ok(CodexHookOutput::default());
+    }
     match kind {
         CodexHookKind::SessionStart => retrieve(
             &root,
@@ -134,9 +185,16 @@ fn handle_hook(
             kind.event_name(),
             input.prompt.as_deref().unwrap_or_default(),
         ),
-        CodexHookKind::PreToolUse
-        | CodexHookKind::PermissionRequest
-        | CodexHookKind::PostToolUse => retrieve(&root, kind.event_name(), &tool_query(&input)),
+        CodexHookKind::PreToolUse | CodexHookKind::PermissionRequest => {
+            retrieve(&root, kind.event_name(), &tool_query(&input))
+        }
+        CodexHookKind::PostToolUse => {
+            let query = tool_query(&input);
+            if query_terms(&query).len() < MIN_TOOL_QUERY_TERMS {
+                return Ok(CodexHookOutput::default());
+            }
+            retrieve(&root, kind.event_name(), &query)
+        }
         CodexHookKind::UserPromptExpansion => {
             let query = [
                 input.expansion_type.as_deref(),
@@ -225,26 +283,53 @@ fn retrieve(root: &Path, event_name: &str, query: &str) -> Result<CodexHookOutpu
 
 fn tool_query(input: &CodexHookInput) -> String {
     let mut parts = Vec::new();
-    if let Some(value) = input.turn_id.as_deref().filter(|value| !value.trim().is_empty()) {
-        parts.push(value.to_string());
-    }
-    if let Some(value) = input.agent_id.as_deref().filter(|value| !value.trim().is_empty()) {
-        parts.push(value.to_string());
-    }
-    if let Some(value) = input.agent_type.as_deref().filter(|value| !value.trim().is_empty()) {
-        parts.push(value.to_string());
-    }
-    if let Some(value) = input.tool_name.as_deref().filter(|value| !value.trim().is_empty()) {
-        parts.push(value.to_string());
-    }
-    if let Some(value) = input.permission_mode.as_deref().filter(|value| !value.trim().is_empty())
+    if let Some(value) = input
+        .turn_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
     {
         parts.push(value.to_string());
     }
-    if let Some(value) = input.trigger.as_deref().filter(|value| !value.trim().is_empty()) {
+    if let Some(value) = input
+        .agent_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
         parts.push(value.to_string());
     }
-    if let Some(value) = input.reason.as_deref().filter(|value| !value.trim().is_empty()) {
+    if let Some(value) = input
+        .agent_type
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        parts.push(value.to_string());
+    }
+    if let Some(value) = input
+        .tool_name
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        parts.push(value.to_string());
+    }
+    if let Some(value) = input
+        .permission_mode
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        parts.push(value.to_string());
+    }
+    if let Some(value) = input
+        .trigger
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        parts.push(value.to_string());
+    }
+    if let Some(value) = input
+        .reason
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
         parts.push(value.to_string());
     }
     if let Some(value) = input.tool_input.as_ref() {
@@ -445,7 +530,9 @@ fn find_session_transcript(sessions_root: &Path, session_id: &str) -> Option<Pat
             } else if path
                 .file_name()
                 .and_then(|name| name.to_str())
-                .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(&expected_suffix))
+                .is_some_and(|name| {
+                    name.starts_with("rollout-") && name.ends_with(&expected_suffix)
+                })
             {
                 return Some(path);
             }
@@ -470,17 +557,26 @@ fn memory_root(root: &Path) -> PathBuf {
 }
 
 fn resolve_root(cwd: &Path, fallback_root: &Path) -> Result<PathBuf> {
-    let candidate = if cwd.as_os_str().is_empty() {
-        fallback_root
-    } else {
-        cwd
-    };
-    candidate.canonicalize().with_context(|| {
+    let fallback = fallback_root.canonicalize().with_context(|| {
         format!(
-            "failed to resolve Codex project root {}",
-            candidate.display()
+            "failed to resolve Codex fallback project root {}",
+            fallback_root.display()
         )
-    })
+    })?;
+    let candidate = if cwd.as_os_str().is_empty() {
+        fallback.clone()
+    } else {
+        cwd.canonicalize()
+            .with_context(|| format!("failed to resolve Codex project root {}", cwd.display()))?
+    };
+    if !candidate.starts_with(&fallback) {
+        anyhow::bail!(
+            "Codex hook cwd {} is outside configured project root {}",
+            candidate.display(),
+            fallback.display()
+        );
+    }
+    Ok(candidate)
 }
 
 #[derive(Debug, Clone)]
@@ -723,6 +819,7 @@ fn current_timestamp() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::integrations::session_recording::set_lint_ai_state;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -787,6 +884,18 @@ mod tests {
         .unwrap();
         assert!(output.hook_specific_output.is_none());
         assert!(!memory_root(&root).exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn disabled_memory_skips_retrieval_without_affecting_hook_success() {
+        let root = temp_dir("memory-disabled");
+        set_lint_ai_state(RecordingProvider::Codex, &root, false).unwrap();
+        let mut prompt = input(&root, None, "UserPromptSubmit");
+        prompt.prompt = Some("retrieve prior routing decision".to_string());
+        let output = handle_hook(CodexHookKind::UserPromptSubmit, prompt, &root).unwrap();
+        assert!(output.hook_specific_output.is_none());
+        assert!(!memory_root(&root).join("index.json").exists());
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/src/integrations/codex/mod.rs
+++ b/src/integrations/codex/mod.rs
@@ -2,12 +2,15 @@ pub mod document;
 pub mod hooks;
 
 use crate::config::normalize_list;
+use crate::graph::{Graph, Tier0Record};
 use crate::integrations::mcp_index;
 use crate::integrations::mcp_transport;
 use crate::integrations::mcp_transport::{
     JsonRpcError, JsonRpcRequest, JsonRpcResponse, ToolDefinition,
 };
-use crate::graph::{Graph, Tier0Record};
+use crate::integrations::session_recording::{
+    lint_ai_enabled, recording_state, set_lint_ai_state, set_recording_state, RecordingProvider,
+};
 use crate::pipeline::{IndexStore, MemoryIndexLayout, PipelineOptions};
 use crate::segments::SegmentRoutingStrategy;
 use crate::source::SourceDocument;
@@ -17,7 +20,7 @@ use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::env;
 use std::fs;
-use std::io::{self, BufReader};
+use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
@@ -86,6 +89,10 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
     let root = root
         .canonicalize()
         .with_context(|| format!("failed to canonicalize {}", root.display()))?;
+    let executable = env::current_exe()
+        .context("failed to locate lint-ai executable; refusing PATH-based installation")?
+        .to_string_lossy()
+        .into_owned();
     let mut config = if config_path.exists() {
         let current = fs::read_to_string(&config_path)?;
         if current.trim().is_empty() {
@@ -108,7 +115,7 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
         .as_table_mut()
         .context("Codex config 'mcp_servers' must be a table")?;
     let mut entry = TomlMap::new();
-    entry.insert("command".to_string(), TomlValue::String("lint-ai".to_string()));
+    entry.insert("command".to_string(), TomlValue::String(executable));
     entry.insert(
         "startup_timeout_sec".to_string(),
         TomlValue::Integer(MCP_STARTUP_TIMEOUT_SECONDS),
@@ -127,10 +134,7 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
     let features = features
         .as_table_mut()
         .context("Codex config 'features' must be a table")?;
-    features.insert(
-        "mcp_2026_07_28".to_string(),
-        TomlValue::Boolean(true),
-    );
+    features.insert("mcp_2026_07_28".to_string(), TomlValue::Boolean(true));
     write_text_object(&config_path, &toml::to_string_pretty(&config)?)
         .context("failed to write Codex config")?;
     Ok(config_path)
@@ -145,9 +149,9 @@ pub fn install_hook_settings(root: &Path, settings_path: Option<&Path>) -> Resul
         .canonicalize()
         .with_context(|| format!("failed to canonicalize {}", root.display()))?;
     let executable = env::current_exe()
-        .ok()
-        .map(|path| path.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "lint-ai".to_string());
+        .context("failed to locate lint-ai executable; refusing PATH-based installation")?
+        .to_string_lossy()
+        .into_owned();
     let mut settings = read_json_object(&settings_path)?;
     let hooks = settings
         .entry("hooks".to_string())
@@ -422,6 +426,87 @@ impl CodexMcp {
                     error: None,
                 })
             }
+            "enable_lint_ai" => {
+                if let Some(name) = unknown_argument(&arguments, &[]) {
+                    return Ok(error_response(
+                        id,
+                        -32602,
+                        &format!("unknown argument: {name}"),
+                    ));
+                }
+                let state = set_lint_ai_state(RecordingProvider::Codex, &self.root, true)?;
+                set_recording_state(RecordingProvider::Codex, &self.root, true)?;
+                Ok(text_response(id, &serde_json::to_string_pretty(&state)?))
+            }
+            "disable_lint_ai" => {
+                if let Some(name) = unknown_argument(&arguments, &[]) {
+                    return Ok(error_response(
+                        id,
+                        -32602,
+                        &format!("unknown argument: {name}"),
+                    ));
+                }
+                let state = set_lint_ai_state(RecordingProvider::Codex, &self.root, false)?;
+                Ok(text_response(id, &serde_json::to_string_pretty(&state)?))
+            }
+            "lint_ai_status" => {
+                if let Some(name) = unknown_argument(&arguments, &[]) {
+                    return Ok(error_response(
+                        id,
+                        -32602,
+                        &format!("unknown argument: {name}"),
+                    ));
+                }
+                let memory_on = lint_ai_enabled(RecordingProvider::Codex, &self.root)?;
+                let recording_on = recording_state(RecordingProvider::Codex, &self.root)?
+                    .get("enabled")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let state = json!({
+                    "provider": "codex",
+                    "enabled": memory_on,
+                    "recording_enabled": recording_on,
+                    "display": format!(
+                        "Lint-AI:{} | Record:{}",
+                        if memory_on { "ON" } else { "OFF" },
+                        if recording_on { "ON" } else { "OFF" }
+                    )
+                });
+                Ok(text_response(id, &serde_json::to_string_pretty(&state)?))
+            }
+            "record_session" => {
+                if let Some(name) = unknown_argument(&arguments, &["action"]) {
+                    return Ok(error_response(
+                        id,
+                        -32602,
+                        &format!("unknown record_session argument: {name}"),
+                    ));
+                }
+                let action = arguments
+                    .get("action")
+                    .and_then(Value::as_str)
+                    .unwrap_or("status");
+                let state = match action {
+                    "start" => set_recording_state(RecordingProvider::Codex, &self.root, true)?,
+                    "stop" => set_recording_state(RecordingProvider::Codex, &self.root, false)?,
+                    "status" => recording_state(RecordingProvider::Codex, &self.root)?,
+                    _ => {
+                        return Ok(error_response(
+                            id,
+                            -32602,
+                            "action must be start, stop, or status",
+                        ))
+                    }
+                };
+                Ok(JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: Some(json!({
+                        "content": [{"type": "text", "text": serde_json::to_string_pretty(&state)?}]
+                    })),
+                    error: None,
+                })
+            }
             "info" => {
                 if let Some(name) = unknown_argument(&arguments, &[]) {
                     return Ok(error_response(
@@ -479,8 +564,62 @@ impl CodexMcp {
                     "additionalProperties": false
                 }),
             },
+            ToolDefinition {
+                name: "record_session".to_string(),
+                description: "Start, stop, or inspect opt-in local session recording. Recording is capture-only and does not inject memory.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "action": {"type": "string", "enum": ["start", "stop", "status"], "default": "status"}
+                    },
+                    "additionalProperties": false
+                }),
+            },
+            ToolDefinition {
+                name: "enable_lint_ai".to_string(),
+                description: "Enable Lint-AI memory retrieval and capture for future hook events. This also turns on session recording by default; use record_session stop to override recording independently.".to_string(),
+                input_schema: json!({"type":"object","properties":{},"additionalProperties":false}),
+            },
+            ToolDefinition {
+                name: "disable_lint_ai".to_string(),
+                description: "Disable Lint-AI memory retrieval and capture for future hook events. Session recording remains unchanged and can be controlled with record_session.".to_string(),
+                input_schema: json!({"type":"object","properties":{},"additionalProperties":false}),
+            },
+            ToolDefinition {
+                name: "lint_ai_status".to_string(),
+                description: "Report whether Lint-AI memory behavior is enabled for this project.".to_string(),
+                input_schema: json!({"type":"object","properties":{},"additionalProperties":false}),
+            },
         ]
     }
+}
+
+/// Render the provider-owned status indicator for Codex integrations that can
+/// execute an external status command. Codex's built-in TUI currently accepts
+/// only its own fixed status item identifiers, so the installer does not put
+/// this command into `tui.status_line` automatically.
+pub fn run_status_line() -> Result<()> {
+    let mut input = String::new();
+    io::stdin().lock().read_to_string(&mut input)?;
+    let payload: Value = serde_json::from_str(&input).unwrap_or_default();
+    let cwd = payload
+        .get("workspace")
+        .and_then(|workspace| workspace.get("current_dir"))
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("cwd").and_then(Value::as_str))
+        .unwrap_or(".");
+    let root = Path::new(cwd);
+    let memory_on = lint_ai_enabled(RecordingProvider::Codex, root)?;
+    let recording_on = recording_state(RecordingProvider::Codex, root)?
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    println!(
+        "Lint-AI:{} | Record:{}",
+        if memory_on { "ON" } else { "OFF" },
+        if recording_on { "ON" } else { "OFF" }
+    );
+    Ok(())
 }
 
 fn segmented_store_options() -> PipelineOptions {
@@ -510,6 +649,15 @@ fn error_response(id: Option<Value>, code: i64, message: &str) -> JsonRpcRespons
             code,
             message: message.to_string(),
         }),
+    }
+}
+
+fn text_response(id: Option<Value>, text: &str) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: Some(json!({"content": [{"type": "text", "text": text}]})),
+        error: None,
     }
 }
 
@@ -618,6 +766,21 @@ mod tests {
         }
     }
 
+    fn call_tool(mcp: &CodexMcp, name: &str, arguments: Value) -> Value {
+        let response = mcp
+            .handle_request(JsonRpcRequest {
+                id: Some(json!(1)),
+                method: "tools/call".to_string(),
+                params: Some(json!({"name": name, "arguments": arguments})),
+            })
+            .unwrap();
+        let text = response.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        serde_json::from_str(&text).unwrap()
+    }
+
     #[test]
     fn install_user_config_merges_existing_servers() {
         let config_path = temp_path("claude-config");
@@ -644,10 +807,13 @@ args = ["old"]
         let text = fs::read_to_string(&config_path).unwrap();
         let parsed: TomlValue = text.parse().unwrap();
         assert_eq!(parsed["title"].as_str(), Some("keep"));
-        assert_eq!(parsed["mcp_servers"]["existing"]["command"].as_str(), Some("npx"));
+        assert_eq!(
+            parsed["mcp_servers"]["existing"]["command"].as_str(),
+            Some("npx")
+        );
         assert_eq!(
             parsed["mcp_servers"]["lint-ai"]["command"].as_str(),
-            Some("lint-ai")
+            Some(env::current_exe().unwrap().to_string_lossy().as_ref())
         );
         assert_eq!(
             parsed["mcp_servers"]["lint-ai"]["startup_timeout_sec"].as_integer(),
@@ -700,7 +866,7 @@ args = ["old"]
     }
 
     #[test]
-    fn tools_list_exposes_search_and_info() {
+    fn tools_list_exposes_search_info_and_recording() {
         let root = temp_dir("mcp-tools");
         let mcp = test_mcp(root.clone(), vec![]);
         let response = mcp
@@ -717,7 +883,67 @@ args = ["old"]
             .iter()
             .map(|tool| tool["name"].as_str().unwrap().to_string())
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["search".to_string(), "info".to_string()]);
+        assert_eq!(
+            names,
+            vec![
+                "search".to_string(),
+                "info".to_string(),
+                "record_session".to_string(),
+                "enable_lint_ai".to_string(),
+                "disable_lint_ai".to_string(),
+                "lint_ai_status".to_string()
+            ]
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn control_tools_cover_recording_and_memory_matrix() {
+        let root = temp_dir("control-matrix");
+        let mcp = test_mcp(root.clone(), vec![]);
+
+        assert_eq!(
+            call_tool(&mcp, "record_session", json!({"action": "status"}))["enabled"],
+            false
+        );
+        assert_eq!(
+            call_tool(&mcp, "enable_lint_ai", json!({}))["enabled"],
+            true
+        );
+        let status = call_tool(&mcp, "lint_ai_status", json!({}));
+        assert_eq!(status["enabled"], true);
+        assert_eq!(status["recording_enabled"], true);
+        assert_eq!(status["display"], "Lint-AI:ON | Record:ON");
+        assert_eq!(
+            call_tool(&mcp, "record_session", json!({"action": "stop"}))["enabled"],
+            false
+        );
+        let status = call_tool(&mcp, "lint_ai_status", json!({}));
+        assert_eq!(status["enabled"], true);
+        assert_eq!(status["recording_enabled"], false);
+        assert_eq!(status["display"], "Lint-AI:ON | Record:OFF");
+        assert_eq!(
+            call_tool(&mcp, "disable_lint_ai", json!({}))["enabled"],
+            false
+        );
+        assert_eq!(
+            call_tool(&mcp, "record_session", json!({"action": "start"}))["enabled"],
+            true
+        );
+        let status = call_tool(&mcp, "lint_ai_status", json!({}));
+        assert_eq!(status["enabled"], false);
+        assert_eq!(status["recording_enabled"], true);
+        assert_eq!(status["display"], "Lint-AI:OFF | Record:ON");
+        assert_eq!(
+            call_tool(&mcp, "enable_lint_ai", json!({}))["enabled"],
+            true
+        );
+        assert_eq!(
+            call_tool(&mcp, "record_session", json!({"action": "stop"}))["enabled"],
+            false
+        );
+        let status = call_tool(&mcp, "lint_ai_status", json!({}));
+        assert_eq!(status["display"], "Lint-AI:ON | Record:OFF");
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -845,5 +1071,4 @@ args = ["old"]
         assert_eq!(payload["results"][0]["doc_id"], "memory-1");
         fs::remove_dir_all(root).unwrap();
     }
-
 }

--- a/src/integrations/mcp_index.rs
+++ b/src/integrations/mcp_index.rs
@@ -93,12 +93,21 @@ fn workspace_state(root: &Path) -> Option<Value> {
 }
 
 fn git_output(root: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git").args(args).current_dir(root).output().ok()?;
-    output.status.success().then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn index_is_current(index_root: &Path, state: Option<&Value>) -> bool {
-    let Some(state) = state else { return false; };
+    let Some(state) = state else {
+        return false;
+    };
     fs::read_to_string(index_root.join("workspace-state.json"))
         .ok()
         .and_then(|content| serde_json::from_str::<Value>(&content).ok())
@@ -107,8 +116,13 @@ fn index_is_current(index_root: &Path, state: Option<&Value>) -> bool {
 }
 
 fn write_index_state(index_root: &Path, state: Option<&Value>) -> Result<()> {
-    let Some(state) = state else { return Ok(()); };
+    let Some(state) = state else {
+        return Ok(());
+    };
     fs::create_dir_all(index_root)?;
-    fs::write(index_root.join("workspace-state.json"), serde_json::to_string_pretty(state)?)?;
+    fs::write(
+        index_root.join("workspace-state.json"),
+        serde_json::to_string_pretty(state)?,
+    )?;
     Ok(())
 }

--- a/src/integrations/mcp_transport.rs
+++ b/src/integrations/mcp_transport.rs
@@ -104,7 +104,11 @@ mod tests {
     #[test]
     fn reads_content_length_requests() {
         let body = br#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#;
-        let input = format!("Content-Length: {}\r\n\r\n{}", body.len(), String::from_utf8_lossy(body));
+        let input = format!(
+            "Content-Length: {}\r\n\r\n{}",
+            body.len(),
+            String::from_utf8_lossy(body)
+        );
         let (_, line_framed) = read_request(&mut Cursor::new(input)).unwrap().unwrap();
         assert!(!line_framed);
     }

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -2,6 +2,7 @@
 pub mod claude_code;
 #[cfg(feature = "codex")]
 pub mod codex;
-pub mod mcp_index;
 pub mod mcp_health;
+pub mod mcp_index;
 pub mod mcp_transport;
+pub mod session_recording;

--- a/src/integrations/session_recording.rs
+++ b/src/integrations/session_recording.rs
@@ -1,0 +1,1271 @@
+use crate::pipeline::{IndexStore, MemoryIndexLayout, PipelineOptions};
+use crate::segments::SegmentRoutingStrategy;
+use crate::source::SourceDocument;
+use anyhow::{Context, Result};
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const MAX_EVENT_BYTES: usize = 64 * 1024;
+const MAX_STRING_BYTES: usize = 8 * 1024;
+const MAX_ARRAY_ITEMS: usize = 128;
+const MAX_TRANSCRIPT_BYTES: u64 = 4 * 1024 * 1024;
+const REPLAY_SESSION_ENV: &str = "LINT_AI_REPLAY_SESSION_ID";
+
+#[derive(Debug, Clone, Copy)]
+pub enum RecordingProvider {
+    Claude,
+    Codex,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionImportReport {
+    pub session_id: String,
+    pub group_id: String,
+    pub imported_document_ids: Vec<String>,
+    pub skipped_events: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ReplayReport {
+    pub provider: String,
+    pub baseline_session_id: String,
+    pub replay_session_id: String,
+    pub replay_archive: String,
+    pub lint_ai_enabled: bool,
+    pub exit_code: Option<i32>,
+    pub output_bytes: usize,
+    pub prompt_count: usize,
+    pub recorded_event_count: usize,
+    pub recording_complete: bool,
+}
+
+/// Launch a fresh provider process from the recorded user prompts.
+/// Replay recording is always enabled for the duration of the process.
+pub fn replay_recorded_session(
+    provider: RecordingProvider,
+    project_root: &Path,
+    archive_override: Option<&Path>,
+    session_id: &str,
+    enable_lint_ai: bool,
+) -> Result<ReplayReport> {
+    let replay_workspace = ReplayWorkspace::create(project_root)?;
+    let archive_root = archive_override
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| session_root(provider, project_root));
+    let baseline_dir = archive_root.join(safe_component(session_id));
+    let events_path = baseline_dir.join("events.jsonl");
+    let prompts = recorded_prompts(&events_path)?;
+    let replay_session_id = format!(
+        "replay-{}-{}",
+        timestamp_compact(),
+        safe_component(session_id)
+    );
+    let replay_dir = archive_root.join(safe_component(&replay_session_id));
+    fs::create_dir_all(&replay_dir)?;
+    let manifest_path = replay_dir.join("manifest.json");
+    write_manifest(
+        &manifest_path,
+        &serde_json::json!({
+            "schema_version": 1,
+            "session_id": replay_session_id,
+            "provider": provider.as_str(),
+            "project_root": project_root,
+            "started_at": timestamp(),
+            "ended_at": Value::Null,
+            "status": "active",
+            "run_type": "replay",
+            "replay_of_session_id": session_id,
+            "recording_mode": "replay",
+            "recording_enabled": true,
+            "lint_ai_enabled": enable_lint_ai,
+            "prompt_count": prompts.len(),
+            "event_count": 0,
+            "redaction_policy": "default-v1"
+        }),
+    )?;
+
+    set_recording_state(provider, replay_workspace.path(), true)?;
+    set_lint_ai_state(provider, replay_workspace.path(), enable_lint_ai)?;
+
+    let command_result = run_provider_process(
+        provider,
+        replay_workspace.path(),
+        &prompts,
+        &replay_session_id,
+    );
+    sync_replay_archive(
+        provider,
+        replay_workspace.path(),
+        archive_root.as_path(),
+        &replay_session_id,
+    )?;
+    let execution = command_result?;
+    let recorded_event_count = provider_event_count(&replay_dir.join("events.jsonl"))?;
+    let recording_complete = recorded_event_count > 0;
+
+    record_event(
+        provider,
+        &archive_root,
+        project_root,
+        &replay_session_id,
+        "ReplayCompleted",
+        serde_json::json!({
+            "replay_of_session_id": session_id,
+            "prompt_count": prompts.len(),
+            "exit_code": execution.exit_code,
+            "stdout": execution.stdout,
+            "stderr": execution.stderr,
+        }),
+    )?;
+    let mut manifest: Value = serde_json::from_str(&fs::read_to_string(&manifest_path)?)?;
+    manifest["ended_at"] = Value::String(timestamp());
+    manifest["status"] = Value::String(if execution.success && recording_complete {
+        "complete".to_string()
+    } else {
+        "failed".to_string()
+    });
+    if !recording_complete {
+        manifest["recording_error"] = Value::String(
+            "provider process completed without recording any provider hook events".to_string(),
+        );
+    }
+    write_manifest(&manifest_path, &manifest)?;
+
+    Ok(ReplayReport {
+        provider: provider.as_str().to_string(),
+        baseline_session_id: session_id.to_string(),
+        replay_session_id,
+        replay_archive: replay_dir.to_string_lossy().into_owned(),
+        lint_ai_enabled: enable_lint_ai,
+        exit_code: execution.exit_code,
+        output_bytes: execution.stdout.len() + execution.stderr.len(),
+        prompt_count: prompts.len(),
+        recorded_event_count,
+        recording_complete,
+    })
+}
+
+struct ReplayWorkspace {
+    path: PathBuf,
+}
+
+impl ReplayWorkspace {
+    fn create(source: &Path) -> Result<Self> {
+        let path = std::env::temp_dir().join(format!(
+            "lint-ai-replay-{}-{}",
+            std::process::id(),
+            timestamp_compact()
+        ));
+        fs::create_dir_all(&path)?;
+        copy_replay_tree(source, &path)?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ReplayWorkspace {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn copy_replay_tree(source: &Path, destination: &Path) -> Result<()> {
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let name = entry.file_name();
+        if matches!(
+            name.to_str(),
+            Some(".git" | ".lint-ai" | "target" | "node_modules")
+        ) {
+            continue;
+        }
+        let destination_path = destination.join(&name);
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            fs::create_dir_all(&destination_path)?;
+            copy_replay_tree(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&source_path, &destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn sync_replay_archive(
+    provider: RecordingProvider,
+    workspace_root: &Path,
+    archive_root: &Path,
+    session_id: &str,
+) -> Result<()> {
+    let source = session_root(provider, workspace_root).join(safe_component(session_id));
+    let destination = archive_root.join(safe_component(session_id));
+    fs::create_dir_all(&destination)?;
+    for name in ["recording.json", "manifest.json", "events.jsonl"] {
+        let source_path = source.join(name);
+        if source_path.is_file() {
+            fs::copy(source_path, destination.join(name))?;
+            restrict_path_permissions(&destination.join(name))?;
+        }
+    }
+    Ok(())
+}
+
+/// Count provider hook events while excluding the synthetic ReplayCompleted
+/// event written by the replay orchestrator itself.
+fn provider_event_count(events_path: &Path) -> Result<usize> {
+    if !events_path.exists() {
+        return Ok(0);
+    }
+    let content = fs::read_to_string(events_path)?;
+    Ok(content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|event| {
+            let kind = event.get("kind").and_then(Value::as_str);
+            !(kind == Some("provider_event")
+                && event
+                    .get("payload")
+                    .and_then(|payload| payload.get("replay_of_session_id"))
+                    .is_some())
+        })
+        .count())
+}
+
+#[derive(Debug, Default)]
+struct ReplayExecution {
+    success: bool,
+    exit_code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+fn recorded_prompts(events_path: &Path) -> Result<Vec<String>> {
+    let content = fs::read_to_string(events_path)
+        .with_context(|| format!("failed to read recorded session {}", events_path.display()))?;
+    let mut prompts = Vec::new();
+    for line in content.lines() {
+        let Ok(event) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if event.get("kind").and_then(Value::as_str) != Some("user_prompt") {
+            continue;
+        }
+        if let Some(prompt) = event
+            .get("payload")
+            .and_then(|payload| payload.get("prompt"))
+            .and_then(Value::as_str)
+            .filter(|prompt| !prompt.trim().is_empty())
+        {
+            prompts.push(prompt.to_string());
+        }
+    }
+    if prompts.is_empty() {
+        anyhow::bail!("recorded session contains no replayable user prompt")
+    }
+    Ok(prompts)
+}
+
+fn run_provider_process(
+    provider: RecordingProvider,
+    project_root: &Path,
+    prompts: &[String],
+    replay_session_id: &str,
+) -> Result<ReplayExecution> {
+    let mut execution = ReplayExecution::default();
+    let mut provider_session_id = None;
+    let isolated_home = project_root.join(".lint-ai-replay-home");
+    fs::create_dir_all(&isolated_home)?;
+    let isolated_codex_home = isolated_home.join(".codex");
+    fs::create_dir_all(&isolated_codex_home)?;
+    let isolated_app_data = isolated_home.join("AppData").join("Roaming");
+    let isolated_local_app_data = isolated_home.join("AppData").join("Local");
+    fs::create_dir_all(&isolated_app_data)?;
+    fs::create_dir_all(&isolated_local_app_data)?;
+
+    for (index, prompt) in prompts.iter().enumerate() {
+        eprintln!(
+            "lint-ai replay: starting turn {}/{} ({})",
+            index + 1,
+            prompts.len(),
+            provider.as_str()
+        );
+        let turn_started = Instant::now();
+        let mut command = match provider {
+            RecordingProvider::Claude => {
+                // Claude's print mode does not expose a portable resume API. Run
+                // each recorded prompt as a fresh provider turn while keeping
+                // all resulting hook events in the replay archive.
+                let mut command = Command::new("claude");
+                command.args(["-p", prompt, "--output-format", "json"]);
+                command
+            }
+            RecordingProvider::Codex if index == 0 => {
+                let mut command = Command::new("codex");
+                command.args(["exec", prompt]);
+                command
+            }
+            RecordingProvider::Codex => {
+                let session_id = provider_session_id.as_deref().with_context(|| {
+                    "Codex replay could not find the provider session ID from the first turn"
+                })?;
+                let mut command = Command::new("codex");
+                command.args(["exec", "resume", session_id, prompt]);
+                command
+            }
+        };
+        let output = command
+            .current_dir(project_root)
+            .env(REPLAY_SESSION_ENV, replay_session_id)
+            .env("HOME", &isolated_home)
+            .env("CODEX_HOME", &isolated_codex_home)
+            .env("XDG_CONFIG_HOME", isolated_home.join(".config"))
+            .env("USERPROFILE", &isolated_home)
+            .env("APPDATA", &isolated_app_data)
+            .env("LOCALAPPDATA", &isolated_local_app_data)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| format!("failed to launch {} replay process", provider.as_str()))?;
+
+        if index == 0 && matches!(provider, RecordingProvider::Codex) {
+            provider_session_id = extract_codex_session_id(&output.stderr);
+        }
+        execution.success = output.status.success();
+        execution.exit_code = output.status.code();
+        execution
+            .stdout
+            .push_str(&String::from_utf8_lossy(&output.stdout));
+        execution
+            .stderr
+            .push_str(&String::from_utf8_lossy(&output.stderr));
+        eprintln!(
+            "lint-ai replay: finished turn {}/{} in {:.1}s ({})",
+            index + 1,
+            prompts.len(),
+            turn_started.elapsed().as_secs_f64(),
+            if output.status.success() {
+                "ok"
+            } else {
+                "failed"
+            }
+        );
+        if !output.status.success() {
+            break;
+        }
+    }
+    Ok(execution)
+}
+
+fn extract_codex_session_id(stderr: &[u8]) -> Option<String> {
+    let stderr = String::from_utf8_lossy(stderr);
+    stderr.lines().find_map(|line| {
+        let (_, value) = line.split_once("session id:")?;
+        let value = value.trim();
+        (!value.is_empty()).then(|| value.to_string())
+    })
+}
+
+pub fn promote_recorded_session(
+    provider: RecordingProvider,
+    project_root: &Path,
+    archive_override: Option<&Path>,
+    session_id: &str,
+) -> Result<SessionImportReport> {
+    let archive_root = archive_override
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| session_root(provider, project_root));
+    let session_dir = archive_root.join(safe_component(session_id));
+    let events_path = session_dir.join("events.jsonl");
+    let content = fs::read_to_string(&events_path)
+        .with_context(|| format!("failed to read recorded session {}", events_path.display()))?;
+    let group_id = format!("{}-session:{}", provider.as_str(), session_id);
+    let memory_root = project_root
+        .join(".lint-ai")
+        .join(format!("{}-memory", provider.as_str()));
+    let options = PipelineOptions {
+        memory_index_layout: MemoryIndexLayout::Segmented {
+            query_top_n: 3,
+            routing_strategy: SegmentRoutingStrategy::LocalDistinctiveness,
+        },
+        ..PipelineOptions::default()
+    };
+    let mut store = IndexStore::at_path(&memory_root, options)?;
+    let mut imported_document_ids = Vec::new();
+    let mut skipped_events = 0;
+
+    for line in content.lines() {
+        let event: Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(_) => {
+                skipped_events += 1;
+                continue;
+            }
+        };
+        let kind = event.get("kind").and_then(Value::as_str).unwrap_or("event");
+        if matches!(kind, "session_start" | "session_end") {
+            skipped_events += 1;
+            continue;
+        }
+        let sequence = event.get("sequence").and_then(Value::as_u64).unwrap_or(0);
+        let doc_id = format!(
+            "session-recording:{}:{}:{}",
+            provider.as_str(),
+            safe_component(session_id),
+            sequence
+        );
+        let mut filters = BTreeMap::new();
+        filters.insert("provider".to_string(), provider.as_str().to_string());
+        filters.insert("session_id".to_string(), session_id.to_string());
+        filters.insert("event_kind".to_string(), kind.to_string());
+        filters.insert("source_type".to_string(), "recorded-session".to_string());
+        let document = SourceDocument {
+            source: format!(
+                "lint-ai://{}/session/{}/{}",
+                provider.as_str(),
+                session_id,
+                sequence
+            ),
+            concept: "recorded-session".to_string(),
+            headings: vec![kind.to_string()],
+            links: vec![],
+            timestamp: event
+                .get("timestamp")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            doc_length: event_content(&event).len(),
+            author_agent: Some(provider.as_str().to_string()),
+            filters,
+            group_id: Some(group_id.clone()),
+            doc_id: doc_id.clone(),
+            content: event_content(&event),
+        };
+        store.upsert(document);
+        imported_document_ids.push(doc_id);
+    }
+    store.refresh()?;
+    Ok(SessionImportReport {
+        session_id: session_id.to_string(),
+        group_id,
+        imported_document_ids,
+        skipped_events,
+    })
+}
+
+fn event_content(event: &Value) -> String {
+    let kind = event.get("kind").and_then(Value::as_str).unwrap_or("event");
+    let payload = event.get("payload").cloned().unwrap_or(Value::Null);
+    format!(
+        "Recorded session event ({kind}):\n{}",
+        serde_json::to_string_pretty(&payload).unwrap_or_default()
+    )
+}
+
+pub fn set_recording_state(
+    provider: RecordingProvider,
+    project_root: &Path,
+    enabled: bool,
+) -> Result<Value> {
+    let root = session_root(provider, project_root);
+    fs::create_dir_all(&root)?;
+    let state = serde_json::json!({
+        "schema_version": 1,
+        "provider": provider.as_str(),
+        "project_root": project_root,
+        "enabled": enabled,
+        "updated_at": timestamp(),
+    });
+    write_manifest(&root.join("recording.json"), &state)?;
+    Ok(state)
+}
+
+pub fn recording_state(provider: RecordingProvider, project_root: &Path) -> Result<Value> {
+    let path = session_root(provider, project_root).join("recording.json");
+    if !path.exists() {
+        return Ok(serde_json::json!({
+            "provider": provider.as_str(),
+            "project_root": project_root,
+            "enabled": false,
+        }));
+    }
+    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+}
+
+pub fn set_lint_ai_state(
+    provider: RecordingProvider,
+    project_root: &Path,
+    enabled: bool,
+) -> Result<Value> {
+    let root = memory_root(provider, project_root);
+    fs::create_dir_all(&root)?;
+    let state = serde_json::json!({
+        "schema_version": 1,
+        "provider": provider.as_str(),
+        "project_root": project_root,
+        "enabled": enabled,
+        "updated_at": timestamp(),
+    });
+    write_manifest(&root.join("integration.json"), &state)?;
+    Ok(state)
+}
+
+pub fn lint_ai_enabled(provider: RecordingProvider, project_root: &Path) -> Result<bool> {
+    let path = memory_root(provider, project_root).join("integration.json");
+    if !path.exists() {
+        return Ok(true);
+    }
+    Ok(
+        serde_json::from_str::<Value>(&fs::read_to_string(path)?)?["enabled"]
+            .as_bool()
+            .unwrap_or(true),
+    )
+}
+
+pub fn record_event_if_enabled(
+    provider: RecordingProvider,
+    project_root: &Path,
+    session_id: &str,
+    event_name: &str,
+    payload: Value,
+) -> Result<()> {
+    let state = recording_state(provider, project_root)?;
+    if !state["enabled"].as_bool().unwrap_or(false) {
+        return Ok(());
+    }
+    let target_session_id = std::env::var(REPLAY_SESSION_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| session_id.to_string());
+    let mut payload = payload;
+    if target_session_id != session_id {
+        if let Some(object) = payload.as_object_mut() {
+            object.insert(
+                "provider_session_id".to_string(),
+                Value::String(session_id.to_string()),
+            );
+        }
+    }
+    record_event(
+        provider,
+        &session_root(provider, project_root),
+        project_root,
+        &target_session_id,
+        event_name,
+        payload,
+    )
+}
+
+fn session_root(provider: RecordingProvider, project_root: &Path) -> PathBuf {
+    project_root
+        .join(".lint-ai")
+        .join(format!("{}-sessions", provider.as_str()))
+}
+
+fn memory_root(provider: RecordingProvider, project_root: &Path) -> PathBuf {
+    project_root
+        .join(".lint-ai")
+        .join(format!("{}-memory", provider.as_str()))
+}
+
+impl RecordingProvider {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+}
+
+pub fn record_event(
+    provider: RecordingProvider,
+    session_root: &Path,
+    project_root: &Path,
+    session_id: &str,
+    event_name: &str,
+    payload: Value,
+) -> Result<()> {
+    let provider_name = provider.as_str();
+    let session_key = safe_component(session_id);
+    let session_dir = session_root.join(session_key);
+    fs::create_dir_all(&session_dir)?;
+    let lock = acquire_lock(&session_dir.join(".lock"))?;
+
+    let events_path = session_dir.join("events.jsonl");
+    let manifest_path = session_dir.join("manifest.json");
+    if !manifest_path.exists() {
+        write_manifest(
+            &manifest_path,
+            &serde_json::json!({
+                "schema_version": 1,
+                "session_id": session_id,
+                "provider": provider_name,
+                "project_root": project_root,
+                "started_at": timestamp(),
+                "ended_at": Value::Null,
+                "status": "active",
+                "recording_mode": "capture-only",
+                "event_count": 0,
+                "redaction_policy": "default-v1"
+            }),
+        )?;
+    }
+
+    let sequence = count_complete_lines(&events_path)? + 1;
+    let mut redactions = Vec::new();
+    let bounded_payload = redact_and_bound(payload, &mut redactions, "payload");
+    let mut usage = extract_usage(&bounded_payload);
+    if let Some(source) = bounded_payload.get("source").and_then(Value::as_str) {
+        if let Some(usage_object) = usage.as_mut().and_then(Value::as_object_mut) {
+            usage_object.insert("source".to_string(), Value::String(source.to_string()));
+        }
+    }
+    let mut event = serde_json::json!({
+        "schema_version": 1,
+        "sequence": sequence,
+        "event_id": format!("{}:{}:{}", session_id, event_name, sequence),
+        "timestamp": timestamp(),
+        "kind": normalized_kind(event_name),
+        "provider": provider_name,
+        "session_id": session_id,
+        "payload": bounded_payload,
+        "redactions": redactions,
+    });
+    if let Some(usage) = usage {
+        event["usage"] = usage;
+    }
+    if serde_json::to_vec(&event)?.len() > MAX_EVENT_BYTES {
+        event["payload"] = serde_json::json!({
+            "truncated": true,
+            "summary": "event exceeded the maximum recording size"
+        });
+        event["truncated"] = Value::Bool(true);
+    }
+
+    let encoded = serde_json::to_vec(&event)?;
+    if encoded.len() > MAX_EVENT_BYTES {
+        return Err(anyhow::anyhow!(
+            "recorded event remains too large after bounding"
+        ));
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&events_path)
+        .with_context(|| format!("failed to open {}", events_path.display()))?;
+    restrict_file_permissions(&file)?;
+    file.write_all(&encoded)?;
+    file.write_all(b"\n")?;
+    file.flush()?;
+
+    let terminal = event_name.eq_ignore_ascii_case("SessionEnd")
+        || event_name.eq_ignore_ascii_case("PostCompact");
+    let mut manifest: Value = serde_json::from_str(&fs::read_to_string(&manifest_path)?)?;
+    manifest["event_count"] = Value::from(sequence);
+    manifest["last_event"] = Value::String(event_name.to_string());
+    if terminal {
+        manifest["ended_at"] = Value::String(timestamp());
+        manifest["status"] = Value::String("complete".to_string());
+    }
+    write_manifest(&manifest_path, &manifest)?;
+    drop(lock);
+    Ok(())
+}
+
+fn normalized_kind(event_name: &str) -> &'static str {
+    match event_name {
+        "SessionStart" => "session_start",
+        "UserPromptSubmit" | "UserPromptExpansion" => "user_prompt",
+        "PreToolUse" => "tool_call",
+        "PostToolUse" => "tool_result",
+        "PostToolUseFailure" => "tool_error",
+        "PreCompact" | "PostCompact" => "compaction",
+        "SubagentStart" => "subagent_start",
+        "SubagentStop" => "subagent_stop",
+        "Stop" => "assistant_message",
+        "TurnUsage" => "turn_usage",
+        "SessionEnd" => "session_end",
+        _ => "provider_event",
+    }
+}
+
+/// Read the provider transcript at a turn boundary and append the latest
+/// authoritative usage object when the provider exposes one there. This is a
+/// best-effort side channel: missing usage remains missing, never zero.
+pub fn record_transcript_usage_if_available(
+    provider: RecordingProvider,
+    project_root: &Path,
+    session_id: &str,
+    transcript_path: Option<&Path>,
+    turn_id: Option<&str>,
+    source: &str,
+) -> Result<bool> {
+    if !recording_state(provider, project_root)?["enabled"]
+        .as_bool()
+        .unwrap_or(false)
+    {
+        return Ok(false);
+    }
+    let Some(path) = transcript_path else {
+        return Ok(false);
+    };
+    if !path.is_file() {
+        return Ok(false);
+    }
+
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("failed to open provider transcript {}", path.display()))?;
+    let mut bytes = Vec::new();
+    std::io::Read::by_ref(&mut file)
+        .take(MAX_TRANSCRIPT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("failed to read provider transcript {}", path.display()))?;
+    if bytes.len() as u64 > MAX_TRANSCRIPT_BYTES {
+        anyhow::bail!(
+            "provider transcript {} exceeds the {} byte recording limit",
+            path.display(),
+            MAX_TRANSCRIPT_BYTES
+        );
+    }
+    let content = String::from_utf8_lossy(&bytes);
+    let mut latest_usage = None;
+    for line in content.lines() {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if let Some(usage) = extract_usage(&value) {
+            latest_usage = Some(usage);
+        }
+    }
+    let Some(mut usage) = latest_usage else {
+        return Ok(false);
+    };
+    if let Some(object) = usage.as_object_mut() {
+        object.insert("source".to_string(), Value::String(source.to_string()));
+    }
+    record_event_if_enabled(
+        provider,
+        project_root,
+        session_id,
+        "TurnUsage",
+        serde_json::json!({
+            "turn_id": turn_id,
+            "source": source,
+            "transcript_path": path,
+            "usage": usage,
+        }),
+    )?;
+    Ok(true)
+}
+
+fn extract_usage(value: &Value) -> Option<Value> {
+    match value {
+        Value::Object(object) => {
+            for key in ["usage", "token_usage", "tokenUsage"] {
+                if let Some(candidate) = object.get(key) {
+                    if let Some(normalized) = normalize_usage(candidate, object) {
+                        return Some(normalized);
+                    }
+                }
+            }
+            object.values().find_map(extract_usage)
+        }
+        Value::Array(values) => values.iter().find_map(extract_usage),
+        _ => None,
+    }
+}
+
+fn normalize_usage(value: &Value, parent: &Map<String, Value>) -> Option<Value> {
+    let object = value.as_object()?;
+    let number = |keys: &[&str]| {
+        keys.iter()
+            .find_map(|key| object.get(*key).and_then(Value::as_u64))
+            .or_else(|| {
+                keys.iter()
+                    .find_map(|key| parent.get(*key).and_then(Value::as_u64))
+            })
+    };
+    let input = number(&["input_tokens", "inputTokens", "prompt_tokens"]);
+    let output = number(&["output_tokens", "outputTokens", "completion_tokens"]);
+    let cache_creation = number(&["cache_creation_input_tokens", "cacheCreationInputTokens"]);
+    let cache_read = number(&["cache_read_input_tokens", "cacheReadInputTokens"]);
+    let total = number(&["total_tokens", "totalTokens"]);
+    if input.is_none()
+        && output.is_none()
+        && cache_creation.is_none()
+        && cache_read.is_none()
+        && total.is_none()
+    {
+        return None;
+    }
+    Some(serde_json::json!({
+        "input_tokens": input,
+        "output_tokens": output,
+        "cache_creation_input_tokens": cache_creation,
+        "cache_read_input_tokens": cache_read,
+        "total_tokens": total.or_else(|| Some(input.unwrap_or(0) + output.unwrap_or(0))),
+        "source": "hook-payload"
+    }))
+}
+
+fn redact_and_bound(value: Value, redactions: &mut Vec<String>, path: &str) -> Value {
+    match value {
+        Value::Object(object) => {
+            let mut output = Map::new();
+            for (key, value) in object {
+                let child_path = format!("{path}.{key}");
+                if is_sensitive_key(&key) {
+                    redactions.push(child_path);
+                    output.insert(key, Value::String("[REDACTED]".to_string()));
+                } else {
+                    output.insert(key, redact_and_bound(value, redactions, &child_path));
+                }
+            }
+            Value::Object(output)
+        }
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .take(MAX_ARRAY_ITEMS)
+                .enumerate()
+                .map(|(index, value)| {
+                    redact_and_bound(value, redactions, &format!("{path}[{index}]"))
+                })
+                .collect(),
+        ),
+        Value::String(value) => {
+            if looks_sensitive(&value) {
+                redactions.push(path.to_string());
+                Value::String("[REDACTED]".to_string())
+            } else {
+                Value::String(truncate(&value, MAX_STRING_BYTES))
+            }
+        }
+        other => other,
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    if matches!(
+        key.as_str(),
+        "input_tokens"
+            | "output_tokens"
+            | "total_tokens"
+            | "prompt_tokens"
+            | "completion_tokens"
+            | "cache_creation_input_tokens"
+            | "cache_read_input_tokens"
+            | "inputtokens"
+            | "outputtokens"
+            | "totaltokens"
+    ) {
+        return false;
+    }
+    [
+        "api_key",
+        "apikey",
+        "access_key",
+        "authorization",
+        "bearer",
+        "cookie",
+        "credential",
+        "client_secret",
+        "password",
+        "private_key",
+        "secret",
+        "token",
+    ]
+    .iter()
+    .any(|needle| key.contains(needle))
+}
+
+fn looks_sensitive(value: &str) -> bool {
+    let trimmed = value.trim();
+    value.contains("-----BEGIN ")
+        || value.contains("Bearer ")
+        || trimmed.starts_with("sk-")
+        || trimmed.starts_with("xoxb-")
+        || trimmed.starts_with("ghp_")
+        || trimmed.starts_with("github_pat_")
+        || trimmed.starts_with("AKIA")
+        || trimmed.starts_with("npm_")
+        || (trimmed.split('.').count() == 3 && trimmed.len() >= 40)
+}
+
+fn truncate(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", value[..end].trim_end())
+}
+
+fn safe_component(value: &str) -> String {
+    let mut output = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if output.is_empty() {
+        output = "unknown-session".to_string();
+    }
+    output.chars().take(120).collect()
+}
+
+fn count_complete_lines(path: &Path) -> Result<usize> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    Ok(fs::read_to_string(path)?.lines().count())
+}
+
+fn write_manifest(path: &Path, value: &Value) -> Result<()> {
+    let temporary = path.with_extension("json.tmp");
+    fs::write(&temporary, serde_json::to_vec_pretty(value)?)?;
+    restrict_path_permissions(&temporary)?;
+    fs::rename(temporary, path)?;
+    restrict_path_permissions(path)?;
+    Ok(())
+}
+
+fn restrict_file_permissions(file: &fs::File) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+fn restrict_path_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+impl Drop for RecordingLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+struct RecordingLock {
+    path: PathBuf,
+}
+
+fn acquire_lock(path: &Path) -> Result<RecordingLock> {
+    for _ in 0..500 {
+        match OpenOptions::new().write(true).create_new(true).open(path) {
+            Ok(_) => {
+                return Ok(RecordingLock {
+                    path: path.to_path_buf(),
+                })
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                thread::sleep(Duration::from_millis(2));
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Err(anyhow::anyhow!(
+        "timed out waiting for session recording lock"
+    ))
+}
+
+fn timestamp() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    format!("unix:{seconds}")
+}
+
+fn timestamp_compact() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::current_dir()
+            .unwrap()
+            .join("target")
+            .join(format!("lint-ai-recording-{name}-{nonce}"));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn records_redacted_event_and_manifest() {
+        let root = temp_root("redaction");
+        record_event(
+            RecordingProvider::Claude,
+            &root,
+            Path::new("/tmp/project"),
+            "session-1",
+            "PostToolUse",
+            serde_json::json!({
+                "tool_name": "Bash",
+                "tool_response": {"token": "secret", "output": "ok"}
+            }),
+        )
+        .unwrap();
+        let events = fs::read_to_string(root.join("session-1/events.jsonl")).unwrap();
+        assert!(events.contains("[REDACTED]"));
+        assert!(!events.contains("secret"));
+        assert!(events.contains("tool_result"));
+        record_event(
+            RecordingProvider::Claude,
+            &root,
+            Path::new("/tmp/project"),
+            "session-1",
+            "PostToolUse",
+            serde_json::json!({
+                "tool_response": {"usage": {"input_tokens": 10, "output_tokens": 4, "total_tokens": 14}}
+            }),
+        )
+        .unwrap();
+        let events = fs::read_to_string(root.join("session-1/events.jsonl")).unwrap();
+        assert!(events.contains("\"total_tokens\""));
+        let manifest = fs::read_to_string(root.join("session-1/manifest.json")).unwrap();
+        assert!(manifest.contains("capture-only"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn records_latest_transcript_usage_only_when_recording_is_enabled() {
+        let root = temp_root("transcript-usage");
+        let transcript = root.join("provider.jsonl");
+        fs::write(
+            &transcript,
+            concat!(
+                "{\"type\":\"assistant\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4,\"cache_read_input_tokens\":2}}\n",
+                "{\"type\":\"assistant\",\"usage\":{\"input_tokens\":22,\"output_tokens\":7,\"total_tokens\":29}}\n"
+            ),
+        )
+        .unwrap();
+
+        assert!(!record_transcript_usage_if_available(
+            RecordingProvider::Claude,
+            &root,
+            "session-off",
+            Some(&transcript),
+            Some("turn-1"),
+            "claude-transcript",
+        )
+        .unwrap());
+
+        set_recording_state(RecordingProvider::Claude, &root, true).unwrap();
+        assert!(record_transcript_usage_if_available(
+            RecordingProvider::Claude,
+            &root,
+            "session-1",
+            Some(&transcript),
+            Some("turn-1"),
+            "claude-transcript",
+        )
+        .unwrap());
+        let events =
+            fs::read_to_string(root.join(".lint-ai/claude-sessions/session-1/events.jsonl"))
+                .unwrap();
+        assert!(events.contains("\"kind\":\"turn_usage\""));
+        assert!(events.contains("\"source\":\"claude-transcript\""));
+        assert!(events.contains("\"total_tokens\":29"));
+        assert!(events.contains("\"turn_id\":\"turn-1\""));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn recording_and_memory_controls_round_trip_for_both_providers() {
+        for provider in [RecordingProvider::Claude, RecordingProvider::Codex] {
+            let root = temp_root(provider.as_str());
+            assert!(!recording_state(provider, &root).unwrap()["enabled"]
+                .as_bool()
+                .unwrap());
+            assert!(lint_ai_enabled(provider, &root).unwrap());
+
+            set_recording_state(provider, &root, true).unwrap();
+            set_lint_ai_state(provider, &root, false).unwrap();
+            assert!(recording_state(provider, &root).unwrap()["enabled"]
+                .as_bool()
+                .unwrap());
+            assert!(!lint_ai_enabled(provider, &root).unwrap());
+
+            set_recording_state(provider, &root, false).unwrap();
+            set_lint_ai_state(provider, &root, true).unwrap();
+            assert!(!recording_state(provider, &root).unwrap()["enabled"]
+                .as_bool()
+                .unwrap());
+            assert!(lint_ai_enabled(provider, &root).unwrap());
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+
+    #[test]
+    fn recording_is_independent_from_memory_state() {
+        for provider in [RecordingProvider::Claude, RecordingProvider::Codex] {
+            let root = temp_root(provider.as_str());
+            set_lint_ai_state(provider, &root, false).unwrap();
+            record_event_if_enabled(
+                provider,
+                &root,
+                "session-off-memory",
+                "UserPromptSubmit",
+                serde_json::json!({"prompt": "still record this"}),
+            )
+            .unwrap();
+            let events = root
+                .join(".lint-ai")
+                .join(format!("{}-sessions", provider.as_str()))
+                .join("session-off-memory/events.jsonl");
+            assert!(!events.exists());
+
+            set_recording_state(provider, &root, true).unwrap();
+            record_event_if_enabled(
+                provider,
+                &root,
+                "session-on-recording",
+                "UserPromptSubmit",
+                serde_json::json!({"prompt": "record despite memory off"}),
+            )
+            .unwrap();
+            assert!(root
+                .join(".lint-ai")
+                .join(format!("{}-sessions", provider.as_str()))
+                .join("session-on-recording/events.jsonl")
+                .exists());
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+
+    #[test]
+    fn promotes_recorded_events_into_memory() {
+        let project_root = temp_root("promotion-project");
+        let archive_root = temp_root("promotion-archive");
+        record_event(
+            RecordingProvider::Claude,
+            &archive_root,
+            &project_root,
+            "baseline",
+            "UserPromptSubmit",
+            serde_json::json!({"prompt": "remember the routing decision"}),
+        )
+        .unwrap();
+        record_event(
+            RecordingProvider::Claude,
+            &archive_root,
+            &project_root,
+            "baseline",
+            "Stop",
+            serde_json::json!({"response": "Use IndexStore with segmented routing"}),
+        )
+        .unwrap();
+
+        let report = promote_recorded_session(
+            RecordingProvider::Claude,
+            &project_root,
+            Some(&archive_root),
+            "baseline",
+        )
+        .unwrap();
+        assert_eq!(report.session_id, "baseline");
+        assert_eq!(report.imported_document_ids.len(), 2);
+        assert!(project_root.join(".lint-ai/claude-memory").exists());
+        fs::remove_dir_all(project_root).unwrap();
+        fs::remove_dir_all(archive_root).unwrap();
+    }
+
+    #[test]
+    fn extracts_all_user_prompts_for_replay() {
+        let root = temp_root("prompt");
+        let events = root.join("events.jsonl");
+        fs::write(
+            &events,
+            concat!(
+                "{\"kind\":\"session_start\",\"payload\":{}}\n",
+                "{\"kind\":\"user_prompt\",\"payload\":{\"prompt\":\"Fix routing\"}}\n",
+                "{\"kind\":\"assistant_message\",\"payload\":{}}\n",
+                "{\"kind\":\"user_prompt\",\"payload\":{\"prompt\":\"Run the tests\"}}\n"
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            recorded_prompts(&events).unwrap(),
+            vec!["Fix routing".to_string(), "Run the tests".to_string()]
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn extracts_codex_session_id_from_provider_output() {
+        let output = b"model: gpt-5\nsession id: 123e4567-e89b-12d3-a456-426614174000\n";
+        assert_eq!(
+            extract_codex_session_id(output).as_deref(),
+            Some("123e4567-e89b-12d3-a456-426614174000")
+        );
+    }
+
+    #[test]
+    fn excludes_synthetic_replay_completion_from_provider_event_count() {
+        let root = temp_root("replay-events");
+        let events = root.join("events.jsonl");
+        fs::write(
+            &events,
+            concat!(
+                "{\"kind\":\"provider_event\",\"payload\":{\"replay_of_session_id\":\"baseline\"}}\n",
+                "{\"kind\":\"session_start\",\"payload\":{}}\n",
+                "{\"kind\":\"user_prompt\",\"payload\":{\"prompt\":\"test\"}}\n"
+            ),
+        )
+        .unwrap();
+        assert_eq!(provider_event_count(&events).unwrap(), 2);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn missing_replay_events_is_not_recording_complete() {
+        let root = temp_root("empty-replay-events");
+        let events = root.join("events.jsonl");
+        fs::write(
+            &events,
+            "{\"kind\":\"provider_event\",\"payload\":{\"replay_of_session_id\":\"baseline\"}}\n",
+        )
+        .unwrap();
+        assert_eq!(provider_event_count(&events).unwrap(), 0);
+        fs::remove_dir_all(root).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the provider integration work for Claude Code and Codex, including session recording and runtime Lint-AI controls.

## What changed

- Adds a feature-gated Codex integration with lifecycle hooks and project-scoped memory.
- Adds shared session recording and replay-session support.
- Adds runtime controls for enabling and disabling Lint-AI.
- Adds independent recording start, stop, and status controls.
- Adds provider status reporting for Lint-AI and recording state.
- Adds replay workflows with new session IDs for A/B comparison.
- Captures lifecycle events, memory activity, tool activity, and available usage metadata.
- Updates benchmark orchestration and scoring for Claude Code and Codex.
- Documents installation, MCP controls, recording, replay, and integration benchmarks.

## User impact

Users can enable Lint-AI for Claude Code or Codex, record sessions for later review, disable memory injection without deleting recordings, and replay sessions with different Lint-AI configurations.

## Validation

- git diff --check
- Reviewed the measured Claude Code and Codex integration smoke benchmark documentation.
- Added provider integration and session-recording implementation changes.

## Related issues

Closes #28
Closes #30