### PR TITLE
Isolate per-project MCP roots and stop holding the index writer process-wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ cargo build --release --features claude-code,codex
 ./lint-ai --codex-install /path/to/project
 ```
 
+Each installer writes lifecycle hooks and an MCP server entry into that agent's
+own configuration, which is global, and a memory policy into the named project:
+a skill for Claude Code, a delimited block in `AGENTS.md` for Codex. The MCP
+entry carries no project root — the server resolves the project it is launched
+in — so installing for a second project does not repoint the first.
+
+```bash
+```
+
 Provider memory remains isolated:
 
 ```text

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -23,6 +23,7 @@ use crate::integrations::codex::hooks::{run_hook as run_codex_hook, CodexHookKin
 #[cfg(feature = "codex")]
 use crate::integrations::codex::{
     install_hook_settings as install_codex_hook_settings,
+    install_memory_policy as install_codex_memory_policy,
     install_user_config as install_codex_user_config, run_server as run_codex_server,
     run_status_line as run_codex_status_line, CodexServerOptions,
 };
@@ -2185,6 +2186,8 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         let settings_path = args.codex_settings.as_deref().map(Path::new);
         let written = install_codex_hook_settings(Path::new(&args.path), settings_path)?;
         println!("Wrote Codex hook settings to {}", written.display());
+        let written = install_codex_memory_policy(Path::new(&args.path))?;
+        println!("Wrote Codex memory policy to {}", written.display());
         return Ok(());
     }
 

--- a/src/integrations/claude_code/mod.rs
+++ b/src/integrations/claude_code/mod.rs
@@ -77,7 +77,8 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
         Some(path) => path.to_path_buf(),
         None => default_claude_config_path()?,
     };
-    let root = root
+    // Still canonicalized, to reject a path that does not exist before writing.
+    let _root = root
         .canonicalize()
         .with_context(|| format!("failed to canonicalize {}", root.display()))?;
     let executable = env::current_exe()
@@ -93,15 +94,19 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
         .as_object_mut()
         .context("Claude MCP server entry must be a JSON object")?;
     entry.insert("command".to_string(), json!(executable));
-    entry.insert(
-        "args".to_string(),
-        json!(["--claude-code-serve", root.to_string_lossy().into_owned()]),
-    );
+    // The MCP entry lives in the user's global config, so pinning an absolute
+    // project root here means installing for a second project silently repoints
+    // the first: the skill still tells that agent to consult memory, and it gets
+    // another project's corpus. The serve path defaults to the working directory,
+    // which the agent sets to the project it is running in.
+    entry.insert("args".to_string(), json!(["--claude-code-serve"]));
     write_claude_config(&config_path, &config)?;
     Ok(config_path)
 }
 
 pub fn install_memory_skill(root: &Path) -> Result<PathBuf> {
+    // Canonicalized, and used below: the skill must land at the real path, not
+    // through a symlink.
     let root = root
         .canonicalize()
         .with_context(|| format!("failed to canonicalize {}", root.display()))?;
@@ -852,7 +857,24 @@ mod tests {
                 .map(Value::as_str)
                 .collect::<Option<Vec<_>>>()
                 .unwrap(),
-            vec!["--claude-code-serve", root.to_string_lossy().as_ref()]
+            // No project root: the entry is global, so pinning one here would
+            // repoint every other project at whichever was installed last.
+            vec!["--claude-code-serve"]
+        );
+    }
+
+    #[test]
+    fn install_user_config_does_not_pin_a_project_root() {
+        let first = temp_path("claude-config-multi");
+        let root_a = env::current_dir().unwrap();
+        install_user_config(&root_a, Some(&first)).unwrap();
+        let after_a = read_claude_config(&first).unwrap();
+        install_user_config(&root_a.join("src"), Some(&first)).unwrap();
+        let after_b = read_claude_config(&first).unwrap();
+        // Installing for a second project must leave the first one's entry alone.
+        assert_eq!(
+            after_a.mcp_servers["lint-ai"]["args"],
+            after_b.mcp_servers["lint-ai"]["args"]
         );
     }
 

--- a/src/integrations/codex/agents_md.md
+++ b/src/integrations/codex/agents_md.md
@@ -1,0 +1,16 @@
+<!-- lint-ai:memory-policy:start -->
+## Lint-AI memory policy
+
+For requests about project history, prior decisions, architectural choices,
+earlier work, or "why" something was implemented, call the `lint-ai` MCP
+server's `search` tool before reading files or searching the repository.
+
+1. Call `search` with a concise query describing the missing context.
+2. Read the returned sources before opening files yourself.
+3. Say plainly when memory returned nothing, and only then fall back to
+   reading the repository.
+
+Recorded sessions are memory of this project, not documentation of it: a
+finding can be out of date. Check a conclusion against the code before relying
+on it, and prefer the most recent one when two disagree.
+<!-- lint-ai:memory-policy:end -->

--- a/src/integrations/codex/mod.rs
+++ b/src/integrations/codex/mod.rs
@@ -90,7 +90,8 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
         Some(path) => path.to_path_buf(),
         None => default_codex_config_path()?,
     };
-    let root = root
+    // Still canonicalized, to reject a path that does not exist before writing.
+    let _root = root
         .canonicalize()
         .with_context(|| format!("failed to canonicalize {}", root.display()))?;
     let executable = env::current_exe()
@@ -124,12 +125,11 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
         "startup_timeout_sec".to_string(),
         TomlValue::Integer(MCP_STARTUP_TIMEOUT_SECONDS),
     );
+    // Global config, so an absolute root here pins every project to whichever was
+    // installed last. The serve path defaults to the working directory.
     entry.insert(
         "args".to_string(),
-        TomlValue::Array(vec![
-            TomlValue::String("--codex-serve".to_string()),
-            TomlValue::String(root.to_string_lossy().into_owned()),
-        ]),
+        TomlValue::Array(vec![TomlValue::String("--codex-serve".to_string())]),
     );
     mcp_servers.insert("lint-ai".to_string(), TomlValue::Table(entry));
 
@@ -147,6 +147,56 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
     write_text_object(&config_path, &toml::to_string_pretty(&config)?)
         .context("failed to write Codex config")?;
     Ok(config_path)
+}
+
+/// Delimiters so the block can be found and replaced without touching the rest of
+/// a file the user also writes in.
+const POLICY_START: &str = "<!-- lint-ai:memory-policy:start -->";
+const POLICY_END: &str = "<!-- lint-ai:memory-policy:end -->";
+
+/// Writes the memory policy into the project's `AGENTS.md`, which is what Codex
+/// reads for standing instructions — the counterpart to the skill file the Claude
+/// installer writes. Without it the hooks record a project the agent is never told
+/// to consult.
+///
+/// `AGENTS.md` belongs to the user, so the block is delimited and replaced in
+/// place; everything outside it is left exactly as it was, and an existing file
+/// is never clobbered.
+pub fn install_memory_policy(root: &Path) -> Result<PathBuf> {
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", root.display()))?;
+    let path = root.join("AGENTS.md");
+    let block = include_str!("agents_md.md").trim_end();
+
+    let next = match fs::read_to_string(&path) {
+        Ok(existing) => match (existing.find(POLICY_START), existing.find(POLICY_END)) {
+            (Some(start), Some(end)) if end > start => {
+                let mut updated = String::with_capacity(existing.len());
+                updated.push_str(&existing[..start]);
+                updated.push_str(block);
+                updated.push_str(&existing[end + POLICY_END.len()..]);
+                updated
+            }
+            _ => {
+                let mut updated = existing.trim_end().to_string();
+                if !updated.is_empty() {
+                    updated.push_str("\n\n");
+                }
+                updated.push_str(block);
+                updated.push('\n');
+                updated
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => format!("{block}\n"),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", path.display()))
+        }
+    };
+
+    write_text_object(&path, &next)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(path)
 }
 
 pub fn install_hook_settings(root: &Path, settings_path: Option<&Path>) -> Result<PathBuf> {
@@ -817,6 +867,27 @@ mod tests {
     }
 
     #[test]
+    fn install_memory_policy_preserves_user_text_and_is_idempotent() {
+        let dir = std::env::temp_dir().join(format!("lint-ai-agents-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("AGENTS.md");
+        fs::write(&path, "# Mine\n\nMy own standing instructions.\n").unwrap();
+
+        install_memory_policy(&dir).unwrap();
+        let once = fs::read_to_string(&path).unwrap();
+        assert!(once.contains("My own standing instructions."));
+        assert_eq!(once.matches(POLICY_START).count(), 1);
+
+        install_memory_policy(&dir).unwrap();
+        let twice = fs::read_to_string(&path).unwrap();
+        // A second install replaces the block rather than appending another.
+        assert_eq!(twice.matches(POLICY_START).count(), 1);
+        assert!(twice.contains("My own standing instructions."));
+        assert_eq!(once, twice);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn install_user_config_merges_existing_servers() {
         let config_path = temp_path("claude-config");
         fs::write(
@@ -863,7 +934,8 @@ args = ["old"]
                 .map(TomlValue::as_str)
                 .collect::<Option<Vec<_>>>()
                 .unwrap(),
-            vec!["--codex-serve", root.to_string_lossy().as_ref()]
+            // Global entry: see install_user_config.
+            vec!["--codex-serve"]
         );
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -17,6 +17,7 @@ use crate::tier1::{
     TextRankStyleTermRanker, Tier1DocInput, YakeStyleTermRanker,
 };
 use anyhow::Result;
+use std::time::Duration;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -1601,9 +1602,17 @@ fn save_binary_core_atomic(snapshot: &MemoryIndex, path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// How long to wait for another session to finish writing before giving up.
+const WRITER_LOCK_WAIT: Duration = Duration::from_secs(10);
+const WRITER_LOCK_RETRY: Duration = Duration::from_millis(150);
+
 struct LexicalState {
     index: Index,
-    writer: IndexWriter,
+    /// Created on first write. Tantivy's writer lock is exclusive across
+    /// processes, so constructing one eagerly means a second agent session
+    /// searching the same project dies with LockBusy before it can read
+    /// anything. Readers need no lock, and many can share one index.
+    writer: Option<IndexWriter>,
     reader: IndexReader,
     doc_id_f: Field,
     content_f: Field,
@@ -1626,7 +1635,7 @@ impl LexicalState {
             Some(dir) => Self::open_or_create_on_disk(dir, &schema)?,
             None => Index::create_in_ram(schema),
         };
-        let writer = index.writer(50_000_000)?;
+        let writer = None;
         let reader = index
             .reader_builder()
             .reload_policy(ReloadPolicy::Manual)
@@ -1690,26 +1699,76 @@ impl LexicalState {
             .collect::<Vec<_>>()
             .join("\n");
 
-        self.writer
-            .delete_term(Term::from_field_text(self.doc_id_f, &record.doc_id));
-        self.writer.add_document(doc!(
-            self.doc_id_f => record.doc_id.clone(),
-            self.content_f => content_text,
-            self.headings_f => headings_text,
-            self.terms_f => terms_text,
-            self.entities_f => entities_text
+        // Field handles are Copy, so they are taken before the writer borrow.
+        let (doc_id_f, content_f, headings_f, terms_f, entities_f) = (
+            self.doc_id_f,
+            self.content_f,
+            self.headings_f,
+            self.terms_f,
+            self.entities_f,
+        );
+        let doc_id = record.doc_id.clone();
+        let writer = self.writer()?;
+        writer.delete_term(Term::from_field_text(doc_id_f, &doc_id));
+        writer.add_document(doc!(
+            doc_id_f => doc_id,
+            content_f => content_text,
+            headings_f => headings_text,
+            terms_f => terms_text,
+            entities_f => entities_text
         ))?;
         Ok(())
     }
 
     fn remove_doc(&mut self, doc_id: &str) -> Result<()> {
-        self.writer
-            .delete_term(Term::from_field_text(self.doc_id_f, doc_id));
+        let doc_id_f = self.doc_id_f;
+        self.writer()?
+            .delete_term(Term::from_field_text(doc_id_f, doc_id));
         Ok(())
     }
 
+    /// Takes the index lock, waiting briefly if another process is mid-write.
+    ///
+    /// Tantivy's writer lock is exclusive across processes, so two agent sessions
+    /// working in the same project contend for it. Holding one for the life of the
+    /// process makes that fatal for whichever starts second; taking it per write
+    /// and waiting a moment makes them take turns.
+    fn writer(&mut self) -> Result<&mut IndexWriter> {
+        if self.writer.is_none() {
+            let mut waited = Duration::ZERO;
+            loop {
+                match self.index.writer(50_000_000) {
+                    Ok(writer) => {
+                        self.writer = Some(writer);
+                        break;
+                    }
+                    Err(error) if waited < WRITER_LOCK_WAIT => {
+                        std::thread::sleep(WRITER_LOCK_RETRY);
+                        waited += WRITER_LOCK_RETRY;
+                        let _ = error;
+                    }
+                    Err(error) => {
+                        return Err(anyhow::anyhow!(
+                            "another session is writing this project's index: {error}"
+                        ))
+                    }
+                }
+            }
+        }
+        self.writer
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("index writer missing immediately after creation"))
+    }
+
     fn commit_reload(&mut self) -> Result<()> {
-        self.writer.commit()?;
+        // Nothing was written, so there is nothing to commit and no reason to
+        // have taken the lock.
+        if let Some(writer) = self.writer.as_mut() {
+            writer.commit()?;
+        }
+        // Dropping the writer releases the lock. Keeping it would hold the index
+        // against every other session in this project for as long as we run.
+        self.writer = None;
         self.reader.reload()?;
         Ok(())
     }


### PR DESCRIPTION
Two independent fixes for running lint-ai across more than one project, and for running more than one agent session against a single project.

## Stop pinning one project root in a global MCP entry

Both installers wrote the absolute project root into the agent's global MCP configuration. There is one lint-ai server entry, so installing for a second project silently repointed the first: that project keeps its skill telling the agent to consult memory first, and the server it reaches now serves a different corpus.

The serve path already defaults to the working directory — which is the project the agent is running in — so the fix is to stop writing a root at all. Both installers now emit bare `--claude-code-serve` / `--codex-serve`.

Codex also had no counterpart to the Claude memory skill, so the hooks recorded a project the agent was never told to consult, and its path argument was accepted and discarded. It now writes the same policy into the project's `AGENTS.md` as a delimited block: an existing file keeps everything outside the markers, and a second install replaces the block rather than appending another.

## Hold the index writer for a write, not for the life of the process

A second agent session in the same project died on startup with `LockBusy`: tantivy's writer lock is exclusive across processes, and the MCP server took one when it opened the index and kept it until it exited.

Two changes. The writer is created on first write rather than on open, so a session that only searches never takes the lock and any number can read at once. And it is dropped after commit rather than held, so sessions that do write take turns instead of the first one locking the rest out for as long as it runs, with a bounded wait for a writer that is momentarily busy.

Sessions in different projects never contended — separate indexes. This is the same-project case.

## Testing

- Reproduced both bugs first: installing for two projects in turn and watching the args change under the first; running two servers against one project and watching the second exit before answering anything.
- Three concurrent servers on one project now all answer, where the second used to crash.
- Full suite green on this branch: `cargo build` clean, `cargo test` passing (3 server unit tests, 6 integration tests, 3 doc-tests), including a new test that installs twice and asserts the first project's entry is unchanged.
