### PR TITLE
Integrate review indexing and document memory terminology

### DIFF
--- a/docs/integration-glossary.md
+++ b/docs/integration-glossary.md
@@ -1,0 +1,93 @@
+# Integration glossary
+
+This glossary defines the provider-neutral terms used by the Lint-AI
+integrations. Provider documentation may use different names for equivalent
+lifecycle events, but these meanings remain the same.
+
+## Core concepts
+
+**Memory** is durable, project-scoped information retained for use by later
+agent work. In Lint-AI, memory is an indexed source document derived from a
+session, note, decision, trace, or other supported corpus item. Memory is not
+the same as a provider's built-in memory and is not automatically equivalent
+to a complete transcript.
+
+**Context** is information supplied to an agent for its current turn or task.
+Retrieved memory is one possible source of context. Context is temporary from
+Lint-AI's perspective unless it is explicitly captured as memory.
+
+**Session** is one provider interaction identified by a provider session ID.
+It may contain multiple turns, messages, tool calls, lifecycle events, and
+subagent activity. A replay is a new session that references an earlier
+session; it is not a continuation of the original archive.
+
+**Message** is a conversational input or output within a session, normally
+associated with a role such as `user` or `assistant`. A message is content,
+not the whole session and not necessarily a complete lifecycle event.
+
+**Event** is an observed provider lifecycle or activity record, such as a
+prompt submission, tool call, tool result, compaction, or stop notification.
+Events are the units captured by session recording. A recorded event does not
+become durable memory automatically.
+
+## Retrieval and capture
+
+**Recall** is the act of finding relevant indexed memory or source material
+for a query. It is a retrieval operation, not a storage operation. The CLI
+`--recall` mode and the integration hook/MCP search paths perform recall.
+
+**Retrieval** is the broader process of querying, ranking, and selecting
+relevant records. Recall names the user-visible result; retrieval describes
+the implementation flow that produces it.
+
+**Injection** is returning selected retrieved material to the provider as
+additional context for the current turn. Injection is bounded and does not
+write the returned text back into memory by itself.
+
+**Capture** is observing provider input or lifecycle data, normalizing it,
+redacting sensitive content, and persisting a bounded record. Capture may
+produce a session archive or a durable memory record depending on the path.
+
+**Session recording** is capture into an append-only, provider-specific event
+archive. Recording is independent from memory retrieval and injection; it can
+run in `capture-only` mode.
+
+**Memory promotion** is the explicit conversion of selected recorded session
+material into durable, searchable memory. It is distinct from recording so
+that every event does not become long-term memory.
+
+## Integration terms
+
+**Provider** is the agent client being integrated, such as Claude Code, Codex,
+Gemini CLI, or AGY. Provider-specific adapters translate that client's hook
+payloads and transcript format into the shared Lint-AI model.
+
+**Lifecycle hook** is a provider callback at a session or activity boundary.
+Hooks can trigger recall, injection, capture, or status handling. A hook is
+not itself a memory record.
+
+**MCP** is the explicit tool interface exposed by Lint-AI to the provider.
+MCP tools let the client or model request operations such as search, status,
+and session recording control. MCP does not capture conversations
+automatically.
+
+**Memory store** is the project-local persistent index containing searchable
+memory records. Provider stores remain isolated because their payloads and
+provenance differ, even though they share the same indexing implementation.
+
+**Session archive** is the provider-specific append-only record of captured
+events. It is an audit or evaluation artifact, not automatically a memory
+store.
+
+**Native memory** is memory maintained by the provider itself. It is separate
+from Lint-AI memory and may be enabled, disabled, or compared independently.
+
+The usual flow is:
+
+```text
+provider event -> hook -> capture -> session archive
+                         |
+                         +-> optional memory promotion -> memory store
+
+current prompt -> recall/retrieval -> bounded context injection -> provider
+```

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -26,7 +26,8 @@ const MAX_CONCURRENT_CONNECTIONS: usize = 128;
 #[derive(Debug, Parser)]
 #[command(
     name = "lint-ai-server",
-    about = "Memory Add/Search server backed by Lint-AI"
+    about = "Memory Add/Search server backed by Lint-AI",
+    version = env!("CARGO_PKG_VERSION")
 )]
 struct Args {
     #[arg(long, default_value = "127.0.0.1:8080")]
@@ -209,7 +210,11 @@ fn handle_connection(
         }
     }
     if method == "GET" && path == "/health" {
-        return write_json(&mut stream, 200, &serde_json::json!({"status": "ok"}));
+        return write_json(
+            &mut stream,
+            200,
+            &serde_json::json!({"status": "ok", "version": env!("CARGO_PKG_VERSION")}),
+        );
     }
     if let Some(expected) = server_token {
         let supplied = authorization.as_deref().unwrap_or("");

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -48,7 +48,9 @@ fn main() -> Result<()> {
             .map(|token| token.trim().to_string())
             .filter(|token| !token.is_empty());
     }
-    if args.server_token.is_none() && !args.allow_unauthenticated && binds_beyond_loopback(&args.bind)?
+    if args.server_token.is_none()
+        && !args.allow_unauthenticated
+        && binds_beyond_loopback(&args.bind)?
     {
         anyhow::bail!(
             "refusing to serve {} without a token: pass --server-token, set SERVER_TOKEN, \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,7 +94,7 @@ pub enum IndexInspectView {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "lint-ai")]
+#[command(name = "lint-ai", version = env!("CARGO_PKG_VERSION"))]
 /// CLI arguments for the lint-ai binary.
 pub struct Args {
     #[arg(default_value = ".")]
@@ -159,6 +159,10 @@ pub struct Args {
     pub config: Option<String>,
     #[arg(long)]
     pub analyze: bool,
+    /// Run the default lint checks with the project search index prepared.
+    /// The no-option invocation uses this same review flow by default.
+    #[arg(long)]
+    pub review: bool,
     #[arg(long, default_value_t = 5_000_000)]
     pub max_bytes: usize,
     #[arg(long, default_value_t = 50_000)]
@@ -321,5 +325,13 @@ mod tests {
             args.inspect_view,
             IndexInspectView::SourceDocuments
         ));
+    }
+
+    #[test]
+    fn parses_review_flag() {
+        let args = Args::try_parse_from(["lint-ai", "--review", "docs"]).unwrap();
+
+        assert!(args.review);
+        assert_eq!(args.path, "docs");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -253,6 +253,9 @@ pub struct Args {
     /// and print chunk-level hits as JSON. Reads no stdin and starts no server.
     #[arg(long)]
     pub recall: Option<String>,
+    /// Keep the project recall indexes open and answer newline-delimited JSON requests.
+    #[arg(long)]
+    pub recall_server: Option<String>,
     #[arg(long)]
     pub inspect_index: Option<String>,
     #[arg(long)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2004,6 +2004,30 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         return inspect_index_store(Path::new(index_path), args.inspect_view);
     }
 
+    if let Some(root) = args.recall_server.as_deref() {
+        #[cfg(any(feature = "claude-code", feature = "codex"))]
+        {
+            let cfg = load_config(
+                args.config.as_deref(),
+                root,
+                args.strict_config,
+                args.max_config_bytes,
+            ).map_err(|err| anyhow::anyhow!(err))?;
+            return crate::integrations::recall::run_recall_server(
+                Path::new(root),
+                &cfg.ignore_paths,
+                args.max_bytes,
+                args.max_files,
+                args.max_depth,
+                args.max_total_bytes,
+            );
+        }
+        #[cfg(not(any(feature = "claude-code", feature = "codex")))]
+        {
+            anyhow::bail!("recall server requires the Claude Code or Codex feature");
+        }
+    }
+
     if args.recall.is_some() {
         #[cfg(any(
             feature = "claude-code",

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2012,7 +2012,8 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
                 root,
                 args.strict_config,
                 args.max_config_bytes,
-            ).map_err(|err| anyhow::anyhow!(err))?;
+            )
+            .map_err(|err| anyhow::anyhow!(err))?;
             return crate::integrations::recall::run_recall_server(
                 Path::new(root),
                 &cfg.ignore_paths,
@@ -2731,6 +2732,51 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
         );
         return Ok(());
     }
+
+    // The default invocation and --review share the same project review flow.
+    // The graph above remains the source of truth for the existing lint rules;
+    // preparing the query index here makes the same corpus immediately
+    // available to review consumers without changing the report semantics.
+    let cache_settings = CacheSettings {
+        root_path: &args.path,
+        ner_provider: &args.tier1_ner_provider,
+        term_ranker: &args.tier1_term_ranker,
+        spacy_model: &args.spacy_model,
+        chunk_strategy: &args.chunk_strategy,
+        chunk_lines: args.chunk_lines,
+        chunk_overlap: args.chunk_overlap,
+        chunk_target_tokens: args.chunk_target_tokens,
+        chunk_max_tokens: args.chunk_max_tokens,
+    };
+    let corpus_fingerprint = compute_corpus_fingerprint(
+        &args.path,
+        args.max_files,
+        args.max_depth,
+        args.max_total_bytes,
+    );
+    let lexical_dir = query_cache_lexical_dir(&cache_settings);
+    let _review_index = if let Some(cached) =
+        load_cached_query_index(&cache_settings, &corpus_fingerprint)
+    {
+        cached
+    } else {
+        let built = build_memory_index(
+            &graph,
+            &args.tier1_ner_provider,
+            &args.spacy_model,
+            &args.tier1_term_ranker,
+            &args.chunk_strategy,
+            args.chunk_lines,
+            args.chunk_overlap,
+            args.chunk_target_tokens,
+            args.chunk_max_tokens,
+            Some(&lexical_dir),
+        )?;
+        if let Err(err) = save_cached_query_index(&cache_settings, &corpus_fingerprint, &built) {
+            eprintln!("warning: unable to persist review search index: {}", err);
+        }
+        built
+    };
     let mut report = Report::new();
 
     check_orphans(&graph, &mut report);

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,8 +2,8 @@ use crate::ids::stable_chunk_id;
 use crate::query_expansion::{expand_query_terms, normalize_for_index};
 use crate::query_semantics::QueryRoutingIntent;
 use crate::temporal::{parse_temporal_date, resolve_temporal_target};
-use crate::tokenizer::{self, TokenizerMode};
 use crate::tier1::{RankedTerm, Tier1Entity};
+use crate::tokenizer::{self, TokenizerMode};
 use anyhow::Result;
 use chrono::{DateTime, NaiveDate, Utc};
 use deunicode::deunicode;
@@ -3355,10 +3355,7 @@ fn build_ngrams(tokens: &[String], n: usize) -> Vec<Vec<String>> {
     if n == 0 || tokens.len() < n {
         return Vec::new();
     }
-    tokens
-        .windows(n)
-        .map(|win| win.to_vec())
-        .collect()
+    tokens.windows(n).map(|win| win.to_vec()).collect()
 }
 
 fn lcs_ratio(query_tokens: &[String], candidate_tokens: &[String]) -> f32 {

--- a/src/integrations/README.md
+++ b/src/integrations/README.md
@@ -3,6 +3,12 @@
 This directory contains the Claude Code and Codex integrations, plus the
 shared MCP infrastructure used by both clients.
 
+The provider-neutral vocabulary used throughout this documentation is defined
+in [the integration glossary](../../docs/integration-glossary.md). In
+particular, `memory`, `context`, `session`, `message`, `event`, and `recall`
+are distinct concepts; recording a session does not automatically create
+durable memory.
+
 Lint-AI has two complementary integration paths:
 
 1. **Lifecycle hooks** retrieve and capture session memory automatically.

--- a/src/integrations/mcp_index.rs
+++ b/src/integrations/mcp_index.rs
@@ -56,16 +56,18 @@ pub fn open_persistent_store(
         store.refresh()?;
         write_index_state(&index_root, state.as_ref())?;
     }
-    sync_memory_documents(&root.join(".lint-ai").join(memory_name), &mut store)?;
-    store.refresh()?;
+    if sync_memory_documents(&root.join(".lint-ai").join(memory_name), &mut store)? {
+        store.refresh()?;
+    }
     Ok(store)
 }
 
-pub fn sync_memory_documents(memory_root: &Path, target: &mut IndexStore) -> Result<()> {
+pub fn sync_memory_documents(memory_root: &Path, target: &mut IndexStore) -> Result<bool> {
     if !memory_root.exists() {
-        return Ok(());
+        return Ok(false);
     }
     let memory = IndexStore::at_path(memory_root, segmented_store_options())?;
+    let mut changed = false;
     for document in memory.source_documents() {
         let unchanged = target
             .source_document_by_id(&document.doc_id)
@@ -81,21 +83,29 @@ pub fn sync_memory_documents(memory_root: &Path, target: &mut IndexStore) -> Res
             .unwrap_or(false);
         if !unchanged {
             target.upsert(document.clone());
+            changed = true;
         }
     }
-    Ok(())
+    Ok(changed)
 }
 
 fn workspace_state(root: &Path, ignore_paths: &[String]) -> Option<Value> {
-    let revision = git_output(root, &["rev-parse", "HEAD"])?;
-    let status = git_output(root, &["status", "--porcelain=v1", "--untracked-files=all"])?;
-    let status = status
-        .lines()
-        .filter(|line| !line.contains(".lint-ai/"))
-        .collect::<Vec<_>>()
-        .join("\n");
     let mut ignore_paths = ignore_paths.to_vec();
     ignore_paths.sort();
+    let revision = git_output(root, &["rev-parse", "HEAD"]);
+    let status = git_output(root, &["status", "--porcelain=v1", "--untracked-files=all"])
+        .map(|status| {
+            status
+                .lines()
+                .filter(|line| !line.contains(".lint-ai/"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        });
+
+    // A configured search root may be a plain directory containing several
+    // repositories (for example ~/sources). It still needs a stable index state;
+    // treating a missing Git revision as "unknown" caused a full rebuild on every
+    // query. Non-Git roots are refreshed explicitly by setup/reindex instead.
     Some(json!({ "revision": revision, "status": status, "ignore_paths": ignore_paths }))
 }
 

--- a/src/integrations/recall.rs
+++ b/src/integrations/recall.rs
@@ -9,8 +9,8 @@ use crate::adapters::{
     apply_ignore_paths, build_project_graph, graph_to_source_documents, AdapterInput,
 };
 use crate::index::{DocRecord, SearchResult, SectionChunk};
-use crate::integrations::mcp_index::open_persistent_store;
 use crate::integrations::mcp_index;
+use crate::integrations::mcp_index::open_persistent_store;
 use crate::pipeline::IndexStore;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -188,8 +188,12 @@ struct RecallServerRequest {
     source: String,
 }
 
-fn default_result_count() -> usize { 20 }
-fn default_source() -> String { "documents".to_string() }
+fn default_result_count() -> usize {
+    20
+}
+fn default_source() -> String {
+    "documents".to_string()
+}
 
 /// Open each provider memory index where it already lives. These stores remain
 /// project-scoped; the desktop worker never creates a consolidated copy.
@@ -201,14 +205,20 @@ fn open_memory_stores(root: &Path, provider: &str) -> Result<Vec<IndexStore>> {
         .into_iter()
         .filter_entry(|entry| {
             let name = entry.file_name().to_string_lossy();
-            !matches!(name.as_ref(), ".git" | "node_modules" | "target" | "dist" | "build" | "vendor")
+            !matches!(
+                name.as_ref(),
+                ".git" | "node_modules" | "target" | "dist" | "build" | "vendor"
+            )
         })
         .filter_map(|entry| entry.ok())
     {
         if !entry.file_type().is_dir() || entry.file_name().to_string_lossy() != memory_name {
             continue;
         }
-        stores.push(IndexStore::at_path(entry.path(), mcp_index::segmented_store_options())?);
+        stores.push(IndexStore::at_path(
+            entry.path(),
+            mcp_index::segmented_store_options(),
+        )?);
     }
     Ok(stores)
 }
@@ -227,19 +237,29 @@ pub fn run_recall_server(
     // are deliberately lazy: opening them here used to delay every first boot,
     // even when the user only searched the configured folder's files.
     let document_store = {
-        let input = AdapterInput { root, max_bytes, max_files, max_depth, max_total_bytes };
+        let input = AdapterInput {
+            root,
+            max_bytes,
+            max_files,
+            max_depth,
+            max_total_bytes,
+        };
         let ignores = ignore_paths.to_vec();
-        open_persistent_store(root, "desktop-document-index", "desktop-empty-memory", &ignores, || {
-            let graph = build_project_graph(&input)?;
-            let graph = apply_ignore_paths(graph, &ignores);
-            Ok(graph_to_source_documents(&graph))
-        })?
+        open_persistent_store(
+            root,
+            "desktop-document-index",
+            "desktop-empty-memory",
+            &ignores,
+            || {
+                let graph = build_project_graph(&input)?;
+                let graph = apply_ignore_paths(graph, &ignores);
+                Ok(graph_to_source_documents(&graph))
+            },
+        )?
     };
     let mut document_store = document_store;
-    let mut memory_stores: HashMap<String, Option<Vec<IndexStore>>> = HashMap::from([
-        ("claude".to_string(), None),
-        ("codex".to_string(), None),
-    ]);
+    let mut memory_stores: HashMap<String, Option<Vec<IndexStore>>> =
+        HashMap::from([("claude".to_string(), None), ("codex".to_string(), None)]);
 
     let stdout = io::stdout();
     let mut output = stdout.lock();
@@ -248,7 +268,9 @@ pub fn run_recall_server(
 
     for line in io::stdin().lock().lines() {
         let line = line?;
-        if line.trim().is_empty() { continue; }
+        if line.trim().is_empty() {
+            continue;
+        }
         let request: RecallServerRequest = serde_json::from_str(&line)?;
         let source = match request.source.as_str() {
             "claude" => "claude",
@@ -260,17 +282,23 @@ pub fn run_recall_server(
         if source == "documents" {
             let results = document_store.query(&request.query, request.result_count)?;
             hits.extend(results.iter().filter_map(|result| {
-                document_store.record_by_id(&result.doc_id).map(|record| hit_from(result, record, &request.query))
+                document_store
+                    .record_by_id(&result.doc_id)
+                    .map(|record| hit_from(result, record, &request.query))
             }));
         } else {
-            let stores = memory_stores.get_mut(source).context("recall source store is unavailable")?;
+            let stores = memory_stores
+                .get_mut(source)
+                .context("recall source store is unavailable")?;
             if stores.is_none() {
                 *stores = Some(open_memory_stores(root, source)?);
             }
             for store in stores.as_mut().unwrap() {
                 let results = store.query(&request.query, request.result_count)?;
                 hits.extend(results.iter().filter_map(|result| {
-                    store.record_by_id(&result.doc_id).map(|record| hit_from(result, record, &request.query))
+                    store
+                        .record_by_id(&result.doc_id)
+                        .map(|record| hit_from(result, record, &request.query))
                 }));
             }
         }
@@ -665,7 +693,10 @@ mod tests {
         ];
 
         for (provider, index_name, memory_name) in providers {
-            let root = std::env::temp_dir().join(format!(
+            let temp_base = std::env::temp_dir()
+                .canonicalize()
+                .unwrap_or_else(|_| std::env::temp_dir());
+            let root = temp_base.join(format!(
                 "lint-ai-recall-{provider}-{}",
                 SystemTime::now()
                     .duration_since(UNIX_EPOCH)

--- a/src/integrations/recall.rs
+++ b/src/integrations/recall.rs
@@ -9,12 +9,16 @@ use crate::adapters::{
     apply_ignore_paths, build_project_graph, graph_to_source_documents, AdapterInput,
 };
 use crate::index::{DocRecord, SearchResult, SectionChunk};
+use crate::integrations::mcp_index::open_persistent_store;
 use crate::integrations::mcp_index;
+use crate::pipeline::IndexStore;
 use anyhow::{Context, Result};
-use serde::Serialize;
-use std::collections::HashSet;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::io::{self, BufRead, Write};
 use std::path::Path;
 use std::time::Instant;
+use walkdir::WalkDir;
 
 /// The project index is shared with the MCP servers rather than kept under a
 /// name of its own. Both paths build it from the same graph with the same
@@ -173,6 +177,115 @@ pub fn recall(options: &RecallOptions<'_>) -> Result<RecallOutput> {
         elapsed_ms: started.elapsed().as_millis(),
         results: hits,
     })
+}
+
+#[derive(Debug, Deserialize)]
+struct RecallServerRequest {
+    query: String,
+    #[serde(default = "default_result_count")]
+    result_count: usize,
+    #[serde(default = "default_source", alias = "session_provider")]
+    source: String,
+}
+
+fn default_result_count() -> usize { 20 }
+fn default_source() -> String { "documents".to_string() }
+
+/// Open each provider memory index where it already lives. These stores remain
+/// project-scoped; the desktop worker never creates a consolidated copy.
+fn open_memory_stores(root: &Path, provider: &str) -> Result<Vec<IndexStore>> {
+    let memory_name = format!("{provider}-memory");
+    let mut stores = Vec::new();
+    for entry in WalkDir::new(root)
+        .max_depth(5)
+        .into_iter()
+        .filter_entry(|entry| {
+            let name = entry.file_name().to_string_lossy();
+            !matches!(name.as_ref(), ".git" | "node_modules" | "target" | "dist" | "build" | "vendor")
+        })
+        .filter_map(|entry| entry.ok())
+    {
+        if !entry.file_type().is_dir() || entry.file_name().to_string_lossy() != memory_name {
+            continue;
+        }
+        stores.push(IndexStore::at_path(entry.path(), mcp_index::segmented_store_options())?);
+    }
+    Ok(stores)
+}
+
+/// Long-lived project recall. The expensive persistent stores are opened once;
+/// each subsequent request only runs the in-memory query and response mapping.
+pub fn run_recall_server(
+    root: &Path,
+    ignore_paths: &[String],
+    max_bytes: usize,
+    max_files: usize,
+    max_depth: usize,
+    max_total_bytes: usize,
+) -> Result<()> {
+    // Documents are needed by the sidebar immediately. Provider memory stores
+    // are deliberately lazy: opening them here used to delay every first boot,
+    // even when the user only searched the configured folder's files.
+    let document_store = {
+        let input = AdapterInput { root, max_bytes, max_files, max_depth, max_total_bytes };
+        let ignores = ignore_paths.to_vec();
+        open_persistent_store(root, "desktop-document-index", "desktop-empty-memory", &ignores, || {
+            let graph = build_project_graph(&input)?;
+            let graph = apply_ignore_paths(graph, &ignores);
+            Ok(graph_to_source_documents(&graph))
+        })?
+    };
+    let mut document_store = document_store;
+    let mut memory_stores: HashMap<String, Option<Vec<IndexStore>>> = HashMap::from([
+        ("claude".to_string(), None),
+        ("codex".to_string(), None),
+    ]);
+
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+    writeln!(output, "{{\"ready\":true}}")?;
+    output.flush()?;
+
+    for line in io::stdin().lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() { continue; }
+        let request: RecallServerRequest = serde_json::from_str(&line)?;
+        let source = match request.source.as_str() {
+            "claude" => "claude",
+            "codex" => "codex",
+            _ => "documents",
+        };
+        let started = Instant::now();
+        let mut hits = Vec::new();
+        if source == "documents" {
+            let results = document_store.query(&request.query, request.result_count)?;
+            hits.extend(results.iter().filter_map(|result| {
+                document_store.record_by_id(&result.doc_id).map(|record| hit_from(result, record, &request.query))
+            }));
+        } else {
+            let stores = memory_stores.get_mut(source).context("recall source store is unavailable")?;
+            if stores.is_none() {
+                *stores = Some(open_memory_stores(root, source)?);
+            }
+            for store in stores.as_mut().unwrap() {
+                let results = store.query(&request.query, request.result_count)?;
+                hits.extend(results.iter().filter_map(|result| {
+                    store.record_by_id(&result.doc_id).map(|record| hit_from(result, record, &request.query))
+                }));
+            }
+        }
+        hits.sort_by(|left, right| right.score.total_cmp(&left.score));
+        hits.truncate(request.result_count);
+        let response = RecallOutput {
+            query: request.query,
+            root: root.to_string_lossy().to_string(),
+            elapsed_ms: started.elapsed().as_millis(),
+            results: hits,
+        };
+        writeln!(output, "{}", serde_json::to_string(&response)?)?;
+        output.flush()?;
+    }
+    Ok(())
 }
 
 fn hit_from(result: &SearchResult, record: &DocRecord, query: &str) -> RecallHit {

--- a/src/integrations/session_recording.rs
+++ b/src/integrations/session_recording.rs
@@ -1017,7 +1017,19 @@ pub(crate) fn contains_credential_material(value: &str) -> bool {
             character.is_whitespace()
                 || matches!(
                     character,
-                    '"' | '\'' | ',' | ';' | '=' | ':' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>'
+                    '"' | '\''
+                        | ','
+                        | ';'
+                        | '='
+                        | ':'
+                        | '('
+                        | ')'
+                        | '['
+                        | ']'
+                        | '{'
+                        | '}'
+                        | '<'
+                        | '>'
                 )
         })
         .any(|token| {

--- a/src/query_semantics.rs
+++ b/src/query_semantics.rs
@@ -724,10 +724,7 @@ fn heuristic_pos_tags(query: &str) -> Vec<POSTag> {
         } else if word
             .chars()
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
-            || word
-                .chars()
-                .next()
-                .is_some_and(|c| c.is_ascii_uppercase())
+            || word.chars().next().is_some_and(|c| c.is_ascii_uppercase())
         {
             "NNP"
         } else if lower.ends_with('s') && lower.len() > 3 {
@@ -778,10 +775,7 @@ fn heuristic_entities(query: &str) -> Vec<QuerySpan> {
             && (token
                 .chars()
                 .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
-                || token
-                    .chars()
-                    .next()
-                    .is_some_and(|c| c.is_ascii_uppercase()));
+                || token.chars().next().is_some_and(|c| c.is_ascii_uppercase()));
         if looks_like_entity {
             current.push(token.to_string());
         } else {

--- a/src/tier1.rs
+++ b/src/tier1.rs
@@ -446,10 +446,7 @@ impl ImportantTermRanker for YakeStyleTermRanker {
             *freq.entry(t.clone()).or_insert(0) += 1;
             first_pos.entry(t.clone()).or_insert(i);
         }
-        for sent in doc
-            .content
-            .split(['.', '!', '?'])
-        {
+        for sent in doc.content.split(['.', '!', '?']) {
             let s_tokens = tokenize_words(sent);
             let unique: HashSet<String> = s_tokens.into_iter().collect();
             for t in unique {


### PR DESCRIPTION
## Summary

- Prepare or load the project query index during the default review flow and retain existing lint-report semantics.
- Add CLI and server version reporting for installed integration diagnostics.
- Keep recall-store initialization lazy and improve recall integration formatting and temporary-path handling.
- Add a provider-neutral integration glossary covering memory, context, sessions, messages, events, recall, retrieval, injection, capture, recording, promotion, MCP, and native memory.
- Link the glossary from the shared integration documentation.

## Validation

- 
running 102 tests
test aggregation::tests::classifies_count_and_sum_intents ... ok
test claim_extractor::tests::conservative_extractor_uses_existing_claims_and_chunk_signals ... ok
test aggregation::tests::normalizes_number_words ... ok
test config::tests::normalize_list_trims_and_lowercases ... ok
test engine::tests::normalize_heading_rules ... ok
test engine::tests::common_prefix ... ok
test graph::tests::link_target_concept_parsing ... ok
test graph::tests::normalize_concept_basic ... ok
test graph::tests::parse_frontmatter_metadata ... ok
test index::tests::timestamped_chunk_detects_chunk_level_temporal_anchor ... ok
test index::tests::normalize_temporal_bounds_orders_reversed_ranges_and_preserves_same_day ... ok
test cli::tests::parses_review_flag ... ok
test cli::tests::parses_index_inspection_view ... ok
test cli::tests::parses_recall_query_and_result_count ... ok
test index::tests::text_overlap_prefers_matching_candidate ... ok
test pipeline::tests::chunk_ids_are_stable_for_same_input ... ok
test aggregation::tests::builds_count_aggregation ... ok
test adapters::tests::ignore_paths_drop_vendored_documents_and_their_tier0_records ... ok
test pipeline::tests::index_store_does_not_delete_invalid_lexical_directory ... ok
test corpus_graph::tests::from_bundle_builds_documents_symbols_and_usage ... ok
test pipeline::tests::index_store_rejects_metadata_schema_mismatch ... ok
test pipeline::tests::chunk_lifecycle_is_removed_when_doc_is_removed ... ok
test pipeline::tests::index_store_publishes_single_snapshot_by_default ... ok
test pipeline::tests::chunk_lifecycle_increments_version_and_tracks_latest ... ok
test pipeline::tests::refresh_is_idempotent_when_no_documents_change ... ok
test pipeline::tests::resolve_store_paths_under_corpus_root ... ok
test pipeline::tests::section_chunks_inherit_parent_timestamp_and_document_lifecycle_is_derived ... ok
test pipeline::tests::index_store_new_falls_back_to_in_memory_when_corpus_root_is_missing ... ok
test query_expansion::tests::expanded_lexical_subset_covers_common_search_terms ... ok
test query_expansion::tests::expansion_caps_and_dedups ... ok
test query_expansion::tests::install_expands_from_generated_subset ... ok
test query_expansion::tests::normalize_basic ... ok
test query_expansion::tests::symmetric_relations_expand_back_to_source_terms ... ok
test pipeline::tests::index_store_new_falls_back_to_in_memory_on_invalid_explicit_root ... ok
test pipeline::tests::index_store_remove_deletes_lexical_doc ... ok
test pipeline::tests::build_memory_index_works_with_defaults ... ok
test memory_api::tests::search_cannot_cross_user_boundaries ... ok
test pipeline::tests::query_results_diversify_by_group_id ... ok
test memory_api::tests::add_is_immediately_searchable ... ok
test query_plan::tests::context_leaves_scoping_to_the_caller ... ok
test pipeline::tests::index_store_publishes_and_queries_segmented_snapshot ... ok
test query_semantics::tests::classifies_quantity_intent ... ok
test query_semantics::tests::augments_query_with_terms ... ok
test review::tests::review_packet_new_initializes_empty_lists ... ok
test review::tests::review_usage_summary_copies_nodes_and_edges ... ok
test review::tests::summary_conversions_preserve_source_fields ... ok
test query_plan::tests::count_queries_carry_count_intent ... ok
test query_plan::tests::search_query_is_the_augmented_query ... ok
test query_semantics::tests::extracts_temporal_phrase ... ok
test query_semantics::tests::classifies_query_routing_intent ... ok
test pipeline::tests::index_store_query_uses_incremental_lexical_updates ... ok
test pipeline::tests::artifact_index_upsert_remove_and_query ... ok
test segments::tests::kl_router_prefers_closest_segment_distribution ... ok
test segments::tests::adaptive_segment_enrichment_expands_when_query_coverage_is_low ... ok
test segments::tests::coverage_local_router_prefers_rare_term_coverage ... ok
test segments::tests::route_aware_rerank_prefers_new_evidence_coverage ... ok
test segments::tests::all_segment_query_matches_global_memory_index_on_asymmetric_corpus ... ok
test segments::tests::diagnostics_report_query_coverage_across_more_segments ... ok
test segments::tests::connected_segment_enrichment_swaps_in_explicitly_related_session ... ok
test segments::tests::local_memory_router_uses_rolling_content_window ... ok
test pipeline::tests::segmented_index_store_rebuilds_segments_after_upsert ... ok
test segments::tests::session_aggregation_combines_segment_evidence_by_group ... ok
test rules::cross_refs::tests::surface_forms_variants ... ok
test segments::tests::missing_coverage_recovery_replaces_weak_segment ... ok
test segments::tests::local_router_prefers_segment_specific_differentiators ... ok
test segments::tests::routes_and_queries_one_group_segment ... ok
test segments::tests::segmented_memory_index_returns_diagnostics ... ok
test segments::tests::typed_evidence_score_requires_explicit_multi_bucket_match ... ok
test source::tests::source_document_round_trips_through_json ... ok
test source::tests::with_stable_doc_id_is_deterministic_for_same_source ... ok
test source::tests::with_stable_doc_id_sets_doc_length_from_content ... ok
test segments::tests::segment_enriched_query_uses_each_selected_segments_local_context ... ok
test symbols::tests::lookup_by_doc_and_attribute_return_matching_records ... ok
test symbols::tests::lookup_by_name_matches_exact_and_normalized_forms ... ok
test temporal::tests::augments_future_phrase ... ok
test temporal::tests::augments_last_weekday ... ok
test temporal::tests::augments_relative_ago_phrase ... ok
test temporal::tests::augments_weekday_prefixes ... ok
test segments::tests::segmented_query_passes_temporal_allowed_doc_ids_to_inner_indexes ... ok
test temporal::tests::augments_weekend_phrase ... ok
test segments::tests::segment_enriched_query_reports_temporal_local_context ... ok
test temporal_fact::tests::as_of_filters_by_validity_window ... ok
test segments::tests::sparse_router_marks_empty_query_terms_as_fallback ... ok
test temporal_fact::tests::store_versions_conflicting_facts_without_hardcoded_patterns ... ok
test temporal::tests::resolves_relative_temporal_target ... ok
test temporal_fact::tests::timeline_window_and_adjacent_pairs_are_ordered ... ok
test tokenizer::tests::stemmed_stopword_matches_segment_router_list ... ok
test tokenizer::tests::unstemmed_stopword_matches_original_list ... ok
test usage::tests::lookup_by_node_is_bidirectional ... ok
test usage::tests::summary_for_symbol_counts_edges_and_connected_nodes ... ok
test tokenizer::tests::unstemmed_matches_manual_regex ... ok
test segments::tests::queries_top_n_segments_and_merges_results ... ok
test segments::tests::all_segment_query_reconstructs_global_index_when_missing ... ok
test symbols::tests::corpus_index_from_bundle_preserves_documents_and_symbols ... ok
test segments::tests::sparse_router_does_not_query_zero_signal_padding_segments ... ok
test segments::tests::sparse_router_reports_no_signal_without_querying_lexicographic_first_segment ... ok
test segments::tests::team_coverage_router_prefers_complementary_segments ... ok
test segments::tests::temporal_path_enrichment_expands_to_nearby_before_segment ... ok
test pipeline::tests::index_store_for_corpus_writes_metadata ... ok
test pipeline::tests::index_store_for_corpus_uses_corpus_local_lexical_dir ... ok
test pipeline::tests::index_store_persists_and_reloads_semantic_state ... ok
test pipeline::tests::index_store_with_lexical_dir_persists_queries_across_instances ... ok

test result: ok. 102 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test tests::loopback_binds_do_not_require_a_token ... ok
test tests::token_accepts_the_documented_schemes ... ok
test tests::header_lines_are_bounded ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 6 tests
test allowlist_limits_crossrefs ... ok
test analyze_suggests_config ... ok
test lint_reports_orphans_and_missing_links ... ok
test ignore_related_section_for_crossrefs ... ok
test query_baseline_still_works_without_semantic_match ... ok
test semantic_expansion_improves_recall_for_synonyms ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s — 111 tests passed.
-  — passed.

Generated local artifact directories were intentionally excluded from the branch.