### PR TITLE
Add Memory Server and Docker Packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.agents
+.claude
+.codex
+.history
+.lint-ai
+.lint-ai-cache
+target
+benchmark
+docs
+tests
+*.md
+!README.md
+.env
+.env.*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Server access token. Replace this with a long, random secret.
+SERVER_TOKEN=change-me-to-a-long-random-token
+
+# The server listens on 127.0.0.1:8080 by default when run locally.
+# Docker deployments should bind the container to 0.0.0.0:8080.

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ Cargo.lock
 
 # Local Python environments and caches
 .venv/
+
+# Local secrets
+.env
 __pycache__/
 *.py[cod]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+FROM rust:1.96-bookworm AS builder
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock* ./
+COPY src ./src
+COPY data/lexical ./data/lexical
+
+RUN cargo build --release --bin server
+
+FROM debian:bookworm-slim AS runtime
+
+RUN groupadd --system lintai \
+    && useradd --system --gid lintai --home-dir /data --no-create-home lintai \
+    && mkdir -p /data/index \
+    && chown -R lintai:lintai /data
+
+COPY --from=builder /build/target/release/server /usr/local/bin/lint-ai-server
+
+USER lintai
+WORKDIR /data
+VOLUME ["/data"]
+EXPOSE 8080
+
+ENV RUST_LOG=info
+
+ENTRYPOINT ["/usr/local/bin/lint-ai-server"]
+CMD ["--bind", "0.0.0.0:8080", "--index", "/data/index"]

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,62 @@
+# Lint-AI server
+
+`server` exposes a synchronous Add/Search contract with Lint-AI's `IndexStore`
+as the memory backend. The API remains compatible with the Agent Memory
+Leaderboard.
+
+## Run locally
+
+Use an explicit index directory for a persistent evaluation instance:
+
+```bash
+cargo run --release --bin server -- \
+  --bind 0.0.0.0:8080 \
+  --index /var/lib/lint-ai/memory-index \
+  --server-token "$SERVER_TOKEN"
+```
+
+The server exposes `GET /health`, `POST /add`, and `POST /search`.
+
+The server token accepts `X-Api-Key`, `Authorization: Bearer <token>`, or
+`Authorization: Token <token>`. It can also be supplied through
+`SERVER_TOKEN`.
+
+## Local contract smoke test
+
+```bash
+curl -sS http://127.0.0.1:8080/health
+
+curl -sS -X POST http://127.0.0.1:8080/add \
+  -H "X-Api-Key: $SERVER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{
+    "request_id": "local-run:session-0:chunk-0",
+    "messages": [{"role": "user", "content": "I prefer dark mode."}],
+    "user_id": "local-run:user-0",
+    "session_id": "local-run:session-0"
+  }'
+
+curl -sS -X POST http://127.0.0.1:8080/search \
+  -H "X-Api-Key: $SERVER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '{
+    "query": "What interface preference does the user have?",
+    "user_id": "local-run:user-0",
+    "top_k": 100
+  }'
+```
+
+## AML submission flow
+
+1. Deploy the server at a public HTTPS address.
+2. Keep the three endpoints stable for the evaluation period.
+3. Submit the endpoint, API-key scheme, fixed product version, capacity,
+   timeout, and rate-limit details through the AML evaluation request.
+4. Bind the returned AML key to the deployed version and run the AML smoke
+   test.
+5. Start the formal Full evaluation only after the smoke test passes.
+
+AML supplies benchmark memories and questions. Search returns evidence only;
+it must not generate the final answer. Evaluation data must be isolated by the
+exact `user_id` supplied in Add and Search and deleted according to AML's
+data-retention requirements.

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,0 +1,173 @@
+use anyhow::Result;
+use clap::Parser;
+use lint_ai::memory_api::{AddRequest, MemoryService, SearchRequest};
+use lint_ai::{IndexStore, PipelineOptions};
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "lint-ai-server",
+    about = "Memory Add/Search server backed by Lint-AI"
+)]
+struct Args {
+    #[arg(long, default_value = "127.0.0.1:8080")]
+    bind: String,
+    #[arg(long)]
+    index: Option<PathBuf>,
+    #[arg(long)]
+    server_token: Option<String>,
+}
+
+fn main() -> Result<()> {
+    let mut args = Args::parse();
+    if args.server_token.is_none() {
+        args.server_token = std::env::var("SERVER_TOKEN").ok();
+    }
+    let store = match args.index.as_deref() {
+        Some(path) => IndexStore::at_path(path, PipelineOptions::default())?,
+        None => IndexStore::in_memory(PipelineOptions::default()),
+    };
+    let service = Arc::new(Mutex::new(MemoryService::new(store)));
+    let listener = TcpListener::bind(&args.bind)?;
+    eprintln!("Lint-AI server listening on {}", args.bind);
+    for connection in listener.incoming() {
+        match connection {
+            Ok(stream) => {
+                let service = Arc::clone(&service);
+                let server_token = args.server_token.clone();
+                std::thread::spawn(move || {
+                    if let Err(error) = handle_connection(stream, service, server_token.as_deref())
+                    {
+                        eprintln!("Request failed: {error:#}");
+                    }
+                });
+            }
+            Err(error) => eprintln!("Accept failed: {error}"),
+        }
+    }
+    Ok(())
+}
+
+fn handle_connection(
+    mut stream: TcpStream,
+    service: Arc<Mutex<MemoryService>>,
+    server_token: Option<&str>,
+) -> Result<()> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line)?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let path = parts.next().unwrap_or("");
+    let mut content_length = 0usize;
+    let mut authorization = None;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line)?;
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            match name.trim().to_ascii_lowercase().as_str() {
+                "content-length" => content_length = value.trim().parse()?,
+                "authorization" | "x-api-key" => authorization = Some(value.trim().to_string()),
+                _ => {}
+            }
+        }
+    }
+    if method == "GET" && path == "/health" {
+        return write_json(&mut stream, 200, &serde_json::json!({"status": "ok"}));
+    }
+    if let Some(expected) = server_token {
+        let supplied = authorization.as_deref().unwrap_or("");
+        let valid = supplied == expected
+            || supplied == format!("Bearer {expected}")
+            || supplied == format!("Token {expected}");
+        if !valid {
+            return write_json(
+                &mut stream,
+                401,
+                &serde_json::json!({"detail": "unauthorized"}),
+            );
+        }
+    }
+
+    if method != "POST" || (path != "/add" && path != "/search") {
+        return write_json(
+            &mut stream,
+            404,
+            &serde_json::json!({"detail": "not found"}),
+        );
+    }
+    if content_length > 16 * 1024 * 1024 {
+        return write_json(
+            &mut stream,
+            413,
+            &serde_json::json!({"detail": "request too large"}),
+        );
+    }
+    let mut body = vec![0; content_length];
+    reader.read_exact(&mut body)?;
+    let value: Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(error) => {
+            return write_json(
+                &mut stream,
+                422,
+                &serde_json::json!({"detail": error.to_string()}),
+            )
+        }
+    };
+    let mut service = service
+        .lock()
+        .map_err(|_| anyhow::anyhow!("service lock poisoned"))?;
+    let response = match path {
+        "/add" => match serde_json::from_value::<AddRequest>(value)
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+            .and_then(|request| service.add(request))
+        {
+            Ok(response) => serde_json::to_value(response)?,
+            Err(error) => {
+                return write_json(
+                    &mut stream,
+                    422,
+                    &serde_json::json!({"detail": error.to_string()}),
+                )
+            }
+        },
+        "/search" => match serde_json::from_value::<SearchRequest>(value)
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+            .and_then(|request| service.search(request))
+        {
+            Ok(response) => serde_json::to_value(response)?,
+            Err(error) => {
+                return write_json(
+                    &mut stream,
+                    422,
+                    &serde_json::json!({"detail": error.to_string()}),
+                )
+            }
+        },
+        _ => unreachable!(),
+    };
+    write_json(&mut stream, 200, &response)
+}
+
+fn write_json(stream: &mut TcpStream, status: u16, body: &Value) -> Result<()> {
+    let bytes = serde_json::to_vec(body)?;
+    let reason = match status {
+        200 => "OK",
+        401 => "Unauthorized",
+        404 => "Not Found",
+        413 => "Payload Too Large",
+        422 => "Unprocessable Entity",
+        _ => "Error",
+    };
+    write!(stream, "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n", bytes.len())?;
+    stream.write_all(&bytes)?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod index;
     feature = "agy"
 ))]
 pub mod integrations;
+pub mod memory_api;
 pub mod ownership;
 pub mod pipeline;
 pub mod query_expansion;

--- a/src/memory_api.rs
+++ b/src/memory_api.rs
@@ -1,0 +1,222 @@
+//! Memory Add/Search API backed by Lint-AI's `IndexStore`.
+
+use crate::{IndexStore, SourceDocument};
+use chrono::{TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+const USER_FILTER: &str = "memory_user_id";
+
+#[derive(Debug, Deserialize)]
+pub struct AddRequest {
+    pub request_id: String,
+    pub messages: Vec<Message>,
+    pub user_id: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Message {
+    pub role: String,
+    pub timestamp: Option<i64>,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AddResponse {
+    pub success: bool,
+    pub request_id: String,
+    pub user_id: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchRequest {
+    pub query: String,
+    #[allow(dead_code)]
+    pub options: Option<Vec<String>>,
+    pub user_id: String,
+    pub top_k: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SearchResponse {
+    pub data: Vec<SearchMemory>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SearchMemory {
+    pub id: String,
+    pub content: String,
+    pub score: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+}
+
+pub struct MemoryService {
+    store: IndexStore,
+}
+
+impl MemoryService {
+    pub fn new(store: IndexStore) -> Self {
+        Self { store }
+    }
+
+    pub fn add(&mut self, request: AddRequest) -> anyhow::Result<AddResponse> {
+        validate_identifier(&request.request_id, "request_id")?;
+        validate_identifier(&request.user_id, "user_id")?;
+        validate_identifier(&request.session_id, "session_id")?;
+        if request.messages.is_empty() {
+            anyhow::bail!("messages must not be empty");
+        }
+
+        for (message_index, message) in request.messages.iter().enumerate() {
+            if message.content.trim().is_empty() {
+                anyhow::bail!("messages[{message_index}].content must not be empty");
+            }
+            if message.role != "user" && message.role != "assistant" {
+                anyhow::bail!("messages[{message_index}].role must be user or assistant");
+            }
+
+            let source = format!(
+                "memory://{}/{}/{}",
+                request.user_id, request.session_id, message_index
+            );
+            let mut filters = BTreeMap::new();
+            filters.insert(USER_FILTER.to_string(), request.user_id.clone());
+            let timestamp = message.timestamp.and_then(|millis| {
+                Utc.timestamp_millis_opt(millis)
+                    .single()
+                    .map(|date| date.to_rfc3339())
+            });
+            self.store.upsert(SourceDocument {
+                doc_id: crate::stable_doc_id_from_source(&format!(
+                    "{}:{message_index}",
+                    request.request_id
+                )),
+                source,
+                content: format!("{}: {}", message.role, message.content),
+                concept: "memory".to_string(),
+                group_id: Some(request.session_id.clone()),
+                headings: vec![],
+                links: vec![],
+                timestamp,
+                doc_length: message.content.len(),
+                author_agent: Some(message.role.clone()),
+                filters,
+            });
+        }
+
+        // Add returns only after the memory is searchable.
+        self.store.refresh()?;
+        Ok(AddResponse {
+            success: true,
+            request_id: request.request_id,
+            user_id: request.user_id,
+            session_id: request.session_id,
+        })
+    }
+
+    pub fn search(&mut self, request: SearchRequest) -> anyhow::Result<SearchResponse> {
+        validate_identifier(&request.user_id, "user_id")?;
+        if request.query.trim().is_empty() {
+            return Ok(SearchResponse { data: vec![] });
+        }
+        let top_k = request.top_k.min(100);
+        let mut filters = BTreeMap::new();
+        filters.insert(USER_FILTER.to_string(), request.user_id);
+        let results = self.store.query_filtered(&request.query, top_k, &filters)?;
+        let data = results
+            .into_iter()
+            .filter_map(|result| {
+                self.store
+                    .source_document_by_id(&result.doc_id)
+                    .map(|doc| SearchMemory {
+                        id: result.doc_id,
+                        content: doc.content.clone(),
+                        score: result.score,
+                        created_at: doc.timestamp.clone(),
+                    })
+            })
+            .collect();
+        Ok(SearchResponse { data })
+    }
+}
+
+fn validate_identifier(value: &str, name: &str) -> anyhow::Result<()> {
+    if value.trim().is_empty() {
+        anyhow::bail!("{name} must not be empty");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PipelineOptions;
+
+    fn service() -> MemoryService {
+        MemoryService::new(IndexStore::in_memory(PipelineOptions::default()))
+    }
+
+    #[test]
+    fn add_is_immediately_searchable() {
+        let mut service = service();
+        service
+            .add(AddRequest {
+                request_id: "request-1".into(),
+                messages: vec![Message {
+                    role: "user".into(),
+                    timestamp: None,
+                    content: "I prefer dark mode in every editor".into(),
+                }],
+                user_id: "user-a".into(),
+                session_id: "session-a".into(),
+            })
+            .unwrap();
+        let response = service
+            .search(SearchRequest {
+                query: "dark mode editor".into(),
+                options: None,
+                user_id: "user-a".into(),
+                top_k: 100,
+            })
+            .unwrap();
+        assert_eq!(response.data.len(), 1);
+        assert!(response.data[0].content.contains("dark mode"));
+    }
+
+    #[test]
+    fn search_cannot_cross_user_boundaries() {
+        let mut service = service();
+        for (request_id, user_id, content) in [
+            ("request-a", "user-a", "the secret project uses amber"),
+            ("request-b", "user-b", "the secret project uses cobalt"),
+        ] {
+            service
+                .add(AddRequest {
+                    request_id: request_id.into(),
+                    messages: vec![Message {
+                        role: "user".into(),
+                        timestamp: None,
+                        content: content.into(),
+                    }],
+                    user_id: user_id.into(),
+                    session_id: "session".into(),
+                })
+                .unwrap();
+        }
+        let response = service
+            .search(SearchRequest {
+                query: "secret project color".into(),
+                options: None,
+                user_id: "user-a".into(),
+                top_k: 100,
+            })
+            .unwrap();
+        assert!(response
+            .data
+            .iter()
+            .all(|memory| memory.content.contains("amber")));
+    }
+}


### PR DESCRIPTION
## Summary

- add a dedicated synchronous memory Add/Search server backed by Lint-AI's IndexStore
- enforce per-user isolation and synchronous Add visibility
- add health endpoint, server-token authentication, persistence support, and integration documentation
- add Docker packaging with a persistent `/data` volume

The `/add` and `/search` routes remain compatible with the Agent Memory Leaderboard evaluation contract.

## Validation

- `cargo test --lib memory_api::tests`
- `cargo check --bin server`
- local HTTP smoke test covering health, Add, Search, authentication, and cross-user isolation
- Docker image build succeeds with `docker build --network=host -t lint-ai-server:test .` in the local firewall-restricted environment

## Notes

The full workspace test was attempted but the environment ran out of disk while compiling an unrelated benchmark binary. Existing unrelated working-tree changes were not included.