### PR TITLE
Fix all clippy warnings and never_loop error

### DIFF
--- a/src/aggregation.rs
+++ b/src/aggregation.rs
@@ -178,8 +178,7 @@ fn build_sum_citations(index: &MemoryIndex, results: &[SearchResult]) -> Vec<Agg
 }
 
 fn aggregate_text(doc: &crate::index::DocRecord) -> String {
-    let mut parts = Vec::new();
-    parts.push(doc.headings.join(" "));
+    let mut parts = vec![doc.headings.join(" ")];
     parts.push(doc.probable_topic.clone().unwrap_or_default());
     parts.push(doc.doc_type_guess.clone().unwrap_or_default());
     parts.push(doc.temporal_terms.join(" "));

--- a/src/bin/haystack_scoped_benchmark.rs
+++ b/src/bin/haystack_scoped_benchmark.rs
@@ -251,6 +251,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_scoped_benchmark(
     raw: Vec<LongMemEvalEntry>,
     limit: Option<usize>,
@@ -467,6 +468,7 @@ fn build_scoped_source_docs(entry: &LongMemEvalEntry) -> Vec<SourceDocument> {
     docs
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_segment_comparison(
     source_docs: &[SourceDocument],
     options: &PipelineOptions,
@@ -718,6 +720,7 @@ fn connection_diagnostics(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn rewrite_stability_diagnostics(
     segmented: &SegmentedMemoryIndex,
     query_text: &str,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -138,9 +138,9 @@ fn surface_forms(raw: &str) -> Vec<String> {
     let mut forms: HashSet<String> = HashSet::new();
     let lowered = deunicode(&raw.nfc().collect::<String>().to_lowercase()).to_lowercase();
     forms.insert(lowered.clone());
-    let spaced = lowered.replace('_', " ").replace('-', " ");
+    let spaced = lowered.replace(['_', '-'], " ");
     forms.insert(spaced.clone());
-    forms.insert(lowered.replace('_', "").replace('-', ""));
+    forms.insert(lowered.replace(['_', '-'], ""));
     forms.insert(spaced.to_plural());
     forms.insert(spaced.to_singular());
     forms.into_iter().filter(|s| !s.is_empty()).collect()
@@ -218,6 +218,7 @@ fn collect_section_concepts(
     sections.push((current.clone(), HashSet::new()));
     section_index.insert(current.clone(), idx);
 
+    #[allow(clippy::too_many_arguments)]
     fn walk<'a>(
         node: &'a AstNode<'a>,
         in_code: bool,
@@ -526,10 +527,11 @@ pub fn analyze_for_tests(graph: &Graph, cfg: &Config) -> String {
 
     let mut suggested_ignore_sections = Vec::new();
     for (section, count) in &section_list {
-        if page_count > 0 && (*count as f64 / page_count as f64) >= 0.3 {
-            if section == "related" || section == "unscoped" {
-                suggested_ignore_sections.push(section.clone());
-            }
+        if page_count > 0
+            && (*count as f64 / page_count as f64) >= 0.3
+            && (section == "related" || section == "unscoped")
+        {
+            suggested_ignore_sections.push(section.clone());
         }
     }
 
@@ -644,6 +646,7 @@ fn show_tier1_terms(graph: &Graph, ranker_kind: &Tier1TermRankerKind) -> Result<
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_memory_index(
     graph: &Graph,
     provider: &Tier1NerProvider,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -106,8 +106,7 @@ pub(crate) fn normalize_concept(s: &str) -> String {
         .collect::<String>()
         .trim()
         .to_lowercase()
-        .replace('_', " ")
-        .replace('-', " ");
+        .replace(['_', '-'], " ");
     deunicode(&normalized).to_lowercase()
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1349,9 +1349,8 @@ impl MemoryIndex {
         let (temporal_start, temporal_end) =
             normalize_temporal_bounds(temporal.starts_from, temporal.ends_at);
         let relative_anchor = temporal_start
-            .map(|_| temporal.starts_from)
-            .flatten()
-            .or(temporal_end.map(|_| temporal.ends_at).flatten())
+            .and(temporal.starts_from)
+            .or(temporal_end.and(temporal.ends_at))
             .or(temporal.starts_from)
             .or(temporal.ends_at);
         let target = resolve_temporal_target(query, relative_anchor);
@@ -2151,7 +2150,8 @@ impl MemoryIndex {
         }
         let group_build_ms = group_build_start.elapsed().as_secs_f64() * 1000.0;
 
-        let mut ranked_groups: Vec<(String, f32, Vec<(usize, f32)>)> = grouped_ranked_docs
+        type RankedGroup = (String, f32, Vec<(usize, f32)>);
+        let mut ranked_groups: Vec<RankedGroup> = grouped_ranked_docs
             .into_iter()
             .map(|(group_key, mut items)| {
                 items.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
@@ -2824,11 +2824,11 @@ fn build_doc_rerank_cache(doc: &DocRecord) -> (String, Vec<String>) {
     (normalized, tokens)
 }
 
-fn cached_doc_rerank_text<'a>(index: &'a MemoryIndex, doc_u32: usize) -> Option<&'a str> {
+fn cached_doc_rerank_text(index: &MemoryIndex, doc_u32: usize) -> Option<&str> {
     index.doc_rerank_texts.get(doc_u32).map(|s| s.as_str())
 }
 
-fn cached_doc_rerank_tokens<'a>(index: &'a MemoryIndex, doc_u32: usize) -> Option<&'a [String]> {
+fn cached_doc_rerank_tokens(index: &MemoryIndex, doc_u32: usize) -> Option<&[String]> {
     index
         .doc_rerank_tokens
         .get(doc_u32)
@@ -2988,8 +2988,8 @@ impl MemoryIndex {
         }
         let has_date = doc_temporal_date(doc).is_some();
         let has_temporal_terms = !doc.temporal_terms.is_empty();
-        let predicate_signal = has_predicate_signal(&normalized, intent);
-        let distractor_penalty = routing_distractor_penalty(&normalized, intent);
+        let predicate_signal = has_predicate_signal(normalized, intent);
+        let distractor_penalty = routing_distractor_penalty(normalized, intent);
 
         let mut score = matched_terms.min(6) as f32 * 0.18;
         if predicate_signal {
@@ -3034,6 +3034,7 @@ impl MemoryIndex {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn group_evidence_boost(
     intent: QueryRoutingIntent,
     supporting_docs: usize,
@@ -3374,7 +3375,7 @@ fn build_ngrams(tokens: &[String], n: usize) -> Vec<Vec<String>> {
     }
     tokens
         .windows(n)
-        .map(|win| win.iter().cloned().collect::<Vec<_>>())
+        .map(|win| win.to_vec())
         .collect()
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -61,19 +61,14 @@ pub enum IndexLocation {
     Explicit(PathBuf),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum MemoryIndexLayout {
+    #[default]
     Single,
     Segmented {
         query_top_n: usize,
         routing_strategy: SegmentRoutingStrategy,
     },
-}
-
-impl Default for MemoryIndexLayout {
-    fn default() -> Self {
-        Self::Single
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -1348,14 +1343,14 @@ fn source_document_from_record(record: &DocRecord) -> SourceDocument {
     }
 }
 
-fn load_semantic_state(
-    store_paths: &StorePaths,
-) -> Result<(
+type SemanticState = (
     HashMap<String, SourceDocument>,
     HashMap<String, DocRecord>,
     HashMap<String, ChunkLifecycleMeta>,
     Option<MemoryIndex>,
-)> {
+);
+
+fn load_semantic_state(store_paths: &StorePaths) -> Result<SemanticState> {
     let Some(records_path) = semantic_records_path(store_paths) else {
         return Ok((HashMap::new(), HashMap::new(), HashMap::new(), None));
     };
@@ -1966,6 +1961,7 @@ pub fn build_query_snapshot(
     build_query_snapshot_from_records(&records, options)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn build_query_snapshot_from_source_documents(
     source_docs: &[SourceDocument],
     provider: &Tier1NerProvider,

--- a/src/query_semantics.rs
+++ b/src/query_semantics.rs
@@ -348,7 +348,7 @@ fn build_query_analysis(
     };
 
     if rust_bert_model_signals {
-        spans.extend(noun_chunks.iter().cloned().map(|phrase| QuerySpan {
+        spans.extend(noun_chunks.iter().map(|phrase| QuerySpan {
             kind: QuerySpanKind::NounPhrase,
             text: phrase.text.clone(),
             normalized: normalize_for_index(&phrase.text),
@@ -366,17 +366,17 @@ fn build_query_analysis(
         //     source: "rust-bert-pos".to_string(),
         // }));
     } else {
-        spans.extend(noun_chunks.iter().cloned().map(|phrase| QuerySpan {
+        spans.extend(noun_chunks.iter().map(|phrase| QuerySpan {
             kind: QuerySpanKind::NounPhrase,
             text: phrase.text.clone(),
             normalized: normalize_for_index(&phrase.text),
             score: 0.4,
             source: "pos".to_string(),
         }));
-        spans.extend(verb_phrases.iter().cloned().map(|phrase| QuerySpan {
+        spans.extend(verb_phrases.iter().map(|phrase| QuerySpan {
             kind: QuerySpanKind::VerbPhrase,
             text: phrase.clone(),
-            normalized: normalize_for_index(&phrase),
+            normalized: normalize_for_index(phrase),
             score: 0.35,
             source: "pos".to_string(),
         }));
@@ -712,24 +712,22 @@ fn heuristic_pos_tags(query: &str) -> Vec<POSTag> {
             "VBG"
         } else if lower.ends_with("ed") && lower.len() > 3 {
             "VBD"
-        } else if lower.ends_with("ly") {
-            "RB"
-        } else if matches!(
-            lower.as_str(),
-            "currently" | "now" | "today" | "recently" | "already"
-        ) {
+        } else if lower.ends_with("ly")
+            || matches!(
+                lower.as_str(),
+                "currently" | "now" | "today" | "recently" | "already"
+            )
+        {
             "RB"
         } else if lower.chars().all(|c| c.is_ascii_digit()) {
             "CD"
         } else if word
             .chars()
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
-        {
-            "NNP"
-        } else if word
-            .chars()
-            .next()
-            .map_or(false, |c| c.is_ascii_uppercase())
+            || word
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_uppercase())
         {
             "NNP"
         } else if lower.ends_with('s') && lower.len() > 3 {
@@ -783,7 +781,7 @@ fn heuristic_entities(query: &str) -> Vec<QuerySpan> {
                 || token
                     .chars()
                     .next()
-                    .map_or(false, |c| c.is_ascii_uppercase()));
+                    .is_some_and(|c| c.is_ascii_uppercase()));
         if looks_like_entity {
             current.push(token.to_string());
         } else {
@@ -833,17 +831,15 @@ struct PhraseMatch {
 }
 
 fn extract_temporal(query: &str) -> Option<QueryTemporal> {
-    for match_ in temporal_candidates(query) {
-        let resolved_at = fuzzy_parse(match_.text.as_str())
-            .ok()
-            .map(|dt: NaiveDateTime| dt.to_string());
-        return Some(QueryTemporal {
-            phrase: match_.text,
-            resolved_at,
-            source: "fuzzydate".to_string(),
-        });
-    }
-    None
+    let match_ = temporal_candidates(query).into_iter().next()?;
+    let resolved_at = fuzzy_parse(match_.text.as_str())
+        .ok()
+        .map(|dt: NaiveDateTime| dt.to_string());
+    Some(QueryTemporal {
+        phrase: match_.text,
+        resolved_at,
+        source: "fuzzydate".to_string(),
+    })
 }
 
 fn temporal_candidates(query: &str) -> Vec<PhraseMatch> {
@@ -984,13 +980,13 @@ fn infer_subject_object(
     let first_verb = tags.iter().position(|tag| is_verbish(&tag.label));
     let subject = noun_phrases
         .iter()
-        .find(|phrase| first_verb.map_or(true, |verb_idx| phrase.end <= verb_idx))
+        .find(|phrase| first_verb.is_none_or(|verb_idx| phrase.end <= verb_idx))
         .and_then(|phrase| subject_head(&phrase.text))
         .or_else(|| entities.first().map(|entity| entity.text.clone()));
     let object = noun_phrases
         .iter()
         .rev()
-        .find(|phrase| first_verb.map_or(true, |verb_idx| phrase.start >= verb_idx))
+        .find(|phrase| first_verb.is_none_or(|verb_idx| phrase.start >= verb_idx))
         .and_then(|phrase| subject_head(&phrase.text))
         .or_else(|| {
             noun_phrases

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+
+#[derive(Default)]
 pub struct Report {
     issues: Vec<String>,
 }
@@ -24,18 +27,20 @@ impl Report {
             }
         }
     }
+}
 
+impl fmt::Display for Report {
     /// Render issues as a single string.
-    pub fn to_string(&self) -> String {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.issues.is_empty() {
-            "No issues found".to_string()
+            f.write_str("No issues found")
         } else {
             let mut out = String::from("Issues:");
             for i in &self.issues {
                 out.push_str("\n- ");
                 out.push_str(i);
             }
-            out
+            f.write_str(&out)
         }
     }
 }

--- a/src/rules/cross_refs.rs
+++ b/src/rules/cross_refs.rs
@@ -45,9 +45,9 @@ fn surface_forms(raw: &str) -> Vec<String> {
     let mut forms: HashSet<String> = HashSet::new();
     let lowered = deunicode(&raw.nfc().collect::<String>().to_lowercase()).to_lowercase();
     forms.insert(lowered.clone());
-    let spaced = lowered.replace('_', " ").replace('-', " ");
+    let spaced = lowered.replace(['_', '-'], " ");
     forms.insert(spaced.clone());
-    forms.insert(lowered.replace('_', "").replace('-', ""));
+    forms.insert(lowered.replace(['_', '-'], ""));
     forms.insert(spaced.to_plural());
     forms.insert(spaced.to_singular());
     forms.into_iter().filter(|s| !s.is_empty()).collect()
@@ -126,6 +126,7 @@ pub fn check_cross_refs(graph: &Graph, report: &mut Report, cfg: &Config) {
         let mut current_heading = String::from("unscoped");
         let mut found: HashSet<String> = HashSet::new();
 
+        #[allow(clippy::too_many_arguments)]
         fn walk<'a>(
             node: &'a comrak::nodes::AstNode<'a>,
             in_code: bool,

--- a/src/rules/orphan_pages.rs
+++ b/src/rules/orphan_pages.rs
@@ -24,7 +24,7 @@ pub fn check_orphans(graph: &Graph, report: &mut Report) {
     }
 
     let mut index_nodes = Vec::new();
-    for (_concept, idx) in &graph.index {
+    for idx in graph.index.values() {
         if let Some(label) = graph.graph.node_weight(*idx) {
             if label.ends_with("index.md") {
                 index_nodes.push(*idx);

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -909,6 +909,7 @@ pub fn query_top_segments_with_diagnostics_and_strategy(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn query_top_segments_with_corpus_stats_and_strategy(
     query: &str,
     top_k: usize,
@@ -1418,6 +1419,7 @@ fn query_top_segments_with_missing_coverage_recovery_segment_enrichment_and_stra
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn query_top_segments_with_adaptive_segment_enrichment_and_strategy(
     query: &str,
     top_k: usize,
@@ -1475,6 +1477,7 @@ fn query_top_segments_with_adaptive_segment_enrichment_and_strategy(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn query_top_segments_with_adaptive_route_aware_segment_enrichment_and_strategy(
     query: &str,
     top_k: usize,
@@ -1854,6 +1857,7 @@ fn route_score_is_close(candidate_score: f32, cutoff_score: f32) -> bool {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn query_selected_segments_with_enrichment(
     query: &str,
     top_k: usize,
@@ -2113,6 +2117,7 @@ struct RouteAwareCandidate {
 }
 
 impl RouteAwareCandidate {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         mut result: SearchResult,
         segment: &MemoryIndexSegment,

--- a/src/source.rs
+++ b/src/source.rs
@@ -24,6 +24,7 @@ pub struct SourceDocument {
 }
 
 impl SourceDocument {
+    #[allow(clippy::too_many_arguments)]
     pub fn with_stable_doc_id_from_source(
         source: String,
         content: String,

--- a/src/temporal.rs
+++ b/src/temporal.rs
@@ -294,9 +294,7 @@ fn resolve_temporal_target_with_temps(query: &str, base_date: NaiveDate) -> Opti
         }
     }
 
-    let Some((_, _, parsed_date, phrase)) = best else {
-        return None;
-    };
+    let (_, _, parsed_date, phrase) = best?;
 
     let delta_days = parsed_date.signed_duration_since(now_date).num_days();
     let target_date = base_date + Duration::days(delta_days);

--- a/src/temporal_fact.rs
+++ b/src/temporal_fact.rs
@@ -150,7 +150,7 @@ impl TemporalFactStore {
             for claim in &record.top_claims {
                 store.ingest_claim(
                     record,
-                    &claim,
+                    claim,
                     source_chunk_id.as_deref(),
                     source_chunk_version,
                     chunk_timestamp.as_deref(),
@@ -564,10 +564,10 @@ mod tests {
         let timeline = built.timeline("alice");
         assert_eq!(timeline.len(), 2);
         assert_eq!(timeline[0].object.as_deref(), Some("Acme"));
-        assert_eq!(timeline[0].is_latest, false);
+        assert!(!timeline[0].is_latest);
         assert_eq!(timeline[0].valid_to.as_deref(), Some("2024-02-01"));
         assert_eq!(timeline[1].object.as_deref(), Some("Beta"));
-        assert_eq!(timeline[1].is_latest, true);
+        assert!(timeline[1].is_latest);
 
         store.ingest_claim(
             &record1,

--- a/src/tier1.rs
+++ b/src/tier1.rs
@@ -411,7 +411,7 @@ fn tokenize_words(content: &str) -> Vec<String> {
 
 fn sentence_count(content: &str) -> usize {
     let count = content
-        .split(|c: char| c == '.' || c == '!' || c == '?')
+        .split(['.', '!', '?'])
         .filter(|s| !s.trim().is_empty())
         .count();
     count.max(1)
@@ -448,7 +448,7 @@ impl ImportantTermRanker for YakeStyleTermRanker {
         }
         for sent in doc
             .content
-            .split(|c: char| c == '.' || c == '!' || c == '?')
+            .split(['.', '!', '?'])
         {
             let s_tokens = tokenize_words(sent);
             let unique: HashSet<String> = s_tokens.into_iter().collect();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -106,8 +106,10 @@ fn ignore_related_section_for_crossrefs() {
         MAX_TOTAL_BYTES,
     )
     .unwrap();
-    let mut cfg = Config::default();
-    cfg.ignore_crossref_sections = vec!["related".to_string()];
+    let cfg = Config {
+        ignore_crossref_sections: vec!["related".to_string()],
+        ..Default::default()
+    };
     let mut report = Report::new();
 
     check_cross_refs(&graph, &mut report, &cfg);
@@ -127,8 +129,10 @@ fn allowlist_limits_crossrefs() {
         MAX_TOTAL_BYTES,
     )
     .unwrap();
-    let mut cfg = Config::default();
-    cfg.allowlist_concepts = vec!["gamma".to_string()];
+    let cfg = Config {
+        allowlist_concepts: vec!["gamma".to_string()],
+        ..Default::default()
+    };
     let mut report = Report::new();
 
     check_cross_refs(&graph, &mut report, &cfg);


### PR DESCRIPTION
## Summary

Makes `cargo clippy --all-targets` fully clean (0 errors, 0 warnings) with minimal, behavior-preserving changes.

- **Fix deny-by-default error**: `clippy::never_loop` in `query_semantics::extract_temporal` — the loop unconditionally returned on its first iteration; rewritten as `into_iter().next()?` with identical behavior.
- **Mechanical lint fixes**: needless borrows, `map().flatten()` on `Option`, consecutive `str::replace` calls merged into `replace(['_', '-'], …)`, elided lifetimes, `to_vec()`, `vec![]` init, `?` operator, `is_some_and`/`is_none_or`, char-array split patterns, collapsible `if`, derived `Default` impls, `Display` impl for `Report`.
- **Complex types factored into aliases** (`RankedGroup`, `SemanticState`).
- **Targeted `#[allow(clippy::too_many_arguments)]`** where signature refactors would be invasive.
- **Tests**: `bool_assert_comparison` fixes and struct-update syntax; no logic changes.

## Verification

- `cargo clippy --all-targets`: 0 errors, 0 warnings
- `cargo test`: all tests pass (93 lib + 6 integration + 3 doc)