### PR TITLE
feat: add provider memory guidance and recency evaluation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,11 @@ experimental = []
 name = "segment_scoped_benchmark"
 path = "src/bin/segment_scoped_benchmark.rs"
 required-features = ["experimental"]
+
+[[bin]]
+name = "recency_benchmark"
+path = "src/bin/recency_benchmark.rs"
+
+[[bin]]
+name = "project_memory_recency_benchmark"
+path = "src/bin/project_memory_recency_benchmark.rs"

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ cargo build --release --features claude-code,codex
 
 Each installer writes lifecycle hooks and an MCP server entry into that agent's
 own configuration, which is global, and a memory policy into the named project:
-a skill for Claude Code, a delimited block in `AGENTS.md` for Codex. The MCP
+a project skill for Claude Code and AGY, plus a delimited block in `AGENTS.md` for Codex. The MCP
 entry carries no project root — the server resolves the project it is launched
 in — so installing for a second project does not repoint the first.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,6 +4,33 @@ This directory holds the retrieval benchmarks for `lint-ai`, including
 haystack-style corpora, LongMemEval-S runs, and agent integration performance
 scaffolds.
 
+## Conversation Recency Benchmark
+
+Run the controlled end-to-end freshness evaluation with:
+
+```bash
+cargo run --release --bin recency_benchmark
+```
+
+The benchmark creates identical fresh (0–30 days), warm (31–90 days), and
+cold (91+ days) conversation memories for five topics. It reports whether the
+fresh memory is ranked first or within the top three, its mean rank, the
+recency score contribution, and the freshness distribution of top-1 results.
+This is intended as a deterministic regression check for ranking behavior and
+does not require external datasets or model downloads.
+
+To evaluate the real persisted Lint-AI project memory corpus instead:
+
+```bash
+cargo run --bin project_memory_recency_benchmark -- \
+  --records .lint-ai/codex-memory/semantic/records.json
+```
+
+This reports the corpus freshness distribution and the freshness distribution
+of the top-1 and top-5 results for representative project-memory queries. The
+real corpus has no gold answer labels, so this measures freshness behavior and
+does not claim semantic answer accuracy.
+
 Benchmark subdirectories:
 
 - `claude_code/`: Claude Code A/B scenarios and parser scaffold

--- a/docs/agy.md
+++ b/docs/agy.md
@@ -13,6 +13,10 @@ lint-ai --agy-install /path/to/project
 The installer writes the MCP server to `~/.gemini/config/mcp_config.json` and
 the hook commands to `~/.gemini/config/hooks.json`. Explicit files
 can be supplied with `--agy-config` and `--agy-settings`.
+The installer also adds the project-scoped `lint-ai-memory` skill under
+`.agents/skills/lint-ai-memory/SKILL.md`, which AGY loads as a workspace skill.
+User-modified skills are preserved; use `--agy-force-skill` to replace one
+intentionally.
 
 AGY receives the same `search`, `info`, `record_session`, `enable_lint_ai`,
 `disable_lint_ai`, and `lint_ai_status` MCP tools as the other integrations.

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -39,6 +39,11 @@ By default this:
   `mcp__lint-ai__search` for prior project context
 - preserves unrelated MCP servers, hooks, and settings
 
+The installer validates the skill before changing global Claude settings. It
+updates a Lint-AI-managed skill during upgrades, but preserves a user-modified
+skill and reports an error. Use `--claude-code-force-skill` only when you
+intentionally want to replace that file.
+
 Claude session memory is persisted under:
 
 ```text

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -29,6 +29,8 @@ By default this should:
   feature flags
 - merge Lint-AI commands into `~/.codex/hooks.json` for the supported Codex
   lifecycle events
+- merge the Lint-AI memory policy into the project's `AGENTS.md`, which Codex
+  uses for standing project instructions
 - preserve unrelated MCP servers, hooks, and settings
 
 Codex's built-in TUI status line currently accepts only Codex-defined item

--- a/src/bin/project_memory_recency_benchmark.rs
+++ b/src/bin/project_memory_recency_benchmark.rs
@@ -1,0 +1,138 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use clap::Parser;
+use lint_ai::index::DocRecord;
+use lint_ai::{
+    build_query_snapshot, temporal::parse_temporal_date, PipelineOptions, SourceDocument,
+};
+use serde::Deserialize;
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+#[derive(Debug, Parser)]
+#[command(about = "Evaluate freshness on a persisted Lint-AI project memory corpus")]
+struct Args {
+    /// Path to semantic/records.json produced by IndexStore.
+    #[arg(long, default_value = ".lint-ai/codex-memory/semantic/records.json")]
+    records: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedRecords {
+    records: Vec<DocRecord>,
+}
+
+const QUERIES: &[&str] = &[
+    "memory",
+    "temporal",
+    "hooks",
+    "benchmark",
+    "Codex",
+    "AGY",
+    "skills",
+    "installation",
+];
+
+fn age_bucket(timestamp: Option<&str>, today: chrono::NaiveDate) -> &'static str {
+    let Some(date) = parse_temporal_date(timestamp) else {
+        return "unknown";
+    };
+    let age = today.signed_duration_since(date).num_days().max(0);
+    match age {
+        0..=30 => "fresh",
+        31..=90 => "warm",
+        _ => "cold",
+    }
+}
+
+fn source_document(record: DocRecord) -> SourceDocument {
+    SourceDocument {
+        doc_id: record.doc_id,
+        source: record.source,
+        content: record.content,
+        concept: record.probable_topic.unwrap_or_default(),
+        group_id: record.group_id,
+        filters: record.filters,
+        headings: record.headings,
+        links: record.doc_links,
+        timestamp: record.timestamp,
+        doc_length: record.doc_length,
+        author_agent: record.author_agent,
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let payload: PersistedRecords = serde_json::from_str(&fs::read_to_string(&args.records)?)?;
+    let now = DateTime::<Utc>::from(SystemTime::now());
+    let today = now.date_naive();
+    let timestamp_by_id = payload
+        .records
+        .iter()
+        .map(|record| (record.doc_id.clone(), record.timestamp.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut corpus_distribution = BTreeMap::<&str, usize>::new();
+    for timestamp in timestamp_by_id.values() {
+        *corpus_distribution
+            .entry(age_bucket(timestamp.as_deref(), today))
+            .or_default() += 1;
+    }
+
+    let documents = payload
+        .records
+        .into_iter()
+        .map(source_document)
+        .collect::<Vec<_>>();
+    let index = build_query_snapshot(&documents, &PipelineOptions::default())?;
+    let mut retrieved_distribution = BTreeMap::<&str, usize>::new();
+    let mut top_1_distribution = BTreeMap::<&str, usize>::new();
+    let mut query_reports = Vec::new();
+
+    for query in QUERIES {
+        let results = index.query(query, 5);
+        for result in &results {
+            let bucket = age_bucket(
+                timestamp_by_id
+                    .get(&result.doc_id)
+                    .and_then(|timestamp| timestamp.as_deref()),
+                today,
+            );
+            *retrieved_distribution.entry(bucket).or_default() += 1;
+        }
+        if let Some(result) = results.first() {
+            let bucket = age_bucket(
+                timestamp_by_id
+                    .get(&result.doc_id)
+                    .and_then(|timestamp| timestamp.as_deref()),
+                today,
+            );
+            *top_1_distribution.entry(bucket).or_default() += 1;
+            query_reports.push(json!({
+                "query": query,
+                "top_1_doc_id": result.doc_id,
+                "top_1_bucket": bucket,
+                "top_1_recency_score": result.score_breakdown.recency_score,
+            }));
+        }
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "benchmark": "lint-ai-project-memory-recency",
+            "records_path": args.records,
+            "record_count": timestamp_by_id.len(),
+            "query_count": QUERIES.len(),
+            "age_buckets": {"fresh": "0-30 days", "warm": "31-90 days", "cold": "91+ days"},
+            "corpus_freshness_distribution": corpus_distribution,
+            "retrieved_top_5_freshness_distribution": retrieved_distribution,
+            "retrieved_top_1_freshness_distribution": top_1_distribution,
+            "queries": query_reports,
+            "note": "This evaluates the current persisted project memory corpus. It measures freshness distribution, not semantic answer correctness."
+        }))?
+    );
+    Ok(())
+}

--- a/src/bin/recency_benchmark.rs
+++ b/src/bin/recency_benchmark.rs
@@ -1,0 +1,107 @@
+use anyhow::Result;
+use chrono::{Duration, Utc};
+use lint_ai::{build_query_snapshot, PipelineOptions, SourceDocument};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::time::SystemTime;
+
+const TOPICS: &[&str] = &["aurora", "beacon", "comet", "delta", "eclipse"];
+const AGE_BUCKETS: &[(&str, i64)] = &[("fresh", 7), ("warm", 45), ("cold", 180)];
+
+fn document(topic: &str, bucket: &str, age_days: i64, today: chrono::NaiveDate) -> SourceDocument {
+    let date = today - Duration::days(age_days);
+    SourceDocument {
+        doc_id: format!("conversation-{topic}-{bucket}"),
+        source: format!("conversation://{topic}/{bucket}"),
+        content: format!(
+            "Conversation memory about project {topic}. The team decided to keep the {topic} rollout plan and review it with the team."
+        ),
+        concept: topic.to_string(),
+        group_id: Some(format!("session-{topic}-{bucket}")),
+        filters: BTreeMap::new(),
+        headings: vec!["Conversation memory".to_string()],
+        links: Vec::new(),
+        timestamp: Some(format!("{date}T12:00:00Z")),
+        doc_length: 0,
+        author_agent: Some("recency-benchmark".to_string()),
+    }
+}
+
+fn bucket(doc_id: &str) -> &'static str {
+    AGE_BUCKETS
+        .iter()
+        .find_map(|(bucket, _)| doc_id.ends_with(bucket).then_some(*bucket))
+        .unwrap_or("unknown")
+}
+
+fn main() -> Result<()> {
+    let today = chrono::DateTime::<Utc>::from(SystemTime::now()).date_naive();
+    let documents = TOPICS
+        .iter()
+        .flat_map(|topic| {
+            AGE_BUCKETS
+                .iter()
+                .map(move |(bucket, age)| document(topic, bucket, *age, today))
+        })
+        .collect::<Vec<_>>();
+    let index = build_query_snapshot(&documents, &PipelineOptions::default())?;
+
+    let mut latest_at_1 = 0usize;
+    let mut latest_at_3 = 0usize;
+    let mut latest_rank_sum = 0usize;
+    let mut bucket_at_1 = BTreeMap::<&str, usize>::new();
+    let mut bucket_at_3 = BTreeMap::<&str, usize>::new();
+    let mut boost_sum = 0.0f32;
+
+    for topic in TOPICS {
+        let results = index.query(&format!("conversation memory project {topic}"), 3);
+        let latest_rank = results
+            .iter()
+            .position(|result| result.doc_id == format!("conversation-{topic}-fresh"));
+        if let Some(rank) = latest_rank {
+            latest_rank_sum += rank + 1;
+            if rank == 0 {
+                latest_at_1 += 1;
+            }
+            if rank < 3 {
+                latest_at_3 += 1;
+            }
+        }
+        if let Some(result) = results.first() {
+            *bucket_at_1.entry(bucket(&result.doc_id)).or_default() += 1;
+            boost_sum += result.score_breakdown.recency_score;
+        }
+        for result in results.iter().take(3) {
+            *bucket_at_3.entry(bucket(&result.doc_id)).or_default() += 1;
+        }
+    }
+
+    let query_count = TOPICS.len();
+    assert_eq!(
+        latest_at_1, query_count,
+        "fresh conversation memory must rank first for every controlled query"
+    );
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "benchmark": "conversation-recency",
+            "query_count": query_count,
+            "document_count": documents.len(),
+            "age_buckets_days": {
+                "fresh": "0-30",
+                "warm": "31-90",
+                "cold": "91+"
+            },
+            "metrics": {
+                "latest_memory_at_1": latest_at_1 as f64 / query_count as f64,
+                "latest_memory_at_3": latest_at_3 as f64 / query_count as f64,
+                "mean_latest_memory_rank": latest_rank_sum as f64 / query_count as f64,
+                "mean_top_1_recency_score": boost_sum as f64 / query_count as f64,
+                "top_1_freshness_distribution": bucket_at_1,
+                "top_3_freshness_distribution": bucket_at_3
+            },
+            "note": "Controlled retrieval benchmark; each topic has identical fresh, warm, and cold conversation memories."
+        }))?
+    );
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -176,6 +176,10 @@ pub struct Args {
     #[arg(long)]
     #[cfg(feature = "claude-code")]
     pub claude_code_install: bool,
+    /// Replace a user-modified Lint-AI Claude skill explicitly.
+    #[arg(long)]
+    #[cfg(feature = "claude-code")]
+    pub claude_code_force_skill: bool,
     #[arg(long)]
     #[cfg(feature = "claude-code")]
     pub claude_code_serve: bool,
@@ -238,6 +242,9 @@ pub struct Args {
     #[arg(long)]
     #[cfg(feature = "agy")]
     pub agy_install: bool,
+    #[arg(long)]
+    #[cfg(feature = "agy")]
+    pub agy_force_skill: bool,
     #[arg(long)]
     #[cfg(feature = "agy")]
     pub agy_serve: bool,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,6 +9,7 @@ use crate::integrations::agy::hooks::{run_hook as run_agy_hook, AgyHookKind};
 #[cfg(feature = "agy")]
 use crate::integrations::agy::{
     install_hook_settings as install_agy_hook_settings,
+    install_memory_skill as install_agy_memory_skill,
     install_user_config as install_agy_user_config, run_server as run_agy_server, AgyServerOptions,
 };
 #[cfg(feature = "claude-code")]
@@ -2244,14 +2245,15 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
 
     #[cfg(feature = "claude-code")]
     if args.claude_code_install {
+        let written =
+            install_memory_skill(Path::new(&args.path), args.claude_code_force_skill)?;
+        println!("Wrote Claude Code memory skill to {}", written.display());
         let config_path = args.claude_code_config.as_deref().map(Path::new);
         let written = install_user_config(Path::new(&args.path), config_path)?;
         println!("Wrote Claude Code config to {}", written.display());
         let settings_path = args.claude_code_settings.as_deref().map(Path::new);
         let written = install_hook_settings(Path::new(&args.path), settings_path)?;
         println!("Wrote Claude Code hook settings to {}", written.display());
-        let written = install_memory_skill(Path::new(&args.path))?;
-        println!("Wrote Claude Code memory skill to {}", written.display());
         return Ok(());
     }
 
@@ -2317,6 +2319,8 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
 
     #[cfg(feature = "agy")]
     if args.agy_install {
+        let written = install_agy_memory_skill(Path::new(&args.path), args.agy_force_skill)?;
+        println!("Wrote AGY memory skill to {}", written.display());
         let written = install_agy_user_config(
             Path::new(&args.path),
             args.agy_config.as_deref().map(Path::new),

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,7 +1,10 @@
 use crate::ids::stable_chunk_id;
 use crate::query_expansion::{expand_query_terms, normalize_for_index};
 use crate::query_semantics::QueryRoutingIntent;
-use crate::temporal::{parse_temporal_date, resolve_temporal_target};
+use crate::temporal::{
+    parse_temporal_date, recency_boost, resolve_temporal_target, DEFAULT_RECENCY_HALF_LIFE_DAYS,
+    DEFAULT_RECENCY_MAX_BOOST,
+};
 use crate::tier1::{RankedTerm, Tier1Entity};
 use crate::tokenizer::{self, TokenizerMode};
 use anyhow::Result;
@@ -34,7 +37,6 @@ const EXPANDED_ENTITY_WEIGHT: f32 = 0.45;
 const EXPANDED_TERM_WEIGHT: f32 = 0.35;
 const TOPIC_OVERLAP_WEIGHT: f32 = 0.35;
 const DOC_TYPE_OVERLAP_WEIGHT: f32 = 0.25;
-const TIMESTAMP_PRESENCE_WEIGHT: f32 = 0.05;
 const DOC_LINK_GRAPH_WEIGHT: f32 = 0.22;
 const GRAPH_MAX_BOOST: f32 = 0.6;
 const ENTITY_GRAPH_WEIGHT: f32 = 0.08;
@@ -1347,8 +1349,6 @@ impl MemoryIndex {
             None => top_k.saturating_mul(5).max(20),
         };
         let total_start = Instant::now();
-        let (mut results, mut timings, diagnostics) =
-            self.query_timed_with_context(query, search_k, temporal);
         let (temporal_start, temporal_end) =
             normalize_temporal_bounds(temporal.starts_from, temporal.ends_at);
         let relative_anchor = temporal_start
@@ -1357,6 +1357,13 @@ impl MemoryIndex {
             .or(temporal.starts_from)
             .or(temporal.ends_at);
         let target = resolve_temporal_target(query, relative_anchor);
+        let apply_recency = !temporal.has_explicit_temporal
+            && target.is_none()
+            && temporal_start.is_none()
+            && temporal_end.is_none()
+            && temporal.time_hint.is_none();
+        let (mut results, mut timings, diagnostics) =
+            self.query_timed_with_context(query, search_k, temporal, apply_recency);
         if target.is_none()
             && temporal_start.is_none()
             && temporal_end.is_none()
@@ -1483,7 +1490,7 @@ impl MemoryIndex {
         query: &str,
         top_k: usize,
     ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
-        self.query_timed_with_context(query, top_k, TemporalQueryContext::default())
+        self.query_timed_with_context(query, top_k, TemporalQueryContext::default(), true)
     }
 
     fn query_timed_with_context(
@@ -1491,6 +1498,7 @@ impl MemoryIndex {
         query: &str,
         top_k: usize,
         temporal: TemporalQueryContext<'_>,
+        apply_recency: bool,
     ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
         let total_start = Instant::now();
         let lexical_start = Instant::now();
@@ -1510,6 +1518,7 @@ impl MemoryIndex {
             temporal.query_routing_intent,
             temporal.has_explicit_temporal,
             temporal.allowed_doc_ids,
+            apply_recency,
         );
         let snapshot_query_ms = snapshot_start.elapsed().as_secs_f64() * 1000.0;
         let total_ms = total_start.elapsed().as_secs_f64() * 1000.0;
@@ -1530,7 +1539,7 @@ impl MemoryIndex {
         top_k: usize,
         lexical_hits: Option<&HashMap<String, f32>>,
     ) -> Vec<SearchResult> {
-        self.query_with_lexical_hits_timed(query, top_k, lexical_hits, None, false, None)
+        self.query_with_lexical_hits_timed(query, top_k, lexical_hits, None, false, None, true)
             .0
     }
 
@@ -1592,8 +1601,16 @@ impl MemoryIndex {
         let Some(allowed) = self.doc_ids_matching_filters(filters) else {
             return self.query_with_lexical_hits(query, top_k, lexical_hits);
         };
-        self.query_with_lexical_hits_timed(query, top_k, lexical_hits, None, false, Some(&allowed))
-            .0
+        self.query_with_lexical_hits_timed(
+            query,
+            top_k,
+            lexical_hits,
+            None,
+            false,
+            Some(&allowed),
+            true,
+        )
+        .0
     }
 
     /// Multi-term variant: builds the allowed-doc set once from `filters`, then scores each
@@ -1638,6 +1655,7 @@ impl MemoryIndex {
                     None,
                     false,
                     allowed_opt.as_ref(),
+                    true,
                 )
                 .0
             })
@@ -1652,6 +1670,7 @@ impl MemoryIndex {
         query_routing_intent: Option<QueryRoutingIntent>,
         has_explicit_temporal: bool,
         allowed_doc_ids: Option<&HashSet<String>>,
+        apply_recency: bool,
     ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
         const MAX_QUERY_CHARS: usize = 4096;
         const MAX_QUERY_TOKENS: usize = 128;
@@ -1985,10 +2004,21 @@ impl MemoryIndex {
                     entry.breakdown.claim_score += best_claim_delta;
                 }
             }
-            if doc_has_timestamped_chunk(doc) || doc.timestamp.is_some() {
-                let delta = TIMESTAMP_PRESENCE_WEIGHT;
-                entry.score += delta;
-                entry.breakdown.recency_score += delta;
+            if apply_recency {
+                let delta = recency_boost(
+                    doc.section_chunks
+                        .iter()
+                        .find_map(|chunk| chunk.timestamp.as_deref())
+                        .or(doc.timestamp.as_deref()),
+                    DateTime::<Utc>::from(SystemTime::now()),
+                    DEFAULT_RECENCY_HALF_LIFE_DAYS,
+                    DEFAULT_RECENCY_MAX_BOOST,
+                )
+                .unwrap_or(0.0);
+                if delta > 0.0 {
+                    entry.score += delta;
+                    entry.breakdown.recency_score += delta;
+                }
             }
         }
         let candidate_accumulation_ms =

--- a/src/integrations/agy/mod.rs
+++ b/src/integrations/agy/mod.rs
@@ -16,6 +16,28 @@ const HOOK_MARKER: &str = "--agy-hook";
 
 pub type AgyServerOptions<'a> = GeminiCliServerOptions<'a>;
 
+pub fn install_memory_skill(root: &Path, force: bool) -> Result<PathBuf> {
+    let root = root.canonicalize()?;
+    let skill_path = root.join(".agents/skills/lint-ai-memory/SKILL.md");
+    if let Some(parent) = skill_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let generated = include_str!("skill.md");
+    if let Ok(existing) = fs::read_to_string(&skill_path) {
+        if !force && existing != generated {
+            anyhow::bail!(
+                "refusing to overwrite existing AGY skill {}; it appears user-modified; use --agy-force-skill to replace it",
+                skill_path.display()
+            );
+        }
+        if existing == generated {
+            return Ok(skill_path);
+        }
+    }
+    fs::write(&skill_path, generated)?;
+    Ok(skill_path)
+}
+
 pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<PathBuf> {
     let path = config_path
         .map(Path::to_path_buf)
@@ -154,6 +176,32 @@ mod tests {
             .contains("mcp_config.json"));
         assert_eq!(HOOK_MARKER, "--agy-hook");
         let _ = root;
+    }
+
+    #[test]
+    fn memory_skill_preserves_user_edits_without_force() {
+        let root = temp_root();
+        let path = root.join(".agents/skills/lint-ai-memory/SKILL.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "custom").unwrap();
+
+        let error = install_memory_skill(&root, false).unwrap_err().to_string();
+        assert!(error.contains("--agy-force-skill"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), "custom");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn memory_skill_force_replaces_user_edits_and_is_idempotent() {
+        let root = temp_root();
+
+        install_memory_skill(&root, true).unwrap();
+        let path = root.join(".agents/skills/lint-ai-memory/SKILL.md");
+        let installed = fs::read_to_string(&path).unwrap();
+        assert!(installed.contains("<!-- lint-ai-managed-skill -->"));
+        install_memory_skill(&root, false).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), installed);
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/integrations/agy/skill.md
+++ b/src/integrations/agy/skill.md
@@ -1,0 +1,17 @@
+---
+name: lint-ai-memory
+description: Use the Lint-AI MCP server as the first source for project memory, prior decisions, and earlier work before inspecting the repository.
+---
+
+<!-- lint-ai-managed-skill -->
+
+# Lint-AI Memory
+
+For requests about project history, prior decisions, architectural choices,
+earlier work, or why something was implemented, call the `lint-ai` MCP
+server's `search` tool before reading files or searching the repository.
+
+Use returned results as context, distinguish retrieved facts from current
+source facts, and check cited files when current source details are required.
+Say plainly when memory returns nothing. Do not treat recorded sessions as
+authoritative documentation; verify conclusions against the current project.

--- a/src/integrations/claude_code/mod.rs
+++ b/src/integrations/claude_code/mod.rs
@@ -103,7 +103,7 @@ pub fn install_user_config(root: &Path, config_path: Option<&Path>) -> Result<Pa
     Ok(config_path)
 }
 
-pub fn install_memory_skill(root: &Path) -> Result<PathBuf> {
+pub fn install_memory_skill(root: &Path, force: bool) -> Result<PathBuf> {
     // Canonicalized, and used below: the skill must land at the real path, not
     // through a symlink.
     let root = root
@@ -120,13 +120,21 @@ pub fn install_memory_skill(root: &Path) -> Result<PathBuf> {
     if skill_path.exists() {
         let existing = fs::read_to_string(&skill_path)
             .with_context(|| format!("failed to read existing skill {}", skill_path.display()))?;
-        if existing != include_str!("skill.md") {
+        let known_generated = existing == include_str!("skill.md")
+            || // Recognize the pre-marker skill shipped by earlier Lint-AI versions
+               // so normal upgrades do not require a replacement flag.
+               (existing.starts_with("---\nname: lint-ai-memory\n")
+                   && existing.contains("mcp__lint-ai__search")
+                   && existing.contains("## Lint-AI Memory"));
+        if !force && !known_generated {
             anyhow::bail!(
-                "refusing to overwrite existing Claude skill {}; remove it or back it up first",
+                "refusing to overwrite existing Claude skill {}; it appears user-modified; use --claude-code-force-skill to replace it",
                 skill_path.display()
             );
         }
-        return Ok(skill_path);
+        if existing == include_str!("skill.md") {
+            return Ok(skill_path);
+        }
     }
     fs::write(&skill_path, include_str!("skill.md"))?;
     Ok(skill_path)
@@ -721,6 +729,41 @@ mod tests {
         let path = temp_path(name).with_extension("");
         fs::create_dir_all(&path).unwrap();
         path
+    }
+
+    #[test]
+    fn install_memory_skill_preserves_user_edits_without_force() {
+        let root = temp_dir("claude-skill-preserve");
+        let skill_path = root.join(".claude/skills/lint-ai-memory/SKILL.md");
+        fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+        fs::write(
+            &skill_path,
+            "---\nname: lint-ai-memory\n---\n\nMy custom instructions\n",
+        )
+        .unwrap();
+
+        let error = install_memory_skill(&root, false).unwrap_err().to_string();
+        assert!(error.contains("--claude-code-force-skill"));
+        assert_eq!(
+            fs::read_to_string(&skill_path).unwrap(),
+            "---\nname: lint-ai-memory\n---\n\nMy custom instructions\n"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn install_memory_skill_force_replaces_user_edits() {
+        let root = temp_dir("claude-skill-force");
+        let skill_path = root.join(".claude/skills/lint-ai-memory/SKILL.md");
+        fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+        fs::write(&skill_path, "custom").unwrap();
+
+        install_memory_skill(&root, true).unwrap();
+
+        let installed = fs::read_to_string(&skill_path).unwrap();
+        assert!(installed.contains("<!-- lint-ai-managed-skill -->"));
+        assert!(!installed.contains("custom"));
+        let _ = fs::remove_dir_all(root);
     }
 
     fn test_mcp(root: PathBuf, documents: Vec<SourceDocument>) -> ClaudeMcp {

--- a/src/integrations/claude_code/skill.md
+++ b/src/integrations/claude_code/skill.md
@@ -3,6 +3,8 @@ name: lint-ai-memory
 description: Use the Lint-AI MCP server as the first source for project memory, prior decisions, and earlier work before inspecting the repository.
 ---
 
+<!-- lint-ai-managed-skill -->
+
 # Lint-AI Memory
 
 ## MCP-first memory policy

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2166,6 +2166,33 @@ mod tests {
     }
 
     #[test]
+    fn query_prefers_latest_equally_relevant_conversation_memory() {
+        let today = chrono::DateTime::<chrono::Utc>::from(SystemTime::now()).date_naive();
+        let mut latest = sample_doc(
+            "conversation-latest",
+            "Conversation memory: the project Aurora rollout decision was to ship in phases.",
+        );
+        latest.timestamp = Some(format!("{today}T12:00:00Z"));
+        let mut old = sample_doc(
+            "conversation-old",
+            "Conversation memory: the project Aurora rollout decision was to ship in phases.",
+        );
+        old.timestamp = Some(format!("{}T12:00:00Z", today - chrono::Duration::days(180)));
+
+        let index = build_query_snapshot(&[old, latest], &PipelineOptions::default())
+            .expect("conversation memories should build");
+        let results = index.query("Aurora rollout decision", 2);
+
+        assert_eq!(
+            results.first().map(|result| result.doc_id.as_str()),
+            Some("conversation-latest")
+        );
+        assert!(
+            results[0].score_breakdown.recency_score > results[1].score_breakdown.recency_score
+        );
+    }
+
+    #[test]
     fn chunk_ids_are_stable_for_same_input() {
         let content = "# Intro\nDocker install on linux\n# Usage\nRun docker info";
         let first = crate::chunking::chunk_document_sections(content, "doc-1");

--- a/src/temporal.rs
+++ b/src/temporal.rs
@@ -11,6 +11,27 @@ pub struct TemporalTarget {
     pub window_days: i64,
 }
 
+pub const DEFAULT_RECENCY_HALF_LIFE_DAYS: f32 = 30.0;
+pub const DEFAULT_RECENCY_MAX_BOOST: f32 = 0.25;
+
+pub fn recency_boost(
+    timestamp: Option<&str>,
+    now: DateTime<Utc>,
+    half_life_days: f32,
+    max_boost: f32,
+) -> Option<f32> {
+    if half_life_days <= 0.0 || !half_life_days.is_finite() || max_boost <= 0.0 {
+        return None;
+    }
+    let timestamp_date = parse_date(timestamp)?;
+    let age_days = now
+        .date_naive()
+        .signed_duration_since(timestamp_date)
+        .num_days()
+        .max(0) as f32;
+    Some((max_boost * 2.0f32.powf(-age_days / half_life_days)).min(max_boost))
+}
+
 pub fn augment_query_with_temporal_context(query: &str, question_date: Option<&str>) -> String {
     let Some(base_date) = parse_date(question_date) else {
         return query.to_string();
@@ -556,6 +577,11 @@ fn parse_date(input: Option<&str>) -> Option<NaiveDate> {
     }
     NaiveDate::parse_from_str(s, "%Y-%m-%d")
         .ok()
+        .or_else(|| {
+            DateTime::parse_from_rfc3339(s)
+                .ok()
+                .map(|date| date.date_naive())
+        })
         .or_else(|| NaiveDate::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").ok())
         .or_else(|| NaiveDate::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f").ok())
 }
@@ -763,5 +789,28 @@ mod tests {
             "expected ~14 days before anchor, got delta={delta}"
         );
         assert!(target.window_days > 0);
+    }
+
+    #[test]
+    fn reveals_bug_rfc3339_timestamp_with_timezone_is_not_parsed() {
+        assert_eq!(
+            parse_temporal_date(Some("2024-05-10T14:30:00+00:00")),
+            Some(NaiveDate::from_ymd_opt(2024, 5, 10).unwrap())
+        );
+    }
+
+    #[test]
+    fn reveals_bug_recency_decay_does_not_prioritize_recent_memory() {
+        let now = DateTime::parse_from_rfc3339("2024-07-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let boost = recency_boost(
+            Some("2024-06-01T12:00:00Z"),
+            now,
+            DEFAULT_RECENCY_HALF_LIFE_DAYS,
+            DEFAULT_RECENCY_MAX_BOOST,
+        )
+        .expect("timestamp should receive a recency boost");
+        assert!((boost - 0.125).abs() < 0.001, "boost={boost}");
     }
 }


### PR DESCRIPTION
## Summary
- Install project memory guidance for Claude, Codex, and AGY using each provider's native instruction mechanism.
- Preserve user-edited skills and provide explicit force flags.
- Validate Claude skill state before changing global settings.
- Add installation tests for AGY and Claude skill behavior.
- Add temporal exponential decay so recent memories receive a bounded freshness boost on normal queries.
- Keep explicit temporal queries on temporal proximity ranking.
- Add a deterministic conversation-memory recency benchmark and a benchmark for the persisted Lint-AI project memory corpus.

## Validation
- `cargo test --all-targets --features claude-code,codex,agy -- --test-threads=1` (204 library tests, 3 server tests, 6 integration tests)
- `cargo run --bin recency_benchmark` (latest memory at top-1: 100%, top-3: 100%)
- `cargo run --bin project_memory_recency_benchmark -- --records .lint-ai/codex-memory/semantic/records.json`

The real project corpus currently contains 320 fresh memories, so it does not yet provide warm/cold records for comparison.