### PR TITLE
Share query preparation across CLI and memory server; release 0.1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,9 @@ benchmark/codex_code/results/*
 !benchmark/codex_code/results/.gitkeep
 benchmark/agy/results/*
 !benchmark/agy/results/.gitkeep
-benchmark/data/longmemeval_s_raw.json
-benchmark/data/lintai_longmemeval_scoped_results*.json
-benchmark/data/python_lintai_longmemeval_scoped_results*.json
+# Benchmark corpora and generated results are local-only. Ignore the directory
+# rather than individual filenames: untracked files here are picked up by
+# `cargo package` and would otherwise ship inside the published crate.
+benchmark/data/
 benchmark/claude_code/results/*
 !benchmark/claude_code/results/.gitkeep

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lint-ai"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Semantic wiki and docs linting for contradictions, stale claims, orphan pages, and missing cross-references"
 license = "Apache-2.0"

--- a/docs/query-context-and-ranking-consolidation.md
+++ b/docs/query-context-and-ranking-consolidation.md
@@ -1,0 +1,356 @@
+# Query Context and Ranking Consolidation
+
+Status: design proposal
+
+This document describes the proposed consolidation of query-context handling and
+session/group ranking across the global and segmented retrieval paths. It does
+not describe an implemented change.
+
+## Motivation
+
+The repository currently has two relevant retrieval paths:
+
+```text
+global path:
+query → MemoryIndex → document candidates → aggregate_group_score
+
+segmented path:
+query → segment routing → selected segment indexes →
+document results → aggregate_segment_results_by_session
+```
+
+Both paths can return results belonging to the same session or group, but they
+currently use different aggregation formulas. The global path has count-query
+behavior, rank-decayed sibling support, and a score threshold. The segmented
+path uses flat sibling support and adds its own term, entity, document-count,
+and graph bonuses.
+
+The goal is not to make segment routing and document retrieval identical. The
+goal is to make the final session/group aggregation policy explicit and shared.
+
+## Query-context behavior
+
+`TemporalQueryContext` already carries temporal filters, document scoping, and
+an optional `QueryRoutingIntent`. The intent values are:
+
+```rust
+QueryRoutingIntent::Count
+QueryRoutingIntent::Sum
+QueryRoutingIntent::Sequence
+```
+
+The existing high-level engine path analyzes the query and populates this
+field. Low-level convenience APIs currently default the context, so direct
+global and segmented calls do not automatically infer intent.
+
+This field is not currently the source of the global aggregator's
+`count_query` decision. In `src/index.rs`, `count_query` is independently
+derived from lowercase query-string markers such as `how many`, `count`,
+`number of`, and `times did i`. Consequently, a direct call such as
+`MemoryIndex::query("How many projects...", ...)` still enters the count
+aggregation branch even though its `TemporalQueryContext.query_routing_intent`
+is `None`.
+
+`QueryRoutingIntent` does affect other global behavior, including the expanded
+candidate limit, disabling some follow-up graph boosts for count/sum queries,
+and intent-specific evidence processing. The context gap is therefore real,
+but it is not what currently controls `aggregate_group_score`'s count branch.
+`QueryRoutingIntent::Sequence` currently has no defined role in group
+aggregation; the consolidated policy must either give it one explicitly or
+state that it has no aggregation effect, rather than leaving it unspecified.
+
+The proposed behavior is:
+
+| Entry point | Context behavior |
+| --- | --- |
+| `MemoryIndex::query` | Build an automatic default context from the raw query (intent only, no augmentation). |
+| `MemoryIndex::query_timed` | Build the same automatic default context. |
+| Segmented convenience APIs (`query_top_segment`, `query_top_segments`, `query_all_segments`; not the internal `_with_strategy`/`_with_corpus_stats` variants) | Build the same automatic default context. |
+| `query_with_temporal_context` APIs | Preserve caller-provided context and values. |
+| High-level engine (`engine.rs`'s `--query`/`--llm-context` handling) | Continue passing its already analyzed, richer context (intent **and** query augmentation) without re-analysis. |
+| `MemoryService::search` (memory server `/search`) | Should be treated like the high-level engine, not like a low-level convenience API — see "Application-level entry points" below. |
+
+The automatic helper should initially infer only `query_routing_intent` and
+preserve the existing raw query text. Query augmentation and explicit temporal
+behavior remain the responsibility of the high-level engine or explicit context
+callers. The shared ranking module should then use the context intent directly;
+the eventual consolidation should remove the independent global string
+heuristic rather than preserve two count-query classifiers.
+
+Conceptually:
+
+```rust
+fn automatic_query_context(query: &str) -> TemporalQueryContext<'static> {
+    let analysis = analyze_query(query);
+    TemporalQueryContext {
+        query_routing_intent: analysis.query_routing_intent,
+        ..TemporalQueryContext::default()
+    }
+}
+```
+
+Explicit context APIs must not overwrite a caller's intent. This preserves
+advanced callers that have already performed analysis or intentionally selected
+a context.
+
+## Application-level entry points
+
+Query-context alignment needs to be traced past the library API and into the
+two concrete places that actually build a query today: the memory server and
+the CLI. They currently diverge, and one of them (the memory server) is the
+newest and most externally-exposed entry point in the codebase.
+
+### Production memory server
+
+```text
+MemoryService::search
+    → IndexStore::query_filtered
+    → MemoryIndex::query_with_filters_and_lexical
+```
+
+See `src/memory_api.rs:120` and `src/pipeline.rs:957`.
+
+This is the actual `/search` production path (the memory server introduced in
+commit `1f2d8d7`, "Add AML-compatible memory server", 2026-08-13). It does not
+go through `engine.rs::query_temporal_context` or `analyze_query` at all today
+— it has no query-intent awareness and no query augmentation. The underlying
+`query_filtered`/`query_with_filters_and_lexical` plumbing itself is older
+(introduced 2026-06-13, commit `7240333`, part of the last tagged release,
+`v0.1.8`); the gap is that the August server work exposed it over HTTP without
+also wiring it into the context/intent story.
+
+### CLI / high-level engine
+
+```text
+engine.rs (args.query / args.llm_context handling)
+    → analyze_query(query)
+    → search_query = analysis.augmented_query
+    → query_temporal_context(&analysis)
+    → MemoryIndex::query_with_temporal_context(&search_query, top_k, temporal_context)
+```
+
+See `src/engine.rs:2409-2447`. This path does more than the "automatic
+default context" proposed above for low-level convenience APIs: it also
+augments the query text (`analysis.augmented_query`), not just infers intent.
+
+### Proposed alignment
+
+`MemoryService::search` should be aligned with the CLI/engine path, not with
+the lighter default meant for low-level convenience callers:
+
+1. `analysis = analyze_query(&request.query)`
+2. `search_query = analysis.augmented_query`
+3. `temporal_context = query_temporal_context(&analysis)`
+4. Build `allowed_doc_ids` from the `memory_user_id` filter (the same shape
+   `query_with_filters_and_lexical` already builds internally from its
+   `filters` map — `MemoryService` only ever filters on that one key)
+5. Set `temporal_context.allowed_doc_ids = Some(&allowed)`
+6. Call `index.query_with_temporal_context(&search_query, top_k, temporal_context)`
+
+This resolves the intent gap, the query-augmentation gap, and the
+filters-vs-`allowed_doc_ids` duplication for this caller in one change.
+
+### Consequence for `query_with_filters_and_lexical`
+
+`TemporalQueryContext` already has `allowed_doc_ids: Option<&'a HashSet<String>>`
+(`src/index.rs:463`), which `query_with_temporal_context` already threads
+through to the same underlying scoring call `query_with_filters_and_lexical`
+uses. The filter-derived `allowed` set the latter builds today
+(`src/index.rs:1548-1557`) maps onto that field directly. Once
+`MemoryService::search` is aligned as above, `query_with_filters_and_lexical`
+and `query_with_filters_multi` as distinct code paths are not technically
+necessary — `filters` → `allowed_doc_ids` and intent are both already covered
+by `query_with_temporal_context`.
+
+The one thing this does not fold in for free: `query_with_filters_and_lexical`
+accepts a caller-supplied, pre-computed `lexical_hits` map, while
+`query_with_temporal_context` → `query_timed_with_context` always computes
+lexical hits itself against `MemoryIndex`'s own internal `self.lexical:
+Option<LexicalIndex>` (`src/index.rs:329`). The pre-computed-hits parameter
+exists to let `IndexStore` (`src/pipeline.rs`) supply hits from its own,
+separate tantivy index — `self.lexical: LexicalState` (`src/pipeline.rs:357`)
+— which is otherwise unused: its only four call sites are
+`query_with_lexical_hits` (for `query_latest`/`query_fresh`) and
+`query_with_filters_and_lexical`/`query_with_filters_multi`
+(`src/pipeline.rs:895,908,972,996`). Because all four of those callers call
+`self.refresh()` first, which rebuilds `MemoryIndex` — and therefore its own
+internal lexical index — from scratch whenever the store is dirty
+(`src/pipeline.rs:801-833`), `MemoryIndex`'s internal index is already exactly
+as fresh as `IndexStore`'s separate one by the time any of them run.
+
+Consequently, folding these callers onto `query_with_temporal_context` makes
+`IndexStore`'s separate `LexicalState` — its schema, writer, reader, and the
+`upsert_record`/`remove_doc`/`commit_reload` maintenance that runs on every
+mutation — removable, not just the four call sites that use it. This is a
+larger change than the aggregation-formula consolidation and should be scoped
+and reviewed as its own step, not folded silently into it.
+
+## Internal ranking module
+
+Add a small internal module:
+
+```text
+src/ranking.rs
+```
+
+Register it as a private or crate-visible module from `src/lib.rs`, depending on
+which APIs need to call it. The module should contain the shared final
+session/group aggregation policy, not segment-routing logic and not Tantivy
+retrieval logic.
+
+The module should accept normalized result evidence rather than either
+`CandidateState` or the full segment implementation. A conceptual input model
+is:
+
+```rust
+struct GroupRankingItem {
+    group_id: String,
+    doc_id: String,
+    base_score: f32,
+    matched_terms: Vec<String>,
+    matched_entities: Vec<String>,
+    graph_support: f32,
+}
+```
+
+The exact representation can use borrowed data or an internal owned adapter;
+the important property is that both retrieval paths provide the same semantic
+signals.
+
+The shared entry point would be conceptually:
+
+```rust
+fn aggregate_groups(
+    items: Vec<GroupRankingItem>,
+    intent: Option<QueryRoutingIntent>,
+) -> Vec<GroupRankingResult>
+```
+
+The shared implementation owns:
+
+- grouping by session/group ID;
+- sorting items within a group;
+- best-result contribution;
+- rank-decayed sibling support;
+- the sibling support threshold;
+- coverage counting and caps;
+- count-query adjustments;
+- unique-term and unique-entity caps;
+- deterministic group ordering;
+- assigning the aggregate group score to returned items.
+
+The current formulas should not be copied blindly. Their useful signals should
+be reconciled into one documented policy, with constants defined in one place.
+
+## Integration points
+
+### Global retrieval
+
+Replace the direct use of `aggregate_group_score` in `src/index.rs` with an
+adapter:
+
+```text
+CandidateState + document metadata
+    → GroupRankingItem
+    → ranking::aggregate_groups(..., query_context.query_routing_intent)
+    → existing global evidence adjustments, where applicable
+```
+
+Tantivy scoring, candidate generation, graph retrieval, and temporal filtering
+remain in the global path.
+
+### Segmented retrieval
+
+Replace `aggregate_segment_results_by_session` in `src/segments.rs` with an
+adapter:
+
+```text
+segment-local SearchResult values
+    → GroupRankingItem
+    → ranking::aggregate_groups(..., temporal.query_routing_intent)
+    → explicitly retained segment-specific adjustments, where applicable
+```
+
+Segment routing remains independent:
+
+```text
+segment routing chooses the search scope
+shared ranking aggregates results inside that scope
+```
+
+The ranking module must not decide which segments are searched.
+
+## Query flow after consolidation
+
+```text
+raw query
+    ↓
+automatic context helper, unless explicit context was supplied
+    ↓
+query intent + temporal/scoping context
+    ↓
+global retrieval or segment routing
+    ↓
+document candidates and evidence
+    ↓
+shared ranking::aggregate_groups
+    ↓
+path-specific final presentation adjustments
+```
+
+The high-level engine remains compatible with this flow because it already
+performs query analysis. It should pass its existing context through rather than
+analyze the query a second time. `MemoryService::search` should join the engine
+on this same footing (see "Application-level entry points" above) rather than
+entering through the automatic-default path meant for low-level convenience
+callers.
+
+## Tests required
+
+The implementation should add tests for:
+
+1. `MemoryIndex::query` and `query_timed` automatically infer count, sum, and
+   sequence intent where applicable.
+2. Segmented convenience APIs infer the same intent.
+3. Explicit `query_with_temporal_context` values are preserved.
+4. High-level engine queries do not double-apply query analysis or augmentation.
+5. Identical synthetic group items produce identical group ordering through the
+   global and segmented adapters.
+6. Count-query aggregation changes support weighting consistently in both paths.
+7. Unique evidence and sibling-support caps are applied consistently.
+8. Segment routing still limits the document scope before shared aggregation.
+9. Results are mapped back to the correct session/group after aggregation.
+10. `MemoryService::search` produces the same `query_routing_intent` and
+    augmented query text as the CLI/engine path for the same input query.
+11. Removing `IndexStore`'s separate `LexicalState` does not change
+    `query_filtered`/`query_filtered_multi`/`query_latest`/`query_fresh`
+    results, since `MemoryIndex`'s own internal lexical index is already
+    rebuilt fresh on every `refresh()` these callers perform.
+
+The parity tests should compare ordering and selected group IDs, not raw scores
+from Tantivy and segment routing. Those scores come from different retrieval
+stages and are not expected to be numerically identical.
+
+**Benchmark regression gate.** Structural/ordering parity tests are not
+sufficient on their own: a plausible-looking consolidation can silently shift
+retrieval quality in either direction depending on which path is unified
+toward which. (A tokenization unification tried during this design's review
+cost ~5pp of recall@5 on segment routing one way, and ~0.2pp on the global
+path the other way, despite passing all structural tests.) Before landing the
+ranking-module consolidation, run the existing `haystack_scoped_benchmark`
+(global path, LongMemEval-S, 500 scoped queries) and `segment_scoped_benchmark`
+(segmented path, multi-session slice) before and after, and gate on no
+regression beyond the ~0.3pp noise floor already established for other
+dependency-level changes in this codebase.
+
+## Non-goals
+
+This proposal does not:
+
+- replace Tantivy's BM25 implementation;
+- make segment IDF numerically match document IDF;
+- remove `SegmentRoutingStrategy`;
+- force global retrieval and segment routing to use the same candidate-generation
+  algorithm;
+- apply query augmentation automatically in every low-level API;
+- change the public explicit-context APIs' caller-controlled behavior.

--- a/docs/releases/0.1.9.md
+++ b/docs/releases/0.1.9.md
@@ -1,0 +1,245 @@
+# Release Notes: v0.1.9
+
+Date: 2026-08-19
+
+This is a large release. Since `0.1.8` the crate gained a network-facing memory
+server, a segmented memory index, agent integrations for four providers with
+session recording, and Python bindings — plus a security-hardening pass over
+the server and a `tantivy` upgrade that clears a RUSTSEC advisory.
+
+> ## ⚠️ Upgrade warning: API removals coming in 0.2.0
+>
+> Five `MemoryIndex` query methods are **deprecated as of this release** and
+> **will be removed in `0.2.0`**:
+>
+> `query_timed` · `query_with_lexical_hits` · `query_with_filters` ·
+> `query_with_filters_and_lexical` · `query_with_filters_multi`
+>
+> `0.1.9` is the migration window. Code calling these still compiles and
+> behaves exactly as before, but now emits deprecation warnings naming the
+> replacement. Building with `-D deprecated` will surface every call site.
+>
+> Migrate before upgrading to `0.2.0` — see [Deprecations](#deprecations) for
+> the replacement table and a worked example. `IndexStore` methods are
+> unaffected; if you only use `IndexStore`, there is nothing to do.
+>
+> `0.2.0` will also stop creating an on-disk lexical directory and will no
+> longer fail initialization when that directory holds unrelated files, since
+> the store's second lexical index is being removed.
+
+## Highlights
+
+- Bumped crate version from `0.1.8` to `0.1.9`.
+- **Memory server**: new `server` binary exposing `GET /health`, `POST /add`,
+  and `POST /search`, backed by `memory_api::MemoryService`.
+- **Segmented memory index**: `SegmentedMemoryIndex` with pluggable
+  `SegmentRoutingStrategy`, selectable through `MemoryIndexLayout`.
+- **Agent integrations**: Claude Code, Codex, Gemini CLI, and AGY, each behind
+  its own feature flag, with hook handling and MCP tools.
+- **Session recording**: provider session capture and replay with secret
+  redaction.
+- **Python bindings**: `IndexStore` exposed to Python behind the `python`
+  feature.
+- **Store inspection**: `IndexStore::inspection` plus CLI views for source
+  documents, records, and segments.
+- **Shared query preparation**: `query_plan::PreparedQuery`, now used by both
+  the CLI and the memory server.
+- **Security**: server authentication is required by default on non-loopback
+  binds; DoS limits; broader credential redaction; `tantivy` `0.22` → `0.25`.
+
+## Memory Server
+
+A new `server` binary serves an Add/Search contract over HTTP, backed by
+`IndexStore`.
+
+```bash
+cargo run --release --bin server -- \
+  --bind 0.0.0.0:8080 \
+  --index /var/lib/lint-ai/memory-index \
+  --server-token "$SERVER_TOKEN"
+```
+
+Endpoints are `GET /health`, `POST /add`, and `POST /search`. The token is
+accepted as `X-Api-Key`, `Authorization: Bearer <token>`, or
+`Authorization: Token <token>`, and may also come from the `SERVER_TOKEN`
+environment variable. See `docs/server.md`.
+
+`memory_api::MemoryService` is usable directly as a library type for callers
+that want the same Add/Search semantics without the HTTP layer.
+
+### Security hardening
+
+- **Authentication is required by default.** The server refuses to start on a
+  non-loopback bind address without a token. `--allow-unauthenticated`
+  overrides this for closed networks.
+- Constant-time token comparison.
+- Socket read/write timeouts, header count and size caps, and a
+  concurrent-connection cap (`503` when exceeded).
+- Request bodies are streamed rather than pre-allocated from `Content-Length`.
+- `request_id`, `user_id`, and `session_id` are rejected if longer than 256
+  bytes or containing control characters.
+
+## Segmented Memory Index
+
+`SegmentedMemoryIndex` partitions the corpus into per-group segments, each a
+self-contained `MemoryIndex`, and routes a query to the most promising segments
+instead of scanning everything. Select it through `PipelineOptions`:
+
+```rust
+let options = PipelineOptions {
+    memory_index_layout: MemoryIndexLayout::Segmented {
+        query_top_n: 5,
+        routing_strategy: SegmentRoutingStrategy::LocalDistinctiveness,
+    },
+    ..PipelineOptions::default()
+};
+```
+
+Routing strategies include sparse overlap, KL divergence, local
+distinctiveness, coverage-based and team-coverage variants, and typed evidence.
+Segment selection, enrichment, and router-miss diagnostics are reported through
+`SegmentQueryDiagnostics`.
+
+An experimental `segment_scoped_benchmark` binary (requires the `experimental`
+feature) reports segmented retrieval metrics and router failure analysis
+alongside the standard scoped benchmark.
+
+## Agent Integrations
+
+Four provider integrations, each behind a feature flag: `claude-code`, `codex`,
+`gemini-cli`, and `agy`. Each maps provider hook events into `SourceDocument`
+values, stores them through `IndexStore`, and exposes MCP search and info
+tools. See `src/integrations/README.md` and the per-provider documents in
+`docs/`.
+
+### Session recording
+
+Provider sessions can be captured and replayed. Recorded events are redacted
+before they are written: key-name matching plus token-shape detection covering
+private keys, bearer tokens, JWTs, and provider key prefixes (AWS, Google,
+GitHub, GitLab, Stripe, Hugging Face, npm, Slack). Manifests and event files are
+written with `0600` permissions.
+
+## Python Bindings
+
+Behind the `python` feature, `IndexStore` is exposed to Python via PyO3,
+covering upsert and query. Build with `--features python` to produce the
+extension module.
+
+## Store Inspection
+
+`IndexStore::inspection()` returns an `IndexStoreInspection` summary of the
+store's contents, including per-segment detail when the segmented layout is
+active. The same information is surfaced through CLI inspection views for
+source documents, records, segments, and store summaries.
+
+## Shared Query Preparation
+
+Previously the CLI analyzed queries — inferring routing intent and augmenting
+query text — while the memory server's `/search` did neither, so the same
+question behaved differently depending on how it arrived. That preparation now
+lives in `query_plan::PreparedQuery`, and both callers use it.
+
+```rust
+use lint_ai::query_plan::PreparedQuery;
+
+let prepared = PreparedQuery::new("How many projects did I ship last quarter?");
+let context = prepared.temporal_context();   // carries QueryRoutingIntent::Count
+let text = prepared.search_query();          // the augmented query text
+```
+
+`PreparedQuery` owns the `QueryAnalysis` so the borrowed
+`TemporalQueryContext` stays valid; build one per query and keep it alive for
+the search. `temporal_context()` leaves `allowed_doc_ids` unset so callers can
+scope the search themselves.
+
+```rust
+let prepared = PreparedQuery::new(&query);
+let results = store.query_prepared(&prepared, top_k, &filters)?;
+```
+
+`IndexStore::query_prepared` applies that preparation and scopes the search
+through `TemporalQueryContext::allowed_doc_ids`, resolved from `filters` via
+the new `MemoryIndex::doc_ids_matching_filters`. Prefer it over
+`IndexStore::query_filtered` for any caller handling a raw user query.
+
+### Behavior change: memory server `/search`
+
+`MemoryService::search` now goes through `query_prepared`, so requests gain
+query-routing intent (affecting candidate limits, graph-boost suppression for
+count and sum queries, and intent-specific evidence processing) and query
+augmentation. Results will differ from the pre-`0.1.9` server for queries where
+either applies. Request and response shapes are unchanged.
+
+This does not affect the count-query branch of group aggregation, which still
+derives `count_query` from query-string markers independently of
+`QueryRoutingIntent`. Reconciling the two count classifiers is deferred.
+
+## Tokenizer Module
+
+`index.rs` and `segments.rs` each carried their own tokenizer and stopword
+list. Both now live in `tokenizer` behind an explicit `TokenizerMode`:
+
+- `TokenizerMode::Unstemmed` — regex-bounded terms, lowercased, no stemming.
+  Used by the lexical and rerank path.
+- `TokenizerMode::Stemmed` — split on non-alphanumeric boundaries, each token
+  stemmed. Used by segment routing.
+
+The two modes are deliberate, not drift. Benchmarking showed each is a measured
+improvement for its own caller and a regression for the other: switching
+segment routing to unstemmed cost roughly 5pp of recall@5, and switching the
+lexical path to stemmed cost roughly 0.1–0.3pp across recall, MRR, and NDCG.
+Only the location of the code changed.
+
+## Dependencies
+
+- `tantivy` `0.22` → `0.25`, which brings in a fixed `crossbeam-epoch`
+  (RUSTSEC-2026-0204) and drops the unmaintained `instant` crate. `0.26` was
+  evaluated and deliberately not adopted: its `TopDocs`/`TopNComputer`
+  tie-breaking change
+  ([quickwit-oss/tantivy#2775](https://github.com/quickwit-oss/tantivy/issues/2775))
+  cost roughly 1.7pp recall@5 and 1.3pp MRR on LongMemEval-S, while `0.25`
+  reproduces `0.1.8` results within noise.
+- `pyo3` updated to clear a security audit finding.
+
+## Deprecations
+
+The following `MemoryIndex` methods are deprecated in `0.1.9` and will be
+removed in `0.2.0`. Each carries a `#[deprecated]` note naming its replacement.
+
+| Deprecated | Replacement |
+| --- | --- |
+| `query_timed` | `query_with_temporal_context` |
+| `query_with_lexical_hits` | `query_with_temporal_context` |
+| `query_with_filters` | `query_with_temporal_context` + `allowed_doc_ids` |
+| `query_with_filters_and_lexical` | `query_with_temporal_context` + `allowed_doc_ids` |
+| `query_with_filters_multi` | `query_with_temporal_context` + `allowed_doc_ids` |
+
+Migrating a filtered query:
+
+```rust
+// before
+let results = index.query_with_filters(query, top_k, &filters);
+
+// after
+let allowed = index.doc_ids_matching_filters(&filters);
+let context = TemporalQueryContext {
+    allowed_doc_ids: allowed.as_ref(),
+    ..TemporalQueryContext::default()
+};
+let results = index.query_with_temporal_context(query, top_k, context).0;
+```
+
+For the multi-query case, resolve `allowed` once and reuse it across queries;
+this preserves the batching `query_with_filters_multi` provided.
+
+`IndexStore::query`, `query_timed`, `query_filtered`, and `query_filtered_multi`
+are **not** deprecated and keep working unchanged.
+
+## Retrieval Quality
+
+The global retrieval path is unchanged. A full LongMemEval-S scoped run (500
+queries) reproduces the `0.1.8` aggregates exactly on all eight metrics:
+recall@5/10/20, recall_any@5/10/20, MRR, and NDCG@10. Upgrading does not
+require re-validating retrieval quality, with the exception of the memory
+server `/search` behavior change noted above.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,7 +3,7 @@ use crate::cli::{GraphExportFormat, GraphLevel, IndexInspectView, LlmChunkStrate
 use crate::config::{load_config, normalize_list, Config};
 use crate::filters::is_noise_concept;
 use crate::graph::{normalize_concept, Graph, Tier0Record};
-use crate::index::{DocRecord, MemoryIndex, SectionChunk, TemporalQueryContext, TemporalQueryHint};
+use crate::index::{DocRecord, MemoryIndex, SectionChunk};
 #[cfg(feature = "agy")]
 use crate::integrations::agy::hooks::{run_hook as run_agy_hook, AgyHookKind};
 #[cfg(feature = "agy")]
@@ -39,7 +39,8 @@ use crate::pipeline::{
     source_documents_to_tier1_inputs, ChunkStrategy, IndexStore, MemoryIndexLayout,
     PipelineOptions, Tier1NerProvider, Tier1TermRankerKind,
 };
-use crate::query_semantics::{analyze_query, QueryAnalysis, QueryTimeHint};
+use crate::query_plan::PreparedQuery;
+use crate::query_semantics::QueryAnalysis;
 use crate::report::Report;
 use crate::rules::cross_refs::check_cross_refs;
 use crate::rules::orphan_pages::check_orphans;
@@ -101,33 +102,6 @@ fn graph_to_source_documents(graph: &Graph) -> Vec<SourceDocument> {
             }
         })
         .collect()
-}
-
-fn query_temporal_context(analysis: &QueryAnalysis) -> TemporalQueryContext<'_> {
-    TemporalQueryContext {
-        starts_from: None,
-        ends_at: None,
-        window_days: match analysis.time_hint {
-            Some(QueryTimeHint::Past) => 365,
-            Some(QueryTimeHint::Present) => 30,
-            Some(QueryTimeHint::Ongoing) => 14,
-            Some(QueryTimeHint::Mixed) => 30,
-            None => 7,
-        },
-        hard_filter: false,
-        time_hint: analysis
-            .time_hint
-            .map(|hint| match hint {
-                QueryTimeHint::Past => TemporalQueryHint::Past,
-                QueryTimeHint::Present => TemporalQueryHint::Present,
-                QueryTimeHint::Ongoing => TemporalQueryHint::Ongoing,
-                QueryTimeHint::Mixed => TemporalQueryHint::Mixed,
-            })
-            .filter(|_| analysis.temporal.is_some()),
-        query_routing_intent: analysis.query_routing_intent,
-        has_explicit_temporal: analysis.temporal.is_some(),
-        allowed_doc_ids: None,
-    }
 }
 
 fn surface_forms(raw: &str) -> Vec<String> {
@@ -2409,9 +2383,10 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         let query_value = args.llm_context.as_deref().or(args.query.as_deref());
         if let Some(query) = query_value {
             let started = Instant::now();
-            let analysis = analyze_query(query);
-            let search_query = analysis.augmented_query.clone();
-            let temporal_context = query_temporal_context(&analysis);
+            let prepared = PreparedQuery::new(query);
+            let analysis = prepared.analysis().clone();
+            let search_query = prepared.search_query().to_string();
+            let temporal_context = prepared.temporal_context();
             if args.llm_context.is_some() {
                 let requested = args.result_count.clamp(1, MAX_RESULT_COUNT);
                 let candidate_top_k = requested.max(LLM_CONTEXT_CANDIDATE_TOP_K);

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,6 +2,7 @@ use crate::ids::stable_chunk_id;
 use crate::query_expansion::{expand_query_terms, normalize_for_index};
 use crate::query_semantics::QueryRoutingIntent;
 use crate::temporal::{parse_temporal_date, resolve_temporal_target};
+use crate::tokenizer::{self, TokenizerMode};
 use crate::tier1::{RankedTerm, Tier1Entity};
 use anyhow::Result;
 use chrono::{DateTime, NaiveDate, Utc};
@@ -2720,13 +2721,7 @@ impl SemanticAggregate {
 }
 
 fn tokenize_query_terms(input: &str) -> Vec<String> {
-    static TOKEN_RE: OnceLock<Regex> = OnceLock::new();
-    let token_re =
-        TOKEN_RE.get_or_init(|| Regex::new(r"[A-Za-z][A-Za-z0-9_-]{2,}").expect("valid regex"));
-    token_re
-        .find_iter(input)
-        .map(|m| m.as_str().to_lowercase())
-        .collect()
+    tokenizer::tokenize(input, TokenizerMode::Unstemmed)
 }
 
 fn claim_tokens(claim: &Claim) -> Vec<String> {
@@ -3075,73 +3070,15 @@ fn group_evidence_boost(
 }
 
 fn routing_content_terms(q_terms: &[String]) -> Vec<String> {
-    let stop = routing_stopwords();
     let mut seen = HashSet::new();
     q_terms
         .iter()
         .filter(|term| term.len() >= 3)
-        .filter(|term| !stop.contains(term.as_str()))
+        .filter(|term| !tokenizer::is_stopword(term, TokenizerMode::Unstemmed))
         .filter(|term| seen.insert((*term).clone()))
         .take(16)
         .cloned()
         .collect()
-}
-
-fn routing_stopwords() -> &'static HashSet<&'static str> {
-    static STOP: OnceLock<HashSet<&'static str>> = OnceLock::new();
-    STOP.get_or_init(|| {
-        [
-            "how",
-            "many",
-            "much",
-            "what",
-            "which",
-            "who",
-            "when",
-            "where",
-            "why",
-            "did",
-            "does",
-            "have",
-            "has",
-            "had",
-            "been",
-            "being",
-            "was",
-            "were",
-            "are",
-            "the",
-            "and",
-            "or",
-            "for",
-            "from",
-            "with",
-            "that",
-            "this",
-            "these",
-            "those",
-            "currently",
-            "recently",
-            "past",
-            "last",
-            "next",
-            "into",
-            "onto",
-            "about",
-            "after",
-            "before",
-            "over",
-            "under",
-            "between",
-            "during",
-            "i",
-            "you",
-            "we",
-            "they",
-        ]
-        .into_iter()
-        .collect()
-    })
 }
 
 fn routing_unit_terms(query: &[String]) -> Vec<String> {

--- a/src/index.rs
+++ b/src/index.rs
@@ -1473,6 +1473,11 @@ impl MemoryIndex {
         (rescored, timings, diagnostics)
     }
 
+    #[deprecated(
+        since = "0.1.9",
+        note = "use `query_with_temporal_context`, which also carries query intent; \
+                scheduled for removal in 0.2.0"
+    )]
     pub fn query_timed(
         &self,
         query: &str,
@@ -1514,6 +1519,11 @@ impl MemoryIndex {
         (results, timings, diagnostics)
     }
 
+    #[deprecated(
+        since = "0.1.9",
+        note = "use `query_with_temporal_context`; externally supplied lexical hits are \
+                no longer needed now that the index scores its own. Scheduled for removal in 0.2.0"
+    )]
     pub fn query_with_lexical_hits(
         &self,
         query: &str,
@@ -1526,6 +1536,12 @@ impl MemoryIndex {
 
     /// Query with exact-match field filtering. All supplied filter key-value pairs must match
     /// a document's `filters` map for it to be included in results.
+    #[deprecated(
+        since = "0.1.9",
+        note = "use `query_with_temporal_context` with `TemporalQueryContext::allowed_doc_ids` \
+                built from `doc_ids_matching_filters`; scheduled for removal in 0.2.0"
+    )]
+    #[allow(deprecated)] // delegates to another deprecated helper; both go in 0.2.0
     pub fn query_with_filters(
         &self,
         query: &str,
@@ -1535,6 +1551,37 @@ impl MemoryIndex {
         self.query_with_filters_and_lexical(query, top_k, filters, None)
     }
 
+    /// Doc ids whose `filters` map matches every supplied key-value pair.
+    ///
+    /// Returns `None` when `filters` is empty, meaning "no scoping" rather
+    /// than "nothing matched" — callers pass this straight to
+    /// `TemporalQueryContext::allowed_doc_ids`.
+    pub fn doc_ids_matching_filters(
+        &self,
+        filters: &std::collections::BTreeMap<String, String>,
+    ) -> Option<HashSet<String>> {
+        if filters.is_empty() {
+            return None;
+        }
+        Some(
+            self.docs
+                .iter()
+                .filter(|(_, doc)| {
+                    filters
+                        .iter()
+                        .all(|(k, v)| doc.filters.get(k).map(|dv| dv == v).unwrap_or(false))
+                })
+                .map(|(doc_id, _)| doc_id.clone())
+                .collect(),
+        )
+    }
+
+    #[deprecated(
+        since = "0.1.9",
+        note = "use `query_with_temporal_context` with `TemporalQueryContext::allowed_doc_ids` \
+                built from `doc_ids_matching_filters`; scheduled for removal in 0.2.0"
+    )]
+    #[allow(deprecated)] // delegates to another deprecated helper; both go in 0.2.0
     pub fn query_with_filters_and_lexical(
         &self,
         query: &str,
@@ -1542,19 +1589,9 @@ impl MemoryIndex {
         filters: &std::collections::BTreeMap<String, String>,
         lexical_hits: Option<&HashMap<String, f32>>,
     ) -> Vec<SearchResult> {
-        if filters.is_empty() {
+        let Some(allowed) = self.doc_ids_matching_filters(filters) else {
             return self.query_with_lexical_hits(query, top_k, lexical_hits);
-        }
-        let allowed: HashSet<String> = self
-            .docs
-            .iter()
-            .filter(|(_, doc)| {
-                filters
-                    .iter()
-                    .all(|(k, v)| doc.filters.get(k).map(|dv| dv == v).unwrap_or(false))
-            })
-            .map(|(doc_id, _)| doc_id.clone())
-            .collect();
+        };
         self.query_with_lexical_hits_timed(query, top_k, lexical_hits, None, false, Some(&allowed))
             .0
     }
@@ -1562,6 +1599,12 @@ impl MemoryIndex {
     /// Multi-term variant: builds the allowed-doc set once from `filters`, then scores each
     /// query against it. At scale (thousands of docs) this avoids rescanning docs N times.
     /// Returns one `Vec<SearchResult>` per input query, in the same order.
+    #[deprecated(
+        since = "0.1.9",
+        note = "use `query_with_temporal_context` with `TemporalQueryContext::allowed_doc_ids` \
+                built once from `doc_ids_matching_filters` and reused across queries; \
+                scheduled for removal in 0.2.0"
+    )]
     pub fn query_with_filters_multi(
         &self,
         queries: &[&str],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod memory_api;
 pub mod ownership;
 pub mod pipeline;
 pub mod query_expansion;
+pub mod query_plan;
 pub mod query_semantics;
 pub mod report;
 pub mod review;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod symbols;
 pub mod temporal;
 pub mod temporal_fact;
 pub mod tier1;
+pub mod tokenizer;
 pub mod usage;
 
 pub use crate::claim_extractor::{ClaimExtractor, ConservativeClaimExtractor, ExtractedClaims};

--- a/src/memory_api.rs
+++ b/src/memory_api.rs
@@ -1,5 +1,6 @@
 //! Memory Add/Search API backed by Lint-AI's `IndexStore`.
 
+use crate::query_plan::PreparedQuery;
 use crate::{IndexStore, SourceDocument};
 use chrono::{TimeZone, Utc};
 use serde::{Deserialize, Serialize};
@@ -125,7 +126,10 @@ impl MemoryService {
         let top_k = request.top_k.min(100);
         let mut filters = BTreeMap::new();
         filters.insert(USER_FILTER.to_string(), request.user_id);
-        let results = self.store.query_filtered(&request.query, top_k, &filters)?;
+        // Same query treatment as the CLI: intent inference and augmentation,
+        // scoped to this user's documents.
+        let prepared = PreparedQuery::new(&request.query);
+        let results = self.store.query_prepared(&prepared, top_k, &filters)?;
         let data = results
             .into_iter()
             .filter_map(|result| {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -6,6 +6,7 @@ use crate::index::{
     build_semantic_doc_state, DocRecord, MemoryIndex, Provenance, QueryDiagnostics, QueryTimings,
     SearchResult, SemanticAggregate, SemanticDocState,
 };
+use crate::query_plan::PreparedQuery;
 use crate::segments::{SegmentRoutingStrategy, SegmentedMemoryIndex};
 use crate::source::SourceDocument;
 use crate::temporal::extract_temporal_terms;
@@ -877,6 +878,8 @@ impl IndexStore {
     }
 
     #[allow(dead_code)]
+    // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
+    #[allow(deprecated)]
     fn query_latest(&mut self, query: &str, top_k: usize) -> Result<Vec<SearchResult>> {
         self.poll_background_refresh()?;
         if self.snapshot.is_none() {
@@ -895,6 +898,8 @@ impl IndexStore {
             .query_with_lexical_hits(query, top_k, Some(&lexical_hits)))
     }
 
+    // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
+    #[allow(deprecated)]
     fn query_fresh(&mut self, query: &str, top_k: usize) -> Result<Vec<SearchResult>> {
         self.refresh()?;
         let lexical_hits = self
@@ -935,6 +940,8 @@ impl IndexStore {
         })
     }
 
+    // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
+    #[allow(deprecated)]
     pub fn query_timed(
         &mut self,
         query: &str,
@@ -954,6 +961,34 @@ impl IndexStore {
         Ok((results, timings, diagnostics))
     }
 
+    /// Searches with the full query treatment the CLI gets — intent inference
+    /// and query augmentation via [`PreparedQuery`] — optionally scoped to the
+    /// documents matching `filters`.
+    ///
+    /// Prefer this over [`IndexStore::query_filtered`] for any caller handling
+    /// a raw user query, so the analysis stays identical across entry points.
+    pub fn query_prepared(
+        &mut self,
+        prepared: &PreparedQuery,
+        top_k: usize,
+        filters: &std::collections::BTreeMap<String, String>,
+    ) -> Result<Vec<SearchResult>> {
+        self.refresh()?;
+        let index = self
+            .snapshot
+            .as_ref()
+            .expect("snapshot should exist after refresh")
+            .global_index();
+        let allowed = index.doc_ids_matching_filters(filters);
+        let mut context = prepared.temporal_context();
+        context.allowed_doc_ids = allowed.as_ref();
+        Ok(index
+            .query_with_temporal_context(prepared.search_query(), top_k, context)
+            .0)
+    }
+
+    // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
+    #[allow(deprecated)]
     pub fn query_filtered(
         &mut self,
         query: &str,
@@ -976,6 +1011,8 @@ impl IndexStore {
     /// query. BM25 (tantivy) is still called once per term — that can't be collapsed — but the
     /// filter scan over all docs happens only once regardless of how many queries are given.
     /// Returns one `Vec<SearchResult>` per input query, in the same order.
+    // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
+    #[allow(deprecated)]
     pub fn query_filtered_multi(
         &mut self,
         queries: &[&str],

--- a/src/query_plan.rs
+++ b/src/query_plan.rs
@@ -1,0 +1,108 @@
+//! Shared query preparation.
+//!
+//! Turning a raw user query into "what we actually search for" has two parts:
+//! analyzing the query (intent, temporal hints, augmentation) and turning that
+//! analysis into a [`TemporalQueryContext`]. Every caller that accepts a raw
+//! query from a user — the CLI, the memory server — should go through here, so
+//! the two cannot drift apart.
+//!
+//! Callers that have already built a context, or that deliberately want the
+//! default one, keep using `query_with_temporal_context` directly.
+
+use crate::index::{TemporalQueryContext, TemporalQueryHint};
+use crate::query_semantics::{analyze_query, QueryAnalysis, QueryTimeHint};
+
+/// A raw query plus the analysis derived from it.
+///
+/// Holds the analysis so the borrowed [`TemporalQueryContext`] it hands out
+/// stays valid; build one per query and keep it alive for the search.
+pub struct PreparedQuery {
+    analysis: QueryAnalysis,
+}
+
+impl PreparedQuery {
+    pub fn new(query: &str) -> Self {
+        Self {
+            analysis: analyze_query(query),
+        }
+    }
+
+    /// Reuses an analysis the caller already computed, so no query is analyzed
+    /// twice on paths that need the analysis for other reasons too.
+    pub fn from_analysis(analysis: QueryAnalysis) -> Self {
+        Self { analysis }
+    }
+
+    pub fn analysis(&self) -> &QueryAnalysis {
+        &self.analysis
+    }
+
+    pub fn into_analysis(self) -> QueryAnalysis {
+        self.analysis
+    }
+
+    /// The text to search with: the augmented query, not the raw input.
+    pub fn search_query(&self) -> &str {
+        &self.analysis.augmented_query
+    }
+
+    /// The context implied by the analysis. `allowed_doc_ids` is left unset;
+    /// callers that scope a search assign it themselves.
+    pub fn temporal_context(&self) -> TemporalQueryContext<'_> {
+        TemporalQueryContext {
+            starts_from: None,
+            ends_at: None,
+            window_days: match self.analysis.time_hint {
+                Some(QueryTimeHint::Past) => 365,
+                Some(QueryTimeHint::Present) => 30,
+                Some(QueryTimeHint::Ongoing) => 14,
+                Some(QueryTimeHint::Mixed) => 30,
+                None => 7,
+            },
+            hard_filter: false,
+            time_hint: self
+                .analysis
+                .time_hint
+                .map(|hint| match hint {
+                    QueryTimeHint::Past => TemporalQueryHint::Past,
+                    QueryTimeHint::Present => TemporalQueryHint::Present,
+                    QueryTimeHint::Ongoing => TemporalQueryHint::Ongoing,
+                    QueryTimeHint::Mixed => TemporalQueryHint::Mixed,
+                })
+                .filter(|_| self.analysis.temporal.is_some()),
+            query_routing_intent: self.analysis.query_routing_intent,
+            has_explicit_temporal: self.analysis.temporal.is_some(),
+            allowed_doc_ids: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_semantics::QueryRoutingIntent;
+
+    #[test]
+    fn count_queries_carry_count_intent() {
+        let prepared = PreparedQuery::new("How many projects did I ship?");
+        assert_eq!(
+            prepared.temporal_context().query_routing_intent,
+            Some(QueryRoutingIntent::Count)
+        );
+    }
+
+    #[test]
+    fn search_query_is_the_augmented_query() {
+        let prepared = PreparedQuery::new("what database did I pick");
+        assert_eq!(
+            prepared.search_query(),
+            prepared.analysis().augmented_query.as_str()
+        );
+    }
+
+    #[test]
+    fn context_leaves_scoping_to_the_caller() {
+        let prepared = PreparedQuery::new("anything");
+        assert!(prepared.temporal_context().allowed_doc_ids.is_none());
+    }
+}

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -1,5 +1,6 @@
 use crate::index::{DocRecord, MemoryIndex, SearchResult, TemporalQueryContext, TemporalQueryHint};
 use crate::query_expansion::normalize_for_index;
+use crate::tokenizer::{self, TokenizerMode};
 use chrono::NaiveDate;
 use serde::Serialize;
 use std::cmp::Ordering;
@@ -3496,10 +3497,8 @@ impl SegmentCorpusStats {
 }
 
 fn query_tokens(query: &str) -> HashSet<String> {
-    query
-        .split(|ch: char| !ch.is_alphanumeric())
-        .map(normalize_for_index)
-        .filter(|token| token.len() > 1)
+    tokenizer::tokenize(query, TokenizerMode::Stemmed)
+        .into_iter()
         .filter(|token| !is_routing_stopword(token))
         .collect()
 }
@@ -3863,45 +3862,7 @@ fn route_has_signal(
 }
 
 fn is_routing_stopword(token: &str) -> bool {
-    matches!(
-        token,
-        "a" | "an"
-            | "and"
-            | "are"
-            | "can"
-            | "did"
-            | "do"
-            | "doe"
-            | "for"
-            | "from"
-            | "had"
-            | "have"
-            | "how"
-            | "i"
-            | "in"
-            | "is"
-            | "it"
-            | "many"
-            | "mani"
-            | "me"
-            | "my"
-            | "of"
-            | "on"
-            | "or"
-            | "that"
-            | "the"
-            | "thi"
-            | "this"
-            | "to"
-            | "wa"
-            | "what"
-            | "when"
-            | "where"
-            | "which"
-            | "who"
-            | "with"
-            | "you"
-    )
+    tokenizer::is_stopword(token, TokenizerMode::Stemmed)
 }
 
 #[cfg(test)]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,0 +1,196 @@
+//! Shared query/document tokenization for the primary lexical/rerank path
+//! (`crate::index`) and the experimental segment-routing path
+//! (`crate::segments`).
+//!
+//! The two callers intentionally use different rules — this is not
+//! duplication to collapse into one behavior. A LongMemEval-S benchmark
+//! (500 scoped queries for the primary path, 133 multi-session queries for
+//! segment routing) showed each mode is a real, measured improvement for
+//! its own caller and a regression for the other:
+//!
+//! - Switching segment routing from `Stemmed` to `Unstemmed` cost ~5pp of
+//!   recall@5 and ~2pp of MRR on segment-routing variants.
+//! - Switching the primary path from `Unstemmed` to `Stemmed` cost
+//!   ~0.1-0.3pp across recall/MRR/NDCG.
+//!
+//! Keep both modes and pick per caller; don't unify them.
+
+use crate::query_expansion::normalize_for_index;
+use regex::Regex;
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenizerMode {
+    /// Regex-bounded terms (`[A-Za-z][A-Za-z0-9_-]{2,}`, min length 3),
+    /// lowercased, not stemmed. Used by `crate::index`'s lexical/rerank
+    /// path.
+    Unstemmed,
+    /// Terms split on non-alphanumeric boundaries (min length 2), each
+    /// stemmed with an English Porter stemmer via
+    /// [`normalize_for_index`]. Used by `crate::segments`'s routing path.
+    Stemmed,
+}
+
+/// Tokenizes `input` according to `mode`. Order matches input order and
+/// duplicates are preserved; callers that need a set should collect into
+/// one (as `crate::segments::query_tokens` does).
+pub fn tokenize(input: &str, mode: TokenizerMode) -> Vec<String> {
+    match mode {
+        TokenizerMode::Unstemmed => unstemmed_tokens(input),
+        TokenizerMode::Stemmed => stemmed_tokens(input),
+    }
+}
+
+/// True if `token` is a stopword under `mode`. `token` must already be
+/// tokenized/normalized under the same mode — the two stopword lists use
+/// different vocabularies (raw words vs. stemmed fragments) and are not
+/// interchangeable.
+pub fn is_stopword(token: &str, mode: TokenizerMode) -> bool {
+    match mode {
+        TokenizerMode::Unstemmed => unstemmed_stopwords().contains(token),
+        TokenizerMode::Stemmed => stemmed_stopwords().contains(token),
+    }
+}
+
+fn unstemmed_tokens(input: &str) -> Vec<String> {
+    static TOKEN_RE: OnceLock<Regex> = OnceLock::new();
+    let token_re =
+        TOKEN_RE.get_or_init(|| Regex::new(r"[A-Za-z][A-Za-z0-9_-]{2,}").expect("valid regex"));
+    token_re
+        .find_iter(input)
+        .map(|m| m.as_str().to_lowercase())
+        .collect()
+}
+
+fn stemmed_tokens(input: &str) -> Vec<String> {
+    input
+        .split(|ch: char| !ch.is_alphanumeric())
+        .map(normalize_for_index)
+        .filter(|token| token.len() > 1)
+        .collect()
+}
+
+fn unstemmed_stopwords() -> &'static HashSet<&'static str> {
+    static STOP: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    STOP.get_or_init(|| {
+        [
+            "how",
+            "many",
+            "much",
+            "what",
+            "which",
+            "who",
+            "when",
+            "where",
+            "why",
+            "did",
+            "does",
+            "have",
+            "has",
+            "had",
+            "been",
+            "being",
+            "was",
+            "were",
+            "are",
+            "the",
+            "and",
+            "or",
+            "for",
+            "from",
+            "with",
+            "that",
+            "this",
+            "these",
+            "those",
+            "currently",
+            "recently",
+            "past",
+            "last",
+            "next",
+            "into",
+            "onto",
+            "about",
+            "after",
+            "before",
+            "over",
+            "under",
+            "between",
+            "during",
+            "i",
+            "you",
+            "we",
+            "they",
+        ]
+        .into_iter()
+        .collect()
+    })
+}
+
+fn stemmed_stopwords() -> &'static HashSet<&'static str> {
+    static STOP: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    STOP.get_or_init(|| {
+        [
+            "a", "an", "and", "are", "can", "did", "do", "doe", "for", "from", "had", "have",
+            "how", "i", "in", "is", "it", "many", "mani", "me", "my", "of", "on", "or", "that",
+            "the", "thi", "this", "to", "wa", "what", "when", "where", "which", "who", "with",
+            "you",
+        ]
+        .into_iter()
+        .collect()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unstemmed_matches_manual_regex() {
+        let re = Regex::new(r"[A-Za-z][A-Za-z0-9_-]{2,}").unwrap();
+        let samples = [
+            "What degree did I graduate with?",
+            "How many miles did I run last week?",
+            "I cooked pasta and watched a movie.",
+        ];
+        for s in samples {
+            let expected: Vec<String> =
+                re.find_iter(s).map(|m| m.as_str().to_lowercase()).collect();
+            let actual = tokenize(s, TokenizerMode::Unstemmed);
+            assert_eq!(expected, actual, "mismatch for {s:?}");
+        }
+    }
+
+    #[test]
+    fn unstemmed_stopword_matches_original_list() {
+        for word in ["how", "many", "does", "was", "the", "and"] {
+            assert!(
+                is_stopword(word, TokenizerMode::Unstemmed),
+                "{word} should be a stopword"
+            );
+        }
+        for word in ["degree", "graduate", "miles", "pasta"] {
+            assert!(
+                !is_stopword(word, TokenizerMode::Unstemmed),
+                "{word} should not be a stopword"
+            );
+        }
+    }
+
+    #[test]
+    fn stemmed_stopword_matches_segment_router_list() {
+        for word in ["doe", "mani", "thi", "wa", "what"] {
+            assert!(
+                is_stopword(word, TokenizerMode::Stemmed),
+                "{word} should be a stopword"
+            );
+        }
+        for word in ["degre", "graduat", "mile", "pasta"] {
+            assert!(
+                !is_stopword(word, TokenizerMode::Stemmed),
+                "{word} should not be a stopword"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Prepares the `0.1.9` release. The headline change is that every entry point accepting a raw user query now gets the same analysis.

Previously the CLI analyzed queries — inferring `QueryRoutingIntent` and augmenting the query text — while the memory server's `/search` did neither, so the same question behaved differently depending on how it arrived. That preparation now lives in one place.

- **`query_plan::PreparedQuery`** — the shared query-analysis entry point. `engine.rs` drops its private `query_temporal_context` in favor of it.
- **`IndexStore::query_prepared`** — applies that preparation and scopes the search via `TemporalQueryContext::allowed_doc_ids`, resolved by the new `MemoryIndex::doc_ids_matching_filters`.
- **`MemoryService::search`** now routes through `query_prepared`.
- **`tokenizer` module** — `index.rs` and `segments.rs` each carried their own tokenizer and stopword list. Both now live behind an explicit `TokenizerMode`. The two modes are deliberate, not drift: benchmarking showed each is a measured improvement for its own caller and a regression for the other (unstemming segment routing costs ~5pp recall@5; stemming the lexical path costs ~0.1–0.3pp).
- **Deprecations** — five `MemoryIndex` query methods are deprecated with replacements, scheduled for removal in `0.2.0`. `MemoryIndex` is re-exported at the crate root and named in the README, so removing them now would be a breaking change; `0.1.9` is the migration window.
- **Release notes** for the full `v0.1.8..HEAD` range (22 commits), including the memory server, segmented index, agent integrations, session recording, and Python bindings that landed since the last release.
- **Packaging fix** — `benchmark/data/` is now ignored wholesale. Only three specific filenames were matched before, so local benchmark output was being packaged: `cargo package` for `0.1.9` pulled in 127MB of result files, taking the crate from 3.6MB to 130.2MB.

## Behavior change

`MemoryService::search` gains query-routing intent and query augmentation, so **memory server results will differ** for queries where either applies. Request and response shapes are unchanged. This does not touch the count-query branch of group aggregation, which still uses its own string-marker heuristic; reconciling the two count classifiers is deferred.

## Test plan

- [x] `cargo build --all-targets` and `cargo clippy --all-targets` clean
- [x] `cargo test --lib --bins` — 99 lib + 3 server tests passing
- [x] LongMemEval-S scoped benchmark (500 queries, global path): reproduces the pre-change aggregates **exactly** on all eight metrics — recall@5/10/20, recall_any@5/10/20, MRR, NDCG@10
- [x] Segment-scoped benchmark (133 multi-session queries): recall identical; MRR/NDCG within 0.04pp
- [x] `cargo package` verified at 3.6MB with no `benchmark/data` entries