### PR TITLE
feat: make MCP search results concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ Results file: `benchmark/data/lintai_longmemeval_scoped_results_0512.json`
 
 | metric | value |
 |---|---|
-| recall@5 | 83.7% |
-| recall@10 | 89.6% |
+| recall@5 | 83.5% |
+| recall@10 | 89.5% |
 | recall@20 | 91.1% |
 | recall_any@5 | 92.4% |
 | recall_any@10 | 95.6% |
 | recall_any@20 | 97.0% |
-| MRR | 84.3% |
-| NDCG@10 | 81.9% |
-| avg query latency | 6.1 ms |
+| MRR | 84.0% |
+| NDCG@10 | 81.8% |
+| avg query latency | 1.9 ms |
 
 `recall@k` is fractional recall over all gold sessions. `recall_any@k` counts 1.0 if any gold session appears in the top k. Latency is measured on a single CPU core with no GPU.
 
@@ -143,8 +143,8 @@ cargo build --release --features claude-code,codex
 Each installer writes lifecycle hooks and an MCP server entry into that agent's
 own configuration, which is global, and a memory policy into the named project:
 a project skill for Claude Code and AGY, plus a delimited block in `AGENTS.md` for Codex. The MCP
-entry carries no project root — the server resolves the project it is launched
-in — so installing for a second project does not repoint the first.
+entry carries no project root. The server resolves the project it is launched
+in, so installing for a second project does not repoint the first.
 
 ```bash
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,8 +4,8 @@ This directory holds the retrieval benchmarks for `lint-ai`, including
 haystack-style corpora, LongMemEval-S runs, and agent integration performance
 scaffolds.
 
-For the reproducible Lint-AI versus AgentMemory service comparison—including
-latency scripts, seeders, recorded JSON results, and methodology—see
+For the reproducible Lint-AI versus AgentMemory service comparison, including
+latency scripts, seeders, recorded JSON results, and methodology, see
 [`comparison/`](../comparison/).
 
 ## Conversation Recency Benchmark
@@ -34,6 +34,12 @@ This reports the corpus freshness distribution and the freshness distribution
 of the top-1 and top-5 results for representative project-memory queries. The
 real corpus has no gold answer labels, so this measures freshness behavior and
 does not claim semantic answer accuracy.
+
+The pipeline also includes a regression case for Markdown-like project guidance
+whose wording changes between revisions. It asks a natural-language ownership
+question and verifies that newer guidance outranks older, still-relevant wording
+while retaining the temporal score signal. This guards the current-state use case
+independently of the LongMemEval conversation benchmark.
 
 Benchmark subdirectories:
 

--- a/benchmark/claude_code/README.md
+++ b/benchmark/claude_code/README.md
@@ -40,7 +40,7 @@ enabled. The Lint-AI arms use hooks and durable memory without the MCP
 code-index server, matching the Codex hooks-only latency comparison. The
 `hooks-only` profile no longer installs the `lint-ai-memory` skill, since that
 skill tells Claude to call `mcp__lint-ai__search`, a tool that does not exist
-once MCP is stripped out of the isolated config — installing it there only
+once MCP is stripped out of the isolated config. Installing it there only
 confused the model and inflated tokens/latency without helping recall.
 
 Each scenario/arm/repetition worktree persists after the run instead of being
@@ -101,10 +101,10 @@ the architecture decision via repeated file reads/searches (9 tool calls).
 directly from 2 tool calls, using about a quarter of native's input tokens
 and roughly half its continuation latency. `claude-both` (Lint-AI memory and
 Claude's native auto-memory both enabled) went further still: 0 tool calls,
-the lowest latency, and the fewest tokens of the three — having two
+the lowest latency, and the fewest tokens of the three. Having two
 independent memory sources available appears to reinforce recall rather than
 add overhead or conflict. This is a single-repetition, single-scenario
-result, not a release benchmark — treat it as directional pending a
+result, not a release benchmark. Treat it as directional pending a
 multi-scenario, multi-repetition run.
 
 ### Latest multi-turn result (`routing-decision-supersession`, multi-turn)
@@ -119,7 +119,7 @@ Getting a clean result here required fixing two shared scoring bugs (both in
 `benchmark/codex_code/src/scorer.py` and `src/runner.py`, so they apply to
 every provider, not just Claude): Claude's harness never wrote a
 final-message-only file the way Codex's `--output-last-message` does, so
-scoring fell back to the full raw transcript — including tool-result text
+scoring fell back to the full raw transcript, including tool-result text
 that could contain scenario/rubric wording verbatim and produce false
 matches. `run_command` now extracts the final assistant message from
 Claude's stream-json output into a `.last` file, mirroring Codex. Separately,
@@ -139,7 +139,7 @@ pattern.
 | Output tokens | 1,897 | 266 | 442 |
 | Tool calls | 7 | 1 | 1 |
 
-All three arms reach identical, perfect accuracy — no arm is "smarter" at
+All three arms reach identical, perfect accuracy. No arm is "smarter" at
 recall. The gap is entirely in how much work it takes to get there:
 `claude-lint-ai` uses about a quarter of native's input tokens, is roughly
 3x faster on continuation, and needs 7x fewer tool calls than
@@ -147,7 +147,7 @@ recall. The gap is entirely in how much work it takes to get there:
 `claude-lint-ai` here, suggesting Lint-AI's injected memory is doing the
 work and Claude's own auto-memory adds little on top of it for this
 scenario. This is a single-repetition, single-scenario result, not a
-release benchmark — treat it as directional pending a multi-scenario,
+release benchmark. Treat it as directional pending a multi-scenario,
 multi-repetition run.
 
 ## Parse Run Metrics

--- a/benchmark/codex_code/README.md
+++ b/benchmark/codex_code/README.md
@@ -152,7 +152,7 @@ target/release/lint-ai \
 A scenario's `setup_messages` array controls this: one message runs as a
 single request/response (single-turn); more than one message chains
 sequential turns into the same Codex session by threading `codex exec resume
-<thread_id>` between per-message processes (multi-turn) — see
+<thread_id>` between per-message processes (multi-turn). See
 `run_resume_chain_phase` in `benchmark/codex_code/src/runner.py`. The same
 applies to the optional `continuation_messages` array. This dispatch is
 shared across all three provider harnesses (Claude, Codex, AGY); Claude uses
@@ -187,9 +187,9 @@ calls versus native's 2, using roughly a fifth of native's input tokens and
 noticeably lower continuation latency. Unlike Claude, where enabling both
 memory layers together (`claude-both`) beat every other arm on every metric,
 Codex's combined arm only marginally improved continuation latency over
-plain `lint-ai` and was slightly worse on setup time and tokens — within the
+plain `lint-ai` and was slightly worse on setup time and tokens, within the
 noise of a single repetition, not a clear win. This is a
-single-repetition, single-scenario result, not a release benchmark — treat
+single-repetition, single-scenario result, not a release benchmark. Treat
 it as directional pending a multi-scenario, multi-repetition run.
 
 ### Latest multi-turn result (`routing-decision-supersession`, multi-turn)
@@ -217,11 +217,11 @@ Lint-AI is far larger here than in the single-turn scenario: to correctly
 distinguish the current decision from the superseded one, `codex-native`
 needed 6 tool calls and 216k input tokens re-deriving the temporal history
 from source, versus 0 tool calls and ~14k tokens for either `lint-ai` arm
-answering directly from injected memory — roughly 15x fewer input tokens and
+answering directly from injected memory, roughly 15x fewer input tokens and
 6x lower continuation latency. Temporal-correction/multi-turn scenarios
 expose Lint-AI's advantage far more sharply than simple single-turn recall.
 This is a single-repetition, single-scenario result, not a release
-benchmark — treat it as directional pending a multi-scenario,
+benchmark. Treat it as directional pending a multi-scenario,
 multi-repetition run.
 
 ## Generated Data

--- a/docs/agent-frameworks.md
+++ b/docs/agent-frameworks.md
@@ -89,7 +89,6 @@ controls.
 - Assign a stable `user_id`; do not use a process-wide default for all users.
 - Use a unique `request_id` for each add operation so retries are safe.
 - Bound injected context by tokens or characters before passing it to the model.
-- Add only durable facts, decisions, and outcomes—not every transient tool log.
+- Add only durable facts, decisions, and outcomes, not every transient tool log.
 - Treat retrieval failure as non-fatal so the agent can continue without memory.
 - Keep memory controls and deletion flows visible to the application owner.
-

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -162,7 +162,7 @@ At a capture event, the adapter reads the transcript, extracts structured
 memory, calls `IndexStore::upsert`, and then calls `refresh`. This makes the
 document available in the index when the hook completes successfully, but it
 does not inject the new document back into the conversation that just ended.
-The document is returned on a later retrieval event—typically the next prompt
+The document is returned on a later retrieval event, typically the next prompt
 or next session. If the transcript is missing or produces no meaningful
 content, the event completes without adding a document.
 

--- a/docs/artifact-indexing.md
+++ b/docs/artifact-indexing.md
@@ -441,6 +441,23 @@ What this is not:
 - it is not a replacement for `DocRecord`
 - it is not a reason to store `tcommit`-style graph jargon in the public API
 
+## Markdown supersession
+
+When a Markdown document replaces an earlier document whose wording or
+timestamp is not enough to establish the relationship, declare the relationship
+in frontmatter:
+
+```yaml
+---
+supersedes: decisions/legacy-routing.md
+---
+```
+
+The referenced document remains in the indexed corpus for historical inspection,
+but default project searches omit it and return the replacement instead. This
+explicit relationship is intentionally preferred over guessing semantic
+replacement between unrelated passages.
+
 Implementation direction:
 
 - store facts in the existing memory store as a dedicated collection or

--- a/docs/benchmark-integration.md
+++ b/docs/benchmark-integration.md
@@ -181,7 +181,7 @@ enabled together). Each client maps these roles onto its own `--arms` names:
 AGY has no built-in "native memory" feature of its own to combine with
 Lint-AI, so it has no `Both` arm; `agy-native` is Lint-AI-absent entirely
 (`--agy-install` is not even run), and `agy-lint-ai-disabled` is a stricter
-control than `agy-native` — Lint-AI is installed identically to `agy-lint-ai`
+control than `agy-native`. Lint-AI is installed identically to `agy-lint-ai`
 but toggled off via `disable_lint_ai`, isolating "installed but inactive"
 from "never installed."
 
@@ -198,11 +198,11 @@ Concretely, each launcher configures its arms as follows:
 - `claude-both`: Claude auto-memory enabled *and* Lint-AI hooks enabled together.
 - `codex-native`: `memories = true` in Codex's own `config.toml`, no Lint-AI hook installation (`--codex-install` is skipped entirely).
 - `lint-ai`: `memories = false`, Lint-AI hooks installed and restricted to the Claude-equivalent lifecycle (see below).
-- `lint-ai-with-codex-memory`: `memories = true` *and* Lint-AI hooks installed — the Codex analogue of `claude-both`.
+- `lint-ai-with-codex-memory`: `memories = true` *and* Lint-AI hooks installed. This is the Codex analogue of `claude-both`.
 - `agy-native`: no `--agy-install` step at all; pure AGY with nothing Lint-AI-related present.
 - `agy-lint-ai`: Lint-AI installed and explicitly enabled (`enable_lint_ai`), MCP server config emptied so only hooks are active.
-- `agy-lint-ai-disabled`: Lint-AI installed identically to `agy-lint-ai` but explicitly disabled (`disable_lint_ai`) — a matched-installation control.
-- `agy-mcp-only`: Lint-AI installed with hook settings emptied (no hooks fire) and the MCP server config left in place — isolates the MCP path.
+- `agy-lint-ai-disabled`: Lint-AI installed identically to `agy-lint-ai` but explicitly disabled (`disable_lint_ai`). This is a matched-installation control.
+- `agy-mcp-only`: Lint-AI installed with hook settings emptied (no hooks fire) and the MCP server config left in place. This isolates the MCP path.
 
 For the fair cross-client comparison, Lint-AI uses the Claude-equivalent
 lifecycle events on Codex (`SessionStart`, `UserPromptSubmit`,
@@ -226,7 +226,7 @@ the continuation phase (not currently used by any real scenario; only
 exercised by a throwaway mechanism-verification scenario during development).
 
 The delivery mechanism differs by client because their CLIs differ, but the
-scenario-authoring contract is identical — a scenario author never needs to
+scenario-authoring contract is identical. A scenario author never needs to
 know which mechanism a client uses:
 
 - **Claude**: a single live process fed multiple JSON user-turn lines via
@@ -242,14 +242,14 @@ know which mechanism a client uses:
 
 Both dispatch strategies live in the same shared `run_turn_phase` function in
 `benchmark/codex_code/src/runner.py`, which every provider's launcher calls
-for both the setup and continuation phases — the choice between them is
+for both the setup and continuation phases. The choice between them is
 purely `metrics_mode` (provider) plus message-count, not separate code paths
 per scenario.
 
 Current real (non-throwaway) multi-turn scenarios:
 
 - `routing-decision-supersession` (Claude, Codex, and AGY): 2 setup messages
-  (initial proposal, then a superseding decision) — see "Current Scenarios"
+  (initial proposal, then a superseding decision). See "Current Scenarios"
   below.
 
 All other current scenarios (`index-store-segmented-routing`,
@@ -468,7 +468,7 @@ recovering useful conversation context.
 ### `routing-decision-supersession` (Claude, Codex, and AGY)
 
 Category: `temporal-correction`. **Multi-turn setup** (2 sequential
-`setup_messages`) — see "Single-Turn vs. Multi-Turn Setup" above.
+`setup_messages`). See "Single-Turn vs. Multi-Turn Setup" above.
 
 Setup first establishes `SparseOverlap` in one turn, then supersedes it with
 `LocalDistinctiveness` and `query_top_n = 3` in a second, sequential turn

--- a/docs/claude-code-hooks-design.md
+++ b/docs/claude-code-hooks-design.md
@@ -486,7 +486,7 @@ response to stdout.
 ## Remaining Work
 
 1. Add benchmark coverage for retrieval quality, hook latency, and injected
-   token usage — including the three new hooks added in this release.
+   token usage, including the three new hooks added in this release.
 2. Replace deterministic bounded transcript extraction with optional structured
    summarization after its quality and cost are measured.
 3. Add configurable context budgets, routing thresholds, and retention.

--- a/docs/filtered-search.md
+++ b/docs/filtered-search.md
@@ -6,7 +6,7 @@ design rationale.
 
 ## Problem
 
-A single `IndexStore` can hold documents from many logical scopes — different
+A single `IndexStore` can hold documents from many logical scopes, different
 runs, workspaces, graphs, or artifact types. Without a way to restrict a query
 to a subset of documents, callers must post-filter results or maintain separate
 `IndexStore` instances per scope.
@@ -77,7 +77,7 @@ All filter predicates use **exact-match AND** semantics:
 - every key-value pair in the supplied filter map must match the document's
   `filters` map
 - a document that is missing a required key does not match
-- an empty filter map means no restriction — all documents are candidates
+- an empty filter map means no restriction, so all documents are candidates
 
 This is intentionally simple. Range queries, OR conditions, and prefix matches
 are not supported.
@@ -96,7 +96,7 @@ pub fn query_filtered(
 ```
 
 1. Calls `self.refresh()` to ensure the snapshot is current.
-2. Runs `self.lexical.search(query, candidate_k)` — BM25 via Tantivy — to get
+2. Runs `self.lexical.search(query, candidate_k)`, using BM25 via Tantivy, to get
    a set of lexical hit scores keyed by `doc_id`.
 3. Passes lexical hits and `filters` to `MemoryIndex::query_with_filters_and_lexical`.
 4. `MemoryIndex` builds the allowed set, then scores candidates that are in
@@ -164,10 +164,10 @@ public for callers that manage their own BM25 pipeline.
 ### Why BM25 before filter
 
 BM25 runs first and produces a candidate set. The filter then restricts that
-set. This order avoids scoring documents that would be excluded anyway — Tantivy
+set. This order avoids scoring documents that would be excluded anyway. Tantivy
 already narrows the field to lexically relevant documents before the filter scan.
 
-An alternative — filter first, then BM25 — would require a Tantivy reader that
+An alternative, filtering first and then running BM25, would require a Tantivy reader that
 restricts to a doc-id allowlist. Tantivy supports this via `BitSetDocSet` but it
 requires building a Tantivy `DocId` bitset, which needs a mapping from our
 string `doc_id` to internal Tantivy row ids. That mapping is not currently
@@ -214,7 +214,7 @@ for (i, text) in texts.iter().enumerate() {
 let scope = BTreeMap::from([("run_id".into(), "run-abc".into())]);
 let results = store.query_filtered("NVDA earnings", 5, &scope)?;
 
-// Multi-term filtered query — filter scan happens once
+// Multi-term filtered query. The filter scan happens once.
 let terms = &["NVDA", "TSLA", "AMD"];
 let per_term = store.query_filtered_multi(terms, 5, &scope)?;
 // per_term[0] = results for "NVDA"

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,27 +6,27 @@ hide:
 
 <div class="hero-stack">
 <section class="hero">
-  <div class="hero__eyebrow">RELIABLE PROJECT MEMORY FOR AI AGENTS</div>
-  <h1>Project memory<br><span>that knows what changed.</span></h1>
-  <p class="hero__lede">Lint-AI captures decisions across agent sessions, recognizes when newer evidence supersedes older guidance, and retrieves current, source-backed context for Codex, Claude Code, Gemini CLI, and AGY.</p>
+  <div class="hero__eyebrow">CURRENT CONTEXT FOR AI AGENTS</div>
+  <h1>Relevant context<br><span>is not always true.</span></h1>
+  <p class="hero__lede">Lint-AI turns scattered project history, including sessions, documents, decisions, and traces, into current, evidence-backed context at the moment an agent needs it.</p>
 </section>
 
 <section class="scenario" aria-label="Example of an agent retrieving a superseded decision">
   <div class="scenario__timeline">
     <article class="scenario-card scenario-card--complete">
-      <div><span>OLDER MEMORY</span><time>INITIAL RECOMMENDATION</time></div>
+      <div><span>OLDER EVIDENCE</span><time>ONCE RELEVANT</time></div>
       <p>“Increase retries to recover from the intermittent timeout.”</p>
-      <small>Still searchable · no longer current</small>
+      <small>Topically relevant · no longer current</small>
     </article>
     <div class="scenario__connector"><span>SUPERSEDED</span></div>
     <article class="scenario-card scenario-card--empty">
-      <div><span>LATEST DECISION</span><time>SUPPORTED BY EVIDENCE</time></div>
+      <div><span>CURRENT STATE</span><time>SUPPORTED BY NEWER EVIDENCE</time></div>
       <p>“Retries amplify load. Cap attempts and fix the token clock skew.”</p>
-      <small>Newer evidence · source-linked · current</small>
+      <small>Source-linked · time-aware · current</small>
     </article>
   </div>
   <div class="failure-points" aria-label="Signals needed to retrieve the right memory">
-    <span>Finding memory is not enough.</span>
+    <span>Finding a relevant passage is not enough.</span>
     <ol>
       <li><b>01</b> Relevance</li>
       <li><b>02</b> Recency</li>
@@ -36,19 +36,19 @@ hide:
   </div>
   <div class="scenario__outcome">
     <span>WITHOUT LINT-AI</span>
-    <p>The stale recommendation can surface as truth—sending the agent toward a fix already proven harmful.</p>
+    <p>Ordinary retrieval can surface an old recommendation as current because it is still topically relevant.</p>
   </div>
   <div class="scenario__outcome scenario__outcome--good">
     <span>WITH LINT-AI</span>
-    <p>The current decision ranks first. Superseded guidance stays out of retrieval, while timestamps and source evidence keep the answer inspectable.</p>
+    <p>The current state ranks first. Older guidance remains useful as history without quietly becoming today’s answer.</p>
   </div>
 </section>
 </div>
 
 <section class="solution-intro">
-  <div class="hero__eyebrow">HOW LINT-AI HELPS</div>
-  <h2>Give agents the right past—not all of it.</h2>
-  <p>Lint-AI turns project history into ranked, current, evidence-backed context. It combines lifecycle capture, temporal reasoning, explicit supersession, and source-aware retrieval across Codex, Claude Code, Gemini CLI, and AGY—so agents can act on what is true now and teams can inspect why.</p>
+  <div class="hero__eyebrow">THE MISSING LAYER</div>
+  <h2>Move from relevant retrieval to current understanding.</h2>
+  <p>Search can find the right topic. Lint-AI helps agents distinguish what is relevant from what is still true, while preserving the sources, timestamps, and history behind each answer.</p>
   <div class="hero__actions">
     <a class="md-button md-button--primary" href="quickstart/">Start building</a>
     <a class="md-button" href="https://github.com/RooAGI/Lint-AI">View on GitHub</a>
@@ -78,31 +78,31 @@ identical retrieval semantics.
 
 [View the comparison methodology and results](comparison.md)
 
-## Memory that understands change {.landing-heading}
+## Prevent confident staleness {.landing-heading}
 
 Agent context is not a pile of text. Decisions supersede older decisions. Terms drift. Ownership changes. The right answer often depends on *when* something was true and *where* the evidence came from.
 
 <div class="feature-grid">
   <article>
     <span class="feature-number">01</span>
-    <h3>Retrieve the right past</h3>
-    <p>Search sessions, notes, docs, and code with lexical, entity, temporal, and graph signals working together.</p>
+    <h3>Know what is current</h3>
+    <p>Rank current evidence ahead of older guidance and preserve historical answers when a question depends on the past.</p>
   </article>
   <article>
     <span class="feature-number">02</span>
-    <h3>Keep answers grounded</h3>
-    <p>Return LLM-ready context with source evidence instead of opaque similarity matches or raw text blobs.</p>
+    <h3>Show why it is current</h3>
+    <p>Return source, time, and relationship signals with the context so an agent or reviewer can inspect the basis for an answer.</p>
   </article>
   <article>
     <span class="feature-number">03</span>
-    <h3>Catch corpus drift</h3>
-    <p>Surface contradictions, stale claims, terminology drift, orphan pages, and missing cross-references.</p>
+    <h3>Make drift visible</h3>
+    <p>Surface contradictions, stale claims, terminology drift, orphan pages, and missing links before they become confident answers.</p>
   </article>
 </div>
 
-## One memory layer. Your agent of choice. {.landing-heading}
+## Keep your sources. Add a current-state layer. {.landing-heading}
 
-Lint-AI integrates with the tools your team already uses. Each provider gets isolated, project-scoped memory, lifecycle capture, and shared MCP controls.
+Lint-AI does not ask you to discard your existing project knowledge. It indexes the sessions, notes, documents, and decisions you already have, then makes their relationships and history usable at retrieval time. Each provider gets isolated, project-scoped memory, lifecycle capture, and shared MCP controls.
 
 <div class="integration-grid">
   <a href="codex/"><strong>Codex</strong><span>Hooks, MCP, replay, project memory →</span></a>

--- a/docs/overrides/partials/extrahead.html
+++ b/docs/overrides/partials/extrahead.html
@@ -1,10 +1,10 @@
 <meta property="og:type" content="website">
-<meta property="og:title" content="Lint-AI — Evidence-aware memory for AI agents">
-<meta property="og:description" content="Retrieve the right sessions, decisions, code, and documentation—with evidence.">
+<meta property="og:title" content="Lint-AI: Evidence-aware memory for AI agents">
+<meta property="og:description" content="Retrieve the right sessions, decisions, code, and documentation with evidence.">
 <meta property="og:image" content="https://rooagi.github.io/Lint-AI/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Lint-AI — Evidence-aware memory for AI agents">
-<meta name="twitter:description" content="Retrieve the right sessions, decisions, code, and documentation—with evidence.">
+<meta name="twitter:title" content="Lint-AI: Evidence-aware memory for AI agents">
+<meta name="twitter:description" content="Retrieve the right sessions, decisions, code, and documentation with evidence.">
 <meta name="twitter:image" content="https://rooagi.github.io/Lint-AI/assets/og.png">
 {% if config.extra.analytics_id %}
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.extra.analytics_id }}"></script>

--- a/docs/query-context-and-ranking-consolidation.md
+++ b/docs/query-context-and-ranking-consolidation.md
@@ -68,7 +68,7 @@ The proposed behavior is:
 | Segmented convenience APIs (`query_top_segment`, `query_top_segments`, `query_all_segments`; not the internal `_with_strategy`/`_with_corpus_stats` variants) | Build the same automatic default context. |
 | `query_with_temporal_context` APIs | Preserve caller-provided context and values. |
 | High-level engine (`engine.rs`'s `--query`/`--llm-context` handling) | Continue passing its already analyzed, richer context (intent **and** query augmentation) without re-analysis. |
-| `MemoryService::search` (memory server `/search`) | Should be treated like the high-level engine, not like a low-level convenience API — see "Application-level entry points" below. |
+| `MemoryService::search` (memory server `/search`) | Should be treated like the high-level engine, not like a low-level convenience API. See "Application-level entry points" below. |
 
 The automatic helper should initially infer only `query_routing_intent` and
 preserve the existing raw query text. Query augmentation and explicit temporal
@@ -113,7 +113,7 @@ See `src/memory_api.rs:120` and `src/pipeline.rs:957`.
 This is the actual `/search` production path (the memory server introduced in
 commit `1f2d8d7`, "Add AML-compatible memory server", 2026-08-13). It does not
 go through `engine.rs::query_temporal_context` or `analyze_query` at all today
-— it has no query-intent awareness and no query augmentation. The underlying
+It has no query-intent awareness and no query augmentation. The underlying
 `query_filtered`/`query_with_filters_and_lexical` plumbing itself is older
 (introduced 2026-06-13, commit `7240333`, part of the last tagged release,
 `v0.1.8`); the gap is that the August server work exposed it over HTTP without
@@ -143,7 +143,7 @@ the lighter default meant for low-level convenience callers:
 3. `temporal_context = query_temporal_context(&analysis)`
 4. Build `allowed_doc_ids` from the `memory_user_id` filter (the same shape
    `query_with_filters_and_lexical` already builds internally from its
-   `filters` map — `MemoryService` only ever filters on that one key)
+   `filters` map. `MemoryService` only ever filters on that one key)
 5. Set `temporal_context.allowed_doc_ids = Some(&allowed)`
 6. Call `index.query_with_temporal_context(&search_query, top_k, temporal_context)`
 
@@ -159,7 +159,7 @@ uses. The filter-derived `allowed` set the latter builds today
 (`src/index.rs:1548-1557`) maps onto that field directly. Once
 `MemoryService::search` is aligned as above, `query_with_filters_and_lexical`
 and `query_with_filters_multi` as distinct code paths are not technically
-necessary — `filters` → `allowed_doc_ids` and intent are both already covered
+necessary. `filters` → `allowed_doc_ids` and intent are both already covered
 by `query_with_temporal_context`.
 
 The one thing this does not fold in for free: `query_with_filters_and_lexical`
@@ -168,20 +168,20 @@ accepts a caller-supplied, pre-computed `lexical_hits` map, while
 lexical hits itself against `MemoryIndex`'s own internal `self.lexical:
 Option<LexicalIndex>` (`src/index.rs:329`). The pre-computed-hits parameter
 exists to let `IndexStore` (`src/pipeline.rs`) supply hits from its own,
-separate tantivy index — `self.lexical: LexicalState` (`src/pipeline.rs:357`)
-— which is otherwise unused: its only four call sites are
+separate tantivy index, `self.lexical: LexicalState` (`src/pipeline.rs:357`),
+which is otherwise unused: its only four call sites are
 `query_with_lexical_hits` (for `query_latest`/`query_fresh`) and
 `query_with_filters_and_lexical`/`query_with_filters_multi`
 (`src/pipeline.rs:895,908,972,996`). Because all four of those callers call
-`self.refresh()` first, which rebuilds `MemoryIndex` — and therefore its own
-internal lexical index — from scratch whenever the store is dirty
+`self.refresh()` first, which rebuilds `MemoryIndex`, and therefore its own
+internal lexical index, from scratch whenever the store is dirty
 (`src/pipeline.rs:801-833`), `MemoryIndex`'s internal index is already exactly
 as fresh as `IndexStore`'s separate one by the time any of them run.
 
 Consequently, folding these callers onto `query_with_temporal_context` makes
-`IndexStore`'s separate `LexicalState` — its schema, writer, reader, and the
+`IndexStore`'s separate `LexicalState`, including its schema, writer, reader, and the
 `upsert_record`/`remove_doc`/`commit_reload` maintenance that runs on every
-mutation — removable, not just the four call sites that use it. This is a
+mutation, removable, not just the four call sites that use it. This is a
 larger change than the aggregation-formula consolidation and should be scoped
 and reviewed as its own step, not folded silently into it.
 

--- a/docs/releases/0.1.8.md
+++ b/docs/releases/0.1.8.md
@@ -14,12 +14,12 @@ efficient at scale.
 - Bumped crate version from `0.1.7` to `0.1.8`.
 - Added `filters: BTreeMap<String, String>` field to `SourceDocument`,
   `DocRecord`, and `PersistedDocRecord`.
-- Added `IndexStore::query_filtered` — single-term filtered search.
-- Added `IndexStore::query_filtered_multi` — multi-term filtered search;
+- Added `IndexStore::query_filtered`, single-term filtered search.
+- Added `IndexStore::query_filtered_multi`, multi-term filtered search;
   builds the allowed-doc set once regardless of query count.
 - Added `MemoryIndex::query_with_filters` and
   `MemoryIndex::query_with_filters_and_lexical` for filtered in-memory queries.
-- Added `MemoryIndex::query_with_filters_multi` — multi-term variant that
+- Added `MemoryIndex::query_with_filters_multi`, a multi-term variant that
   reuses the allowed-doc set across all queries.
 - Propagated `filters` through all serialization round-trips (`PersistedDocRecord`
   `From` conversions, `assemble_doc_record`, `source_document_from_record`).
@@ -60,7 +60,7 @@ before returning results.
 let per_term_results = store.query_filtered_multi(&queries, top_k, &filters)?;
 ```
 
-Runs N BM25 searches (one per query term — tantivy cannot batch these), but
+Runs N BM25 searches, one per query term, because tantivy cannot batch these, but
 builds the allowed-doc set from `filters` only once. At scale this avoids
 scanning all documents once per query term.
 

--- a/docs/releases/0.1.9.md
+++ b/docs/releases/0.1.9.md
@@ -4,7 +4,7 @@ Date: 2026-08-19
 
 This is a large release. Since `0.1.8` the crate gained a network-facing memory
 server, a segmented memory index, agent integrations for four providers with
-session recording, and Python bindings — plus a security-hardening pass over
+session recording, and Python bindings, plus a security-hardening pass over
 the server and a `tantivy` upgrade that clears a RUSTSEC advisory.
 
 > ## ⚠️ Upgrade warning: API removals coming in 0.2.0
@@ -19,7 +19,7 @@ the server and a `tantivy` upgrade that clears a RUSTSEC advisory.
 > behaves exactly as before, but now emits deprecation warnings naming the
 > replacement. Building with `-D deprecated` will surface every call site.
 >
-> Migrate before upgrading to `0.2.0` — see [Deprecations](#deprecations) for
+> Migrate before upgrading to `0.2.0`. See [Deprecations](#deprecations) for
 > the replacement table and a worked example. `IndexStore` methods are
 > unaffected; if you only use `IndexStore`, there is nothing to do.
 >
@@ -135,8 +135,8 @@ source documents, records, segments, and store summaries.
 
 ## Shared Query Preparation
 
-Previously the CLI analyzed queries — inferring routing intent and augmenting
-query text — while the memory server's `/search` did neither, so the same
+Previously the CLI analyzed queries, inferring routing intent and augmenting
+query text, while the memory server's `/search` did neither, so the same
 question behaved differently depending on how it arrived. That preparation now
 lives in `query_plan::PreparedQuery`, and both callers use it.
 
@@ -180,9 +180,9 @@ derives `count_query` from query-string markers independently of
 `index.rs` and `segments.rs` each carried their own tokenizer and stopword
 list. Both now live in `tokenizer` behind an explicit `TokenizerMode`:
 
-- `TokenizerMode::Unstemmed` — regex-bounded terms, lowercased, no stemming.
+- `TokenizerMode::Unstemmed`: regex-bounded terms, lowercased, no stemming.
   Used by the lexical and rerank path.
-- `TokenizerMode::Stemmed` — split on non-alphanumeric boundaries, each token
+- `TokenizerMode::Stemmed`: split on non-alphanumeric boundaries, each token
   stemmed. Used by segment routing.
 
 The two modes are deliberate, not drift. Benchmarking showed each is a measured

--- a/docs/semantic-supersession.md
+++ b/docs/semantic-supersession.md
@@ -1,0 +1,86 @@
+# Semantic supersession
+
+Lint-AI treats supersession as a core semantic relationship. Source adapters
+and provider integrations only normalize content into `SourceDocument` records;
+the core decides how records relate over time.
+
+```text
+source adapters and agent integrations
+                 │
+                 ▼
+          SourceDocument
+                 │
+                 ▼
+           IndexStore::refresh
+          ├─ claims and provenance
+          ├─ temporal facts
+          └─ semantic relations
+                 │
+                 ▼
+              query
+          ├─ relevance ranking
+          ├─ temporal ranking
+          └─ current-state policy
+```
+
+## What the core records
+
+Each extracted claim retains its source document, evidence text, scope,
+confidence, and effective timestamp when one is available. Relationships are
+directional and may be:
+
+- `supersedes`: newer evidence replaces an older claim for normal queries;
+- `conflicts_with`: two claims disagree but the core cannot safely choose one;
+- `confirms`: later evidence repeats the same claim and value.
+
+Original documents and claims are never deleted. A historical query can still
+retrieve superseded evidence, together with its replacement and relationship
+evidence.
+
+## Detection policy
+
+The default detector is local and conservative. It compares claims within a
+project semantic scope using canonical subjects and predicates.
+
+- Explicit replacement metadata is strongest evidence.
+- A direct correction cue can establish replacement across source types.
+- A newer changed value with the same canonical claim and source kind can be
+  superseded automatically.
+- Automatic replacement suppresses a document only when that document contains
+  only the superseded claim. If the document also carries other guidance, it
+  remains searchable and is marked as conflicted until claim- or chunk-level
+  filtering can isolate the replaced evidence.
+- A timestamp-only disagreement between a document and an agent memory is a
+  conflict, not an automatic replacement.
+- Claims without enough evidence remain visible; they are never hidden merely
+  because they are older.
+
+Normal searches suppress only high-confidence superseded evidence. Conflicts
+remain visible and carry status, confidence, and evidence in search results.
+The core searches project-wide, while `semantic_scope` and `memory_user_id`
+prevent unrelated users or scenarios from affecting one another.
+
+For normal queries, the core computes the eligible current document IDs before
+ranking and intersects them with user, project, temporal, and segment filters.
+Superseded documents therefore never consume ranked candidate slots. Search
+returns up to `top_k` matching current documents; historical queries rank the
+full eligible corpus and annotate superseded results as historical.
+
+## Integration contract
+
+An integration should provide content and provenance such as `source`,
+`timestamp`, `group_id`, `author_agent`, and optional relationship hints. It
+should not implement its own supersession filtering. Markdown frontmatter and
+the memory API's optional `supersedes_id` remain supported as explicit evidence
+for the same core relation engine.
+
+The public Rust API exposes `SemanticClaim`, `SemanticRelation`,
+`SemanticRelationStore`, and `SupersessionOptions`. `IndexStore` rebuilds this
+state alongside its lexical, semantic, chunk-lifecycle, and temporal state on
+refresh.
+
+Enabled supersession configurations are validated during `IndexStore`
+construction and refresh. Fallible callers can use
+`SemanticRelationStore::try_from_documents` directly and receive the same
+validation error. Setting `enabled: false` intentionally returns an empty
+relation store without validating thresholds that will not be used.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - Light understanding: tier1-light-understanding.md
       - Filtered search: filtered-search.md
       - Artifact indexing: artifact-indexing.md
+      - Semantic supersession: semantic-supersession.md
       - Corpus graph: build-corpus-graph.md
       - Integration glossary: integration-glossary.md
       - Chunk strategy: chunk-strategy.md

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -76,13 +76,18 @@ pub fn graph_to_source_documents(graph: &Graph) -> Vec<SourceDocument> {
         .iter()
         .map(|p| {
             let t0 = tier0_by_source.get(&p.rel_path).copied();
+            let mut filters = BTreeMap::new();
+            if let Some(supersedes_id) = t0.and_then(|record| record.metadata.get("supersedes_id"))
+            {
+                filters.insert("supersedes_id".to_string(), supersedes_id.clone());
+            }
             SourceDocument {
                 doc_id: p.rel_path.clone(),
                 source: p.rel_path.clone(),
                 content: p.content.clone(),
                 concept: p.raw_concept.clone(),
                 group_id: None,
-                filters: BTreeMap::new(),
+                filters,
                 headings: p.headings.clone(),
                 links: p
                     .links

--- a/src/adapters/markdown.rs
+++ b/src/adapters/markdown.rs
@@ -223,6 +223,12 @@ pub fn build_markdown_corpus(
             .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
             .map(|d| d.as_secs().to_string());
         let frontmatter = parse_frontmatter_kv(&page.content);
+        if let Some(supersedes) = frontmatter
+            .get("supersedes")
+            .or_else(|| frontmatter.get("supersedes_id"))
+        {
+            basic_metadata.insert("supersedes_id".to_string(), supersedes.clone());
+        }
         let author_agent = frontmatter
             .get("author")
             .cloned()
@@ -320,7 +326,10 @@ mod tests {
         fs::remove_dir_all(&root)?;
 
         let corpus = result?;
-        assert!(corpus.pages.iter().any(|page| page.rel_path == "readable.md"));
+        assert!(corpus
+            .pages
+            .iter()
+            .any(|page| page.rel_path == "readable.md"));
         Ok(())
     }
 }

--- a/src/aggregation.rs
+++ b/src/aggregation.rs
@@ -301,6 +301,10 @@ mod tests {
                 matched_terms: vec![],
                 probable_topic: Some("hiking".to_string()),
                 doc_type_guess: Some("note".to_string()),
+                semantic_status: None,
+                superseded_by: None,
+                relation_confidence: None,
+                relation_evidence: vec![],
             },
             SearchResult {
                 doc_id: "d2".to_string(),
@@ -312,6 +316,10 @@ mod tests {
                 matched_terms: vec![],
                 probable_topic: Some("hiking".to_string()),
                 doc_type_guess: Some("note".to_string()),
+                semantic_status: None,
+                superseded_by: None,
+                relation_confidence: None,
+                relation_evidence: vec![],
             },
         ];
         let agg = build_aggregate_output(&index, "How many miles did I walk?", &results, 5)

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -275,8 +275,7 @@ fn handle_connection(
                     .write()
                     .map_err(|_| anyhow::anyhow!("service lock poisoned"))?
                     .add(request)
-            })
-        {
+            }) {
             Ok(response) => serde_json::to_value(response)?,
             Err(error) => {
                 return write_json(
@@ -293,8 +292,7 @@ fn handle_connection(
                     .read()
                     .map_err(|_| anyhow::anyhow!("service lock poisoned"))?
                     .search_cached(request)
-            })
-        {
+            }) {
             Ok(response) => serde_json::to_value(response)?,
             Err(error) => {
                 return write_json(
@@ -311,8 +309,7 @@ fn handle_connection(
                     .write()
                     .map_err(|_| anyhow::anyhow!("service lock poisoned"))?
                     .delete(&request.user_id, &request.doc_id)
-            })
-        {
+            }) {
             Ok(affected) => serde_json::json!({"success": true, "affected": affected as usize}),
             Err(error) => {
                 return write_json(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -648,6 +648,7 @@ fn build_memory_index(
         text_rerank_ngram: false,
         text_rerank_lcs: false,
         claim_extraction: false,
+        supersession: crate::semantic_relations::SupersessionOptions::default(),
         index_location: lexical_dir
             .map(|path| crate::pipeline::IndexLocation::Explicit(path.to_path_buf()))
             .unwrap_or(crate::pipeline::IndexLocation::InMemory),
@@ -2245,8 +2246,7 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
 
     #[cfg(feature = "claude-code")]
     if args.claude_code_install {
-        let written =
-            install_memory_skill(Path::new(&args.path), args.claude_code_force_skill)?;
+        let written = install_memory_skill(Path::new(&args.path), args.claude_code_force_skill)?;
         println!("Wrote Claude Code memory skill to {}", written.display());
         let config_path = args.claude_code_config.as_deref().map(Path::new);
         let written = install_user_config(Path::new(&args.path), config_path)?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -421,6 +421,14 @@ pub struct SearchResult {
     pub matched_terms: Vec<String>,
     pub probable_topic: Option<String>,
     pub doc_type_guess: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub semantic_status: Option<crate::semantic_relations::SemanticStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relation_confidence: Option<f32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relation_evidence: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -1563,7 +1571,7 @@ impl MemoryIndex {
     /// Doc ids whose `filters` map matches every supplied key-value pair.
     ///
     /// Returns `None` when `filters` is empty, meaning "no scoping" rather
-    /// than "nothing matched" — callers pass this straight to
+    /// than "nothing matched". Callers pass this straight to
     /// `TemporalQueryContext::allowed_doc_ids`.
     pub fn doc_ids_matching_filters(
         &self,
@@ -2411,6 +2419,10 @@ impl MemoryIndex {
                         .unwrap_or_default(),
                     probable_topic: doc.probable_topic.clone(),
                     doc_type_guess: doc.doc_type_guess.clone(),
+                    semantic_status: None,
+                    superseded_by: None,
+                    relation_confidence: None,
+                    relation_evidence: Vec::new(),
                 });
             }
             if results.len() >= top_k.min(self.doc_u32_to_id.len()) {

--- a/src/integrations/claude_code/mod.rs
+++ b/src/integrations/claude_code/mod.rs
@@ -26,7 +26,6 @@ use std::fs;
 use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::Instant;
 
 const SERVER_NAME: &str = "lint-ai";
 const DEFAULT_QUERY_TOP_K: usize = 5;
@@ -366,7 +365,6 @@ impl ClaudeMcp {
                     .and_then(Value::as_u64)
                     .unwrap_or(DEFAULT_QUERY_TOP_K as u64)
                     .clamp(1, 20) as usize;
-                let started = Instant::now();
                 let mut store = self.store()?;
                 let store = store.as_mut().expect("MCP store initialized");
                 mcp_index::sync_memory_documents(
@@ -374,17 +372,7 @@ impl ClaudeMcp {
                     &mut *store,
                 )?;
                 let results = store.query(query, top_k)?;
-                let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
-                let diagnostics = store.inspection();
-                let payload = json!({
-                    "query": query,
-                    "top_k": top_k,
-                    "root": self.root,
-                    "docs_count": store.source_documents().len(),
-                    "results": results,
-                    "timings_ms": { "total_ms": elapsed_ms },
-                    "diagnostics": diagnostics,
-                });
+                let payload = mcp_tools::search_results(&store, results);
                 Ok(JsonRpcResponse {
                     jsonrpc: "2.0",
                     id,
@@ -541,7 +529,7 @@ impl ClaudeMcp {
             ToolDefinition {
                 name: "search".to_string(),
                 description:
-                    "Search the indexed workspace and return ranked results with diagnostics."
+                    "Search the indexed workspace and return concise, self-contained relevant memories."
                         .to_string(),
                 input_schema: json!({
                     "type": "object",
@@ -1059,9 +1047,19 @@ mod tests {
         let result = response.result.unwrap();
         let text = result["content"][0]["text"].as_str().unwrap();
         let parsed: Value = serde_json::from_str(text).unwrap();
-        assert_eq!(parsed["docs_count"].as_u64(), Some(1));
         assert_eq!(parsed["results"].as_array().unwrap().len(), 1);
-        assert_eq!(parsed["results"][0]["doc_id"].as_str(), Some("doc-1"));
+        assert_eq!(parsed["results"][0]["id"].as_str(), Some("doc-1"));
+        assert_eq!(
+            parsed["results"][0]["content"].as_str(),
+            Some("docker install guide")
+        );
+        assert_eq!(
+            parsed["results"][0]["source"].as_str(),
+            Some("docs/install.md")
+        );
+        assert!(parsed.get("diagnostics").is_none());
+        assert!(parsed.get("root").is_none());
+        assert!(parsed.get("timings_ms").is_none());
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1120,7 +1118,11 @@ mod tests {
             .unwrap()
             .to_string();
         let payload: Value = serde_json::from_str(&text).unwrap();
-        assert_eq!(payload["results"][0]["doc_id"], "memory-1");
+        assert_eq!(payload["results"][0]["id"], "memory-1");
+        assert_eq!(
+            payload["results"][0]["content"],
+            "The durable routing codename is cobalt"
+        );
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/integrations/codex/mod.rs
+++ b/src/integrations/codex/mod.rs
@@ -27,7 +27,6 @@ use std::fs;
 use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::Instant;
 use toml::map::Map as TomlMap;
 use toml::Value as TomlValue;
 
@@ -385,7 +384,6 @@ impl CodexMcp {
                     .and_then(Value::as_u64)
                     .unwrap_or(DEFAULT_QUERY_TOP_K as u64)
                     .clamp(1, 20) as usize;
-                let started = Instant::now();
                 let mut store = self.store()?;
                 let store = store.as_mut().expect("MCP store initialized");
                 mcp_index::sync_memory_documents(
@@ -393,17 +391,7 @@ impl CodexMcp {
                     &mut *store,
                 )?;
                 let results = store.query(query, top_k)?;
-                let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
-                let diagnostics = store.inspection();
-                let payload = json!({
-                    "query": query,
-                    "top_k": top_k,
-                    "root": self.root,
-                    "docs_count": store.source_documents().len(),
-                    "results": results,
-                    "timings_ms": { "total_ms": elapsed_ms },
-                    "diagnostics": diagnostics,
-                });
+                let payload = mcp_tools::search_results(&store, results);
                 Ok(JsonRpcResponse {
                     jsonrpc: "2.0",
                     id,
@@ -559,7 +547,7 @@ impl CodexMcp {
             ToolDefinition {
                 name: "search".to_string(),
                 description:
-                    "Search the indexed workspace and return ranked results with diagnostics."
+                    "Search the indexed workspace and return concise, self-contained relevant memories."
                         .to_string(),
                 input_schema: json!({
                     "type": "object",
@@ -1048,9 +1036,19 @@ args = ["old"]
         let result = response.result.unwrap();
         let text = result["content"][0]["text"].as_str().unwrap();
         let parsed: Value = serde_json::from_str(text).unwrap();
-        assert_eq!(parsed["docs_count"].as_u64(), Some(1));
         assert_eq!(parsed["results"].as_array().unwrap().len(), 1);
-        assert_eq!(parsed["results"][0]["doc_id"].as_str(), Some("doc-1"));
+        assert_eq!(parsed["results"][0]["id"].as_str(), Some("doc-1"));
+        assert_eq!(
+            parsed["results"][0]["content"].as_str(),
+            Some("docker install guide")
+        );
+        assert_eq!(
+            parsed["results"][0]["source"].as_str(),
+            Some("docs/install.md")
+        );
+        assert!(parsed.get("diagnostics").is_none());
+        assert!(parsed.get("root").is_none());
+        assert!(parsed.get("timings_ms").is_none());
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1109,7 +1107,11 @@ args = ["old"]
             .unwrap()
             .to_string();
         let payload: Value = serde_json::from_str(&text).unwrap();
-        assert_eq!(payload["results"][0]["doc_id"], "memory-1");
+        assert_eq!(payload["results"][0]["id"], "memory-1");
+        assert_eq!(
+            payload["results"][0]["content"],
+            "The durable routing codename is cobalt"
+        );
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/integrations/codex/mod.rs
+++ b/src/integrations/codex/mod.rs
@@ -157,7 +157,7 @@ const POLICY_START: &str = "<!-- lint-ai:memory-policy:start -->";
 const POLICY_END: &str = "<!-- lint-ai:memory-policy:end -->";
 
 /// Writes the memory policy into the project's `AGENTS.md`, which is what Codex
-/// reads for standing instructions — the counterpart to the skill file the Claude
+/// reads for standing instructions, the counterpart to the skill file the Claude
 /// installer writes. Without it the hooks record a project the agent is never told
 /// to consult.
 ///

--- a/src/integrations/mcp_index.rs
+++ b/src/integrations/mcp_index.rs
@@ -93,8 +93,8 @@ fn workspace_state(root: &Path, ignore_paths: &[String]) -> Option<Value> {
     let mut ignore_paths = ignore_paths.to_vec();
     ignore_paths.sort();
     let revision = git_output(root, &["rev-parse", "HEAD"]);
-    let status = git_output(root, &["status", "--porcelain=v1", "--untracked-files=all"])
-        .map(|status| {
+    let status =
+        git_output(root, &["status", "--porcelain=v1", "--untracked-files=all"]).map(|status| {
             status
                 .lines()
                 .filter(|line| !line.contains(".lint-ai/"))

--- a/src/integrations/mcp_tools.rs
+++ b/src/integrations/mcp_tools.rs
@@ -1,7 +1,29 @@
+use crate::index::SearchResult;
 use crate::integrations::mcp_transport::ToolDefinition;
 use crate::pipeline::IndexStore;
 use crate::source::SourceDocument;
 use serde_json::{json, Value};
+
+/// Format retrieval hits for an agent. Keep this separate from the internal
+/// ranking representation: diagnostics and score components are useful while
+/// tuning the index, but distract an agent from the memory itself.
+pub(crate) fn search_results(store: &IndexStore, results: Vec<SearchResult>) -> Value {
+    let results = results
+        .into_iter()
+        .filter_map(|result| {
+            let document = store.source_document_by_id(&result.doc_id)?;
+            Some(json!({
+                "id": result.doc_id,
+                "source": result.source,
+                "content": document.content.chars().take(4_000).collect::<String>(),
+                "score": result.score,
+                "matched_terms": result.matched_terms,
+                "matched_entities": result.matched_entities,
+            }))
+        })
+        .collect::<Vec<_>>();
+    json!({"results": results})
+}
 
 /// Return a bounded, provider-neutral view of the indexed memories.
 pub(crate) fn list_memories(store: &IndexStore, limit: usize) -> Value {

--- a/src/integrations/mcp_tools.rs
+++ b/src/integrations/mcp_tools.rs
@@ -19,6 +19,10 @@ pub(crate) fn search_results(store: &IndexStore, results: Vec<SearchResult>) -> 
                 "score": result.score,
                 "matched_terms": result.matched_terms,
                 "matched_entities": result.matched_entities,
+                "semantic_status": result.semantic_status,
+                "superseded_by": result.superseded_by,
+                "relation_confidence": result.relation_confidence,
+                "relation_evidence": result.relation_evidence,
             }))
         })
         .collect::<Vec<_>>();

--- a/src/integrations/recall.rs
+++ b/src/integrations/recall.rs
@@ -77,7 +77,7 @@ pub struct RecallHit {
     /// Documents keep their repo-relative path here; the dispatcher rewrites
     /// relative paths against the worker's base path, so they are never
     /// absolutised on this side. A memory is not a file, so it carries the
-    /// corpus it lives in — the dispatcher turns that into a real absolute path
+    /// corpus it lives in. The dispatcher turns that into a real absolute path
     /// too, which is what a reader on another machine can act on.
     pub doc_id: String,
     pub source: String,
@@ -100,6 +100,14 @@ pub struct RecallHit {
     pub document_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub semantic_status: Option<crate::semantic_relations::SemanticStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relation_confidence: Option<f32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub relation_evidence: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -123,7 +131,7 @@ pub struct RecallChunk {
     pub truncated: bool,
 }
 
-/// Query the unified store — project documents and recorded memories together —
+/// Query the unified store, including project documents and recorded memories,
 /// and return chunk-level hits.
 pub fn recall(options: &RecallOptions<'_>) -> Result<RecallOutput> {
     let started = Instant::now();
@@ -349,6 +357,10 @@ fn hit_from(result: &SearchResult, record: &DocRecord, query: &str) -> RecallHit
         revision: filter("revision"),
         document_type: filter("document_type"),
         timestamp: record.timestamp.clone(),
+        semantic_status: result.semantic_status,
+        superseded_by: result.superseded_by.clone(),
+        relation_confidence: result.relation_confidence,
+        relation_evidence: result.relation_evidence.clone(),
     }
 }
 
@@ -412,7 +424,7 @@ fn chunk_score(chunk: &SectionChunk, terms: &HashSet<String>) -> usize {
 
 /// Take a contiguous run of lines that fits the byte cap, centred on the
 /// densest match, and report the line numbers that run really occupies.
-/// The recorder writes a machine header above what it concluded — the agent
+/// The recorder writes a machine header above what it concluded. The agent
 /// that wrote the memory and the type of the record. An excerpt that opens on
 /// those lines spends its budget saying nothing, so leading header lines are
 /// dropped when they carry none of what was asked about. The reported range
@@ -648,6 +660,10 @@ mod tests {
             filters,
             probable_topic: None,
             doc_type_guess: None,
+            semantic_status: None,
+            superseded_by: None,
+            relation_confidence: None,
+            relation_evidence: vec![],
             headings: Vec::new(),
             doc_links: Vec::new(),
             temporal_terms: Vec::new(),
@@ -671,6 +687,10 @@ mod tests {
             matched_terms: matched_terms.iter().map(|t| t.to_string()).collect(),
             probable_topic: None,
             doc_type_guess: None,
+            semantic_status: None,
+            superseded_by: None,
+            relation_confidence: None,
+            relation_evidence: Vec::new(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Lint AI — semantic linting for Markdown documentation and related semantic graphs.
+//! Lint AI: semantic linting for Markdown documentation and related semantic graphs.
 //!
 //! This crate provides the core pipeline for building a concept inventory from
 //! a Markdown corpus, matching mentions, building symbol and ownership graphs,
@@ -47,6 +47,7 @@ pub mod report;
 pub mod review;
 pub mod rules;
 pub mod segments;
+pub mod semantic_relations;
 pub mod source;
 pub mod symbols;
 pub mod temporal;
@@ -75,6 +76,10 @@ pub use crate::review::{
     DocumentSummary, OwnershipSummary, ReviewCategory, ReviewContext, ReviewDiff,
     ReviewDiffSummary, ReviewEvidence, ReviewFileChange, ReviewFinding, ReviewHunk, ReviewPacket,
     ReviewRepoRef, ReviewSeverity, ReviewUsageSummary, SymbolSummary,
+};
+pub use crate::semantic_relations::{
+    DocumentSemanticState, SemanticClaim, SemanticRelation, SemanticRelationKind,
+    SemanticRelationStore, SemanticStatus, SupersessionOptions,
 };
 pub use crate::source::SourceDocument;
 pub use crate::symbols::{

--- a/src/memory_api.rs
+++ b/src/memory_api.rs
@@ -200,8 +200,7 @@ impl MemoryService {
         let mut filters = BTreeMap::new();
         filters.insert(USER_FILTER.to_string(), request.user_id.clone());
         let prepared = PreparedQuery::new(&request.query);
-        self.store
-            .query_prepared_cached(&prepared, top_k, &filters)
+        self.store.query_prepared_cached(&prepared, top_k, &filters)
     }
 
     fn format_search_response(&self, results: Vec<crate::SearchResult>) -> SearchResponse {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -4,10 +4,13 @@ use crate::chunking::{
 use crate::claim_extractor::{ClaimExtractor, ConservativeClaimExtractor};
 use crate::index::{
     build_semantic_doc_state, DocRecord, MemoryIndex, Provenance, QueryDiagnostics, QueryTimings,
-    SearchResult, SemanticAggregate, SemanticDocState,
+    SearchResult, SemanticAggregate, SemanticDocState, TemporalQueryContext,
 };
 use crate::query_plan::PreparedQuery;
 use crate::segments::{SegmentRoutingStrategy, SegmentedMemoryIndex};
+use crate::semantic_relations::{
+    is_historical_query, SemanticRelationStore, SemanticStatus, SupersessionOptions,
+};
 use crate::source::SourceDocument;
 use crate::temporal::extract_temporal_terms;
 use crate::temporal_fact::TemporalFactStore;
@@ -17,7 +20,6 @@ use crate::tier1::{
     TextRankStyleTermRanker, Tier1DocInput, YakeStyleTermRanker,
 };
 use anyhow::Result;
-use std::time::Duration;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -28,6 +30,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::sync::Mutex;
 use std::thread;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
@@ -87,6 +90,7 @@ pub struct PipelineOptions {
     pub text_rerank_ngram: bool,
     pub text_rerank_lcs: bool,
     pub claim_extraction: bool,
+    pub supersession: SupersessionOptions,
     pub index_location: IndexLocation,
     pub memory_index_layout: MemoryIndexLayout,
 }
@@ -105,6 +109,7 @@ impl Default for PipelineOptions {
             text_rerank_ngram: false,
             text_rerank_lcs: false,
             claim_extraction: false,
+            supersession: SupersessionOptions::default(),
             index_location: IndexLocation::InMemory,
             memory_index_layout: MemoryIndexLayout::Single,
         }
@@ -335,7 +340,7 @@ pub fn resolve_store_paths(
 /// Opaque byte buffers produced by `IndexStore::dump()` and consumed by
 /// `IndexStore::load_from_dump()`. Intended for storage in an external system
 /// (e.g. Postgres `BYTEA` / `JSONB` columns). Callers should treat the contents
-/// as opaque — the schema version embedded in `records_json` guards against
+/// as opaque. The schema version embedded in `records_json` guards against
 /// version mismatches on restore.
 #[derive(Debug, Clone)]
 pub struct IndexDump {
@@ -355,6 +360,7 @@ pub struct IndexStore {
     chunk_lifecycle: HashMap<String, ChunkLifecycleMeta>,
     chunk_latest_by_lineage: HashMap<String, String>,
     temporal_facts: TemporalFactStore,
+    semantic_relations: SemanticRelationStore,
     dirty_docs: HashSet<String>,
     tombstones: HashSet<String>,
     lexical: LexicalState,
@@ -454,6 +460,8 @@ impl IndexStore {
         let mut semantic_aggregate = SemanticAggregate::default();
         let mut chunk_latest_by_lineage = HashMap::new();
         let temporal_facts = TemporalFactStore::from_records(records.values(), &chunk_lifecycle);
+        let semantic_relations =
+            SemanticRelationStore::try_from_documents(source_docs.values(), options.supersession)?;
         for record in records.values() {
             let state = build_semantic_doc_state(record, options.claim_extraction);
             semantic_aggregate.insert_doc_state(&state);
@@ -477,6 +485,7 @@ impl IndexStore {
             chunk_lifecycle,
             chunk_latest_by_lineage,
             temporal_facts,
+            semantic_relations,
             dirty_docs: HashSet::new(),
             tombstones: HashSet::new(),
             lexical,
@@ -590,6 +599,8 @@ impl IndexStore {
             .map(|m| (m.lineage_key.clone(), m.chunk_id.clone()))
             .collect();
         let temporal_facts = TemporalFactStore::from_records(records.values(), &chunk_lifecycle);
+        let semantic_relations =
+            SemanticRelationStore::try_from_documents(source_docs.values(), options.supersession)?;
         let mut semantic_docs = HashMap::new();
         let mut semantic_aggregate = SemanticAggregate::default();
         for record in records.values() {
@@ -618,6 +629,7 @@ impl IndexStore {
             chunk_lifecycle,
             chunk_latest_by_lineage,
             temporal_facts,
+            semantic_relations,
             dirty_docs: HashSet::new(),
             tombstones: HashSet::new(),
             lexical,
@@ -763,6 +775,14 @@ impl IndexStore {
 
     pub fn temporal_facts(&self) -> Vec<&crate::temporal_fact::TemporalFact> {
         self.temporal_facts.facts().iter().collect::<Vec<_>>()
+    }
+
+    pub fn semantic_claims(&self) -> &[crate::semantic_relations::SemanticClaim] {
+        self.semantic_relations.claims()
+    }
+
+    pub fn semantic_relations(&self) -> &[crate::semantic_relations::SemanticRelation] {
+        self.semantic_relations.relations()
     }
 
     pub fn temporal_facts_as_of(&self, date: &str) -> Vec<&crate::temporal_fact::TemporalFact> {
@@ -917,11 +937,16 @@ impl IndexStore {
 
     pub fn query(&mut self, query: &str, top_k: usize) -> Result<Vec<SearchResult>> {
         self.refresh()?;
+        let allowed = self.semantic_allowed_doc_ids(query);
+        let context = TemporalQueryContext {
+            allowed_doc_ids: allowed.as_ref(),
+            ..TemporalQueryContext::default()
+        };
         let snapshot = self
             .snapshot
             .as_ref()
             .expect("snapshot should exist after refresh");
-        Ok(match (snapshot, &self.options.memory_index_layout) {
+        let results = match (snapshot, &self.options.memory_index_layout) {
             (
                 MemoryIndexSnapshot::Segmented(index),
                 MemoryIndexLayout::Segmented {
@@ -930,16 +955,23 @@ impl IndexStore {
                 },
             ) => {
                 index
-                    .query_with_diagnostics_and_strategy(
+                    .query_with_temporal_context_and_diagnostics_and_strategy(
                         query,
                         top_k,
                         (*query_top_n).max(1),
                         *routing_strategy,
+                        context,
                     )
                     .results
             }
-            _ => self.query_fresh(query, top_k)?,
-        })
+            _ => {
+                snapshot
+                    .global_index()
+                    .query_with_temporal_context(query, top_k, context)
+                    .0
+            }
+        };
+        Ok(self.annotate_semantic_results(query, results, top_k))
     }
 
     // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
@@ -952,19 +984,29 @@ impl IndexStore {
         let refresh_start = std::time::Instant::now();
         self.refresh()?;
         let refresh_ms = refresh_start.elapsed().as_secs_f64() * 1000.0;
-        let (results, mut timings, diagnostics) = self
+        let index = self
             .snapshot
             .as_ref()
             .expect("snapshot should exist after refresh")
-            .global_index()
-            .query_timed(query, top_k);
+            .global_index();
+        let allowed = self.semantic_allowed_doc_ids(query);
+        let context = TemporalQueryContext {
+            allowed_doc_ids: allowed.as_ref(),
+            ..TemporalQueryContext::default()
+        };
+        let (results, mut timings, diagnostics) =
+            index.query_with_temporal_context(query, top_k, context);
         timings.refresh_ms = refresh_ms;
         timings.total_ms += refresh_ms;
-        Ok((results, timings, diagnostics))
+        Ok((
+            self.annotate_semantic_results(query, results, top_k),
+            timings,
+            diagnostics,
+        ))
     }
 
-    /// Searches with the full query treatment the CLI gets — intent inference
-    /// and query augmentation via [`PreparedQuery`] — optionally scoped to the
+    /// Searches with the full query treatment the CLI gets, including intent inference
+    /// and query augmentation via [`PreparedQuery`], optionally scoped to the
     /// documents matching `filters`.
     ///
     /// Prefer this over [`IndexStore::query_filtered`] for any caller handling
@@ -981,12 +1023,16 @@ impl IndexStore {
             .as_ref()
             .expect("snapshot should exist after refresh")
             .global_index();
-        let allowed = index.doc_ids_matching_filters(filters);
+        let allowed = intersect_doc_id_filters(
+            index.doc_ids_matching_filters(filters),
+            self.semantic_allowed_doc_ids(prepared.search_query()),
+        );
         let mut context = prepared.temporal_context();
         context.allowed_doc_ids = allowed.as_ref();
-        Ok(index
+        let results = index
             .query_with_temporal_context(prepared.search_query(), top_k, context)
-            .0)
+            .0;
+        Ok(self.annotate_semantic_results(prepared.search_query(), results, top_k))
     }
 
     /// Query the current immutable snapshot without attempting a refresh.
@@ -1002,12 +1048,16 @@ impl IndexStore {
             return Ok(Vec::new());
         };
         let index = snapshot.global_index();
-        let allowed = index.doc_ids_matching_filters(filters);
+        let allowed = intersect_doc_id_filters(
+            index.doc_ids_matching_filters(filters),
+            self.semantic_allowed_doc_ids(prepared.search_query()),
+        );
         let mut context = prepared.temporal_context();
         context.allowed_doc_ids = allowed.as_ref();
-        Ok(index
+        let results = index
             .query_with_temporal_context(prepared.search_query(), top_k, context)
-            .0)
+            .0;
+        Ok(self.annotate_semantic_results(prepared.search_query(), results, top_k))
     }
 
     // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
@@ -1019,19 +1069,72 @@ impl IndexStore {
         filters: &std::collections::BTreeMap<String, String>,
     ) -> Result<Vec<SearchResult>> {
         self.refresh()?;
-        let lexical_hits = self
-            .lexical
-            .search(query, top_k.saturating_mul(5).max(20))?;
-        Ok(self
+        let index = self
             .snapshot
             .as_ref()
             .expect("snapshot should exist after refresh")
-            .global_index()
-            .query_with_filters_and_lexical(query, top_k, filters, Some(&lexical_hits)))
+            .global_index();
+        let allowed = intersect_doc_id_filters(
+            index.doc_ids_matching_filters(filters),
+            self.semantic_allowed_doc_ids(query),
+        );
+        let context = TemporalQueryContext {
+            allowed_doc_ids: allowed.as_ref(),
+            ..TemporalQueryContext::default()
+        };
+        let results = index.query_with_temporal_context(query, top_k, context).0;
+        Ok(self.annotate_semantic_results(query, results, top_k))
+    }
+
+    fn semantic_allowed_doc_ids(&self, query: &str) -> Option<HashSet<String>> {
+        if is_historical_query(query) {
+            return None;
+        }
+
+        let has_superseded = self.source_docs.keys().any(|doc_id| {
+            self.semantic_relations.document_state(doc_id).status
+                == Some(SemanticStatus::Superseded)
+        });
+        has_superseded.then(|| {
+            self.source_docs
+                .keys()
+                .filter(|doc_id| {
+                    self.semantic_relations.document_state(doc_id).status
+                        != Some(SemanticStatus::Superseded)
+                })
+                .cloned()
+                .collect()
+        })
+    }
+
+    fn annotate_semantic_results(
+        &self,
+        query: &str,
+        results: Vec<SearchResult>,
+        top_k: usize,
+    ) -> Vec<SearchResult> {
+        let historical = is_historical_query(query);
+        results
+            .into_iter()
+            .map(|mut result| {
+                let state = self.semantic_relations.document_state(&result.doc_id);
+                result.semantic_status =
+                    if historical && state.status == Some(SemanticStatus::Superseded) {
+                        Some(SemanticStatus::Historical)
+                    } else {
+                        state.status
+                    };
+                result.superseded_by = state.superseded_by;
+                result.relation_confidence = state.relation_confidence;
+                result.relation_evidence = state.evidence;
+                result
+            })
+            .take(top_k)
+            .collect()
     }
 
     /// Multi-term variant: builds the allowed-doc set once from `filters`, then scores every
-    /// query. BM25 (tantivy) is still called once per term — that can't be collapsed — but the
+    /// query. BM25 (tantivy) is still called once per term. That cannot be collapsed, but the
     /// filter scan over all docs happens only once regardless of how many queries are given.
     /// Returns one `Vec<SearchResult>` per input query, in the same order.
     // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
@@ -1043,17 +1146,27 @@ impl IndexStore {
         filters: &std::collections::BTreeMap<String, String>,
     ) -> Result<Vec<Vec<SearchResult>>> {
         self.refresh()?;
-        let candidate_k = top_k.saturating_mul(5).max(20);
-        let mut lexical_hits_per_query = Vec::with_capacity(queries.len());
-        for q in queries {
-            lexical_hits_per_query.push(self.lexical.search(q, candidate_k)?);
-        }
-        Ok(self
+        let index = self
             .snapshot
             .as_ref()
             .expect("snapshot should exist after refresh")
-            .global_index()
-            .query_with_filters_multi(queries, top_k, filters, &lexical_hits_per_query))
+            .global_index();
+        let filter_allowed = index.doc_ids_matching_filters(filters);
+        queries
+            .iter()
+            .map(|query| {
+                let query_allowed = intersect_doc_id_filters(
+                    filter_allowed.clone(),
+                    self.semantic_allowed_doc_ids(query),
+                );
+                let context = TemporalQueryContext {
+                    allowed_doc_ids: query_allowed.as_ref(),
+                    ..TemporalQueryContext::default()
+                };
+                let results = index.query_with_temporal_context(query, top_k, context).0;
+                Ok(self.annotate_semantic_results(query, results, top_k))
+            })
+            .collect()
     }
 
     fn prepare_pending_changes(&mut self) -> Result<()> {
@@ -1084,6 +1197,10 @@ impl IndexStore {
         }
         self.temporal_facts =
             TemporalFactStore::from_records(self.records.values(), &self.chunk_lifecycle);
+        self.semantic_relations = SemanticRelationStore::try_from_documents(
+            self.source_docs.values(),
+            self.options.supersession,
+        )?;
         let lexical_upserts = if self.snapshot.is_none() && self.snapshot_revision == 0 {
             self.records
                 .iter()
@@ -1871,6 +1988,17 @@ pub fn source_documents_to_tier1_inputs(docs: &[SourceDocument]) -> Vec<Tier1Doc
         .collect()
 }
 
+fn intersect_doc_id_filters(
+    left: Option<HashSet<String>>,
+    right: Option<HashSet<String>>,
+) -> Option<HashSet<String>> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.intersection(&right).cloned().collect()),
+        (Some(allowed), None) | (None, Some(allowed)) => Some(allowed),
+        (None, None) => None,
+    }
+}
+
 fn build_doc_records(
     source_docs: &[SourceDocument],
     options: &PipelineOptions,
@@ -2110,6 +2238,7 @@ pub fn build_query_snapshot_from_source_documents(
         text_rerank_ngram,
         text_rerank_lcs,
         claim_extraction: false,
+        supersession: crate::semantic_relations::SupersessionOptions::default(),
         index_location: IndexLocation::InMemory,
         memory_index_layout: MemoryIndexLayout::Single,
     };
@@ -2216,6 +2345,36 @@ mod tests {
         );
         assert!(
             results[0].score_breakdown.recency_score > results[1].score_breakdown.recency_score
+        );
+    }
+
+    #[test]
+    fn query_prefers_current_markdown_guidance_when_wording_changes() {
+        let today = chrono::DateTime::<chrono::Utc>::from(SystemTime::now()).date_naive();
+        let mut old = sample_doc(
+            "ownership-history",
+            "The national structure assigned valve control to the National Park POD. This was the prior owner assignment.",
+        );
+        old.timestamp = Some(format!("{}T12:00:00Z", today - chrono::Duration::days(180)));
+
+        let mut current = sample_doc(
+            "ownership-current",
+            "Current domain responsibility: the Controls POD owns valve control. Effective today, use the Controls POD for this work.",
+        );
+        current.timestamp = Some(format!("{today}T12:00:00Z"));
+
+        let index = build_query_snapshot(&[old, current], &PipelineOptions::default())
+            .expect("Markdown-like ownership guidance should build");
+        let results = index.query("who is responsible for valve control", 2);
+
+        assert_eq!(
+            results.first().map(|result| result.doc_id.as_str()),
+            Some("ownership-current"),
+            "current guidance should outrank the older, still-relevant wording: {results:?}"
+        );
+        assert!(
+            results[0].score_breakdown.recency_score > results[1].score_breakdown.recency_score,
+            "current guidance should receive the stronger temporal signal: {results:?}"
         );
     }
 
@@ -2556,6 +2715,78 @@ mod tests {
         assert!(result.is_err());
 
         let _ = fs::remove_dir_all(index_root);
+    }
+
+    #[test]
+    fn reveals_bug_invalid_supersession_thresholds_are_silently_accepted() {
+        let index_root = unique_temp_dir("invalid-supersession-options");
+        let options = PipelineOptions {
+            supersession: SupersessionOptions {
+                suppress_confidence: 1.2,
+                ..SupersessionOptions::default()
+            },
+            ..PipelineOptions::default()
+        };
+
+        let result = IndexStore::at_path(&index_root, options);
+
+        match result {
+            Ok(store) => {
+                drop(store);
+                panic!("invalid supersession thresholds must fail IndexStore construction");
+            }
+            Err(error) => assert!(
+                error
+                    .to_string()
+                    .contains("confidence thresholds must be between 0 and 1"),
+                "constructor should report the invalid threshold clearly: {error}"
+            ),
+        }
+
+        let _ = fs::remove_dir_all(index_root);
+    }
+
+    #[test]
+    fn reveals_bug_fixed_candidate_window_returns_fewer_than_top_k_current_results() {
+        let mut index = IndexStore::new(PipelineOptions::default());
+
+        for i in 0..20 {
+            let old_id = format!("old-{i}");
+            let mut old = sample_doc(&old_id, "needle highrank highrank");
+            old.filters.insert("semantic_scope".into(), "test".into());
+            index.upsert(old);
+
+            let replacement_id = format!("replacement-{i}");
+            let mut replacement = sample_doc(&replacement_id, "replacement guidance");
+            replacement
+                .filters
+                .insert("semantic_scope".into(), "test".into());
+            replacement.filters.insert("supersedes_id".into(), old_id);
+            index.upsert(replacement);
+        }
+
+        for i in 0..3 {
+            let mut current = sample_doc(&format!("current-{i}"), "needle");
+            current
+                .filters
+                .insert("semantic_scope".into(), "test".into());
+            index.upsert(current);
+        }
+
+        let results = index
+            .query("needle highrank", 3)
+            .expect("query should succeed");
+        assert_eq!(
+            results.len(),
+            3,
+            "eligible current results should fill top_k before ranking"
+        );
+        assert!(
+            results
+                .iter()
+                .all(|result| result.doc_id.starts_with("current-")),
+            "superseded documents must not consume candidate slots: {results:?}"
+        );
     }
 
     #[test]

--- a/src/query_plan.rs
+++ b/src/query_plan.rs
@@ -3,7 +3,7 @@
 //! Turning a raw user query into "what we actually search for" has two parts:
 //! analyzing the query (intent, temporal hints, augmentation) and turning that
 //! analysis into a [`TemporalQueryContext`]. Every caller that accepts a raw
-//! query from a user — the CLI, the memory server — should go through here, so
+//! query from a user. The CLI and memory server should go through here, so
 //! the two cannot drift apart.
 //!
 //! Callers that have already built a context, or that deliberately want the

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -3929,6 +3929,10 @@ mod tests {
             matched_terms: Vec::new(),
             probable_topic: None,
             doc_type_guess: None,
+            semantic_status: None,
+            superseded_by: None,
+            relation_confidence: None,
+            relation_evidence: vec![],
         }
     }
 

--- a/src/semantic_relations.rs
+++ b/src/semantic_relations.rs
@@ -1,0 +1,1006 @@
+use crate::source::SourceDocument;
+use crate::temporal::parse_temporal_date;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct SupersessionOptions {
+    pub enabled: bool,
+    pub suppress_confidence: f32,
+    pub conflict_confidence: f32,
+}
+
+impl Default for SupersessionOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            suppress_confidence: 0.90,
+            conflict_confidence: 0.65,
+        }
+    }
+}
+
+impl SupersessionOptions {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if !(0.0..=1.0).contains(&self.conflict_confidence)
+            || !(0.0..=1.0).contains(&self.suppress_confidence)
+        {
+            anyhow::bail!("semantic relationship confidence thresholds must be between 0 and 1");
+        }
+        if self.conflict_confidence > self.suppress_confidence {
+            anyhow::bail!("conflict confidence must not exceed suppress confidence");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SemanticRelationKind {
+    Supersedes,
+    ConflictsWith,
+    Confirms,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SemanticStatus {
+    Current,
+    Superseded,
+    Conflicted,
+    Historical,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SemanticClaim {
+    pub claim_id: String,
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+    pub source_doc_id: String,
+    pub evidence: String,
+    pub effective_at: Option<String>,
+    pub scope: String,
+    pub confidence: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SemanticRelation {
+    pub relation_id: String,
+    pub kind: SemanticRelationKind,
+    /// The newer or confirming claim.
+    pub source_claim_id: String,
+    /// The older or conflicting claim.
+    pub target_claim_id: String,
+    pub source_doc_id: String,
+    pub target_doc_id: String,
+    pub confidence: f32,
+    pub method: String,
+    pub evidence: Vec<String>,
+    pub scope: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DocumentSemanticState {
+    pub status: Option<SemanticStatus>,
+    pub superseded_by: Option<String>,
+    pub relation_confidence: Option<f32>,
+    pub evidence: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SemanticRelationStore {
+    claims: Vec<SemanticClaim>,
+    relations: Vec<SemanticRelation>,
+    document_states: HashMap<String, DocumentSemanticState>,
+}
+
+impl SemanticRelationStore {
+    pub fn from_documents<'a, I>(documents: I, options: SupersessionOptions) -> Self
+    where
+        I: IntoIterator<Item = &'a SourceDocument>,
+    {
+        Self::try_from_documents(documents, options).expect("invalid semantic supersession options")
+    }
+
+    pub fn try_from_documents<'a, I>(
+        documents: I,
+        options: SupersessionOptions,
+    ) -> anyhow::Result<Self>
+    where
+        I: IntoIterator<Item = &'a SourceDocument>,
+    {
+        if !options.enabled {
+            return Ok(Self::default());
+        }
+        options.validate()?;
+
+        let documents = documents.into_iter().collect::<Vec<_>>();
+        let by_id = documents
+            .iter()
+            .map(|doc| (doc.doc_id.as_str(), *doc))
+            .collect::<HashMap<_, _>>();
+        let mut claims = documents
+            .iter()
+            .flat_map(|doc| extract_claims(doc))
+            .collect::<Vec<_>>();
+        claims.sort_by(|a, b| {
+            claim_date(a)
+                .cmp(&claim_date(b))
+                .then_with(|| a.source_doc_id.cmp(&b.source_doc_id))
+                .then_with(|| a.claim_id.cmp(&b.claim_id))
+        });
+        let claim_by_id = claims
+            .iter()
+            .map(|claim| (claim.claim_id.clone(), claim.clone()))
+            .collect::<HashMap<_, _>>();
+
+        let mut relations = Vec::new();
+        let mut seen_relations = HashSet::new();
+
+        // Explicit links are authoritative evidence, regardless of source type.
+        for doc in &documents {
+            let Some(target_id) = doc.filters.get("supersedes_id") else {
+                continue;
+            };
+            let Some(target) = by_id.get(target_id.as_str()) else {
+                continue;
+            };
+            if semantic_scope(doc) != semantic_scope(target) {
+                continue;
+            }
+            let source_claim = claims
+                .iter()
+                .find(|claim| claim.source_doc_id == doc.doc_id)
+                .cloned()
+                .unwrap_or_else(|| document_claim(doc));
+            let target_claim = claims
+                .iter()
+                .find(|claim| claim.source_doc_id == target.doc_id)
+                .cloned()
+                .unwrap_or_else(|| document_claim(target));
+            push_relation(
+                &mut relations,
+                &mut seen_relations,
+                &source_claim,
+                &target_claim,
+                SemanticRelationKind::Supersedes,
+                1.0,
+                "explicit",
+                vec![format!(
+                    "{} explicitly supersedes {}",
+                    doc.doc_id, target.doc_id
+                )],
+            );
+        }
+
+        let mut latest_by_key = HashMap::<(String, String, String), String>::new();
+        for claim in &claims {
+            let key = (
+                claim.scope.clone(),
+                normalize(&claim.subject),
+                normalize(&claim.predicate),
+            );
+            if let Some(previous_id) = latest_by_key.get(&key) {
+                let Some(previous) = claim_by_id.get(previous_id) else {
+                    continue;
+                };
+                if previous.source_doc_id == claim.source_doc_id {
+                    latest_by_key.insert(key, claim.claim_id.clone());
+                    continue;
+                }
+                if normalize(&previous.object) == normalize(&claim.object) {
+                    push_relation(
+                        &mut relations,
+                        &mut seen_relations,
+                        claim,
+                        previous,
+                        SemanticRelationKind::Confirms,
+                        0.95,
+                        "canonical_claim",
+                        vec!["same canonical claim and value".to_string()],
+                    );
+                } else {
+                    let source_doc = by_id.get(claim.source_doc_id.as_str()).copied();
+                    let target_doc = by_id.get(previous.source_doc_id.as_str()).copied();
+                    let direct_correction =
+                        source_doc.is_some_and(|doc| has_correction_cue(&doc.content));
+                    let chronological = claim_date(claim)
+                        .zip(claim_date(previous))
+                        .is_some_and(|(newer, older)| newer > older);
+                    let same_source_kind = source_doc
+                        .zip(target_doc)
+                        .is_some_and(|(source, target)| source_kind(source) == source_kind(target));
+                    let (kind, confidence, method) = if direct_correction {
+                        (SemanticRelationKind::Supersedes, 0.95, "correction_cue")
+                    } else if chronological && same_source_kind {
+                        (
+                            SemanticRelationKind::Supersedes,
+                            0.90,
+                            "canonical_claim_and_time",
+                        )
+                    } else {
+                        (
+                            SemanticRelationKind::ConflictsWith,
+                            0.75,
+                            "canonical_claim_conflict",
+                        )
+                    };
+                    push_relation(
+                        &mut relations,
+                        &mut seen_relations,
+                        claim,
+                        previous,
+                        kind,
+                        confidence,
+                        method,
+                        vec![format!(
+                            "{} changed from '{}' to '{}'",
+                            claim.subject, previous.object, claim.object
+                        )],
+                    );
+                }
+            }
+            latest_by_key.insert(key, claim.claim_id.clone());
+        }
+
+        let document_states = build_document_states(&documents, &claims, &relations, options);
+        Ok(Self {
+            claims,
+            relations,
+            document_states,
+        })
+    }
+
+    pub fn claims(&self) -> &[SemanticClaim] {
+        &self.claims
+    }
+
+    pub fn relations(&self) -> &[SemanticRelation] {
+        &self.relations
+    }
+
+    pub fn document_state(&self, doc_id: &str) -> DocumentSemanticState {
+        self.document_states
+            .get(doc_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+fn build_document_states(
+    documents: &[&SourceDocument],
+    claims: &[SemanticClaim],
+    relations: &[SemanticRelation],
+    options: SupersessionOptions,
+) -> HashMap<String, DocumentSemanticState> {
+    let mut states = documents
+        .iter()
+        .map(|doc| {
+            (
+                doc.doc_id.clone(),
+                DocumentSemanticState {
+                    status: Some(SemanticStatus::Current),
+                    ..DocumentSemanticState::default()
+                },
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    for relation in relations {
+        match relation.kind {
+            SemanticRelationKind::Supersedes
+                if relation.confidence >= options.suppress_confidence =>
+            {
+                let state = states.entry(relation.target_doc_id.clone()).or_default();
+                if relation.method != "explicit"
+                    && !document_contains_only_target_claim(documents, claims, relation)
+                {
+                    if state.status != Some(SemanticStatus::Superseded) {
+                        state.status = Some(SemanticStatus::Conflicted);
+                        state.relation_confidence = Some(relation.confidence);
+                        state.evidence = relation.evidence.clone();
+                    }
+                    continue;
+                }
+                if state.relation_confidence.unwrap_or_default() <= relation.confidence {
+                    state.status = Some(SemanticStatus::Superseded);
+                    state.superseded_by = Some(relation.source_doc_id.clone());
+                    state.relation_confidence = Some(relation.confidence);
+                    state.evidence = relation.evidence.clone();
+                }
+            }
+            SemanticRelationKind::ConflictsWith
+                if relation.confidence >= options.conflict_confidence =>
+            {
+                for doc_id in [&relation.source_doc_id, &relation.target_doc_id] {
+                    let state = states.entry(doc_id.clone()).or_default();
+                    if state.status != Some(SemanticStatus::Superseded) {
+                        state.status = Some(SemanticStatus::Conflicted);
+                        state.relation_confidence = Some(relation.confidence);
+                        state.evidence = relation.evidence.clone();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    states
+}
+
+fn document_contains_only_target_claim(
+    documents: &[&SourceDocument],
+    claims: &[SemanticClaim],
+    relation: &SemanticRelation,
+) -> bool {
+    let mut target_claims = claims
+        .iter()
+        .filter(|claim| claim.source_doc_id == relation.target_doc_id);
+    let Some(target_claim) = target_claims.next() else {
+        return false;
+    };
+    if target_claims.next().is_some() || target_claim.claim_id != relation.target_claim_id {
+        return false;
+    }
+    documents
+        .iter()
+        .find(|document| document.doc_id == relation.target_doc_id)
+        .is_some_and(|document| normalize(&document.content) == normalize(&target_claim.evidence))
+}
+
+fn push_relation(
+    relations: &mut Vec<SemanticRelation>,
+    seen: &mut HashSet<String>,
+    source: &SemanticClaim,
+    target: &SemanticClaim,
+    kind: SemanticRelationKind,
+    confidence: f32,
+    method: &str,
+    evidence: Vec<String>,
+) {
+    let relation_id = format!("{}::{:?}::{}", source.claim_id, kind, target.claim_id);
+    if !seen.insert(relation_id.clone()) {
+        return;
+    }
+    relations.push(SemanticRelation {
+        relation_id,
+        kind,
+        source_claim_id: source.claim_id.clone(),
+        target_claim_id: target.claim_id.clone(),
+        source_doc_id: source.source_doc_id.clone(),
+        target_doc_id: target.source_doc_id.clone(),
+        confidence,
+        method: method.to_string(),
+        evidence,
+        scope: source.scope.clone(),
+    });
+}
+
+fn extract_claims(doc: &SourceDocument) -> Vec<SemanticClaim> {
+    let mut claims = Vec::new();
+    for sentence in sentences(&doc.content) {
+        if let Some((subject, predicate, object)) = ownership_claim(sentence) {
+            claims.push(make_claim(
+                doc,
+                sentence,
+                &subject,
+                predicate,
+                &object,
+                claims.len(),
+            ));
+        }
+        if let Some((subject, predicate, object)) = assignment_claim(sentence) {
+            claims.push(make_claim(
+                doc,
+                sentence,
+                &subject,
+                predicate,
+                &object,
+                claims.len(),
+            ));
+        }
+        if let Some((subject, predicate, object)) = usage_claim(sentence) {
+            claims.push(make_claim(
+                doc,
+                sentence,
+                &subject,
+                predicate,
+                &object,
+                claims.len(),
+            ));
+        }
+    }
+    dedupe_claims(&mut claims);
+    claims
+}
+
+fn document_claim(doc: &SourceDocument) -> SemanticClaim {
+    make_claim(
+        doc,
+        &doc.content.chars().take(240).collect::<String>(),
+        &doc.concept,
+        "document_state",
+        &doc.doc_id,
+        0,
+    )
+}
+
+fn make_claim(
+    doc: &SourceDocument,
+    evidence: &str,
+    subject: &str,
+    predicate: &str,
+    object: &str,
+    index: usize,
+) -> SemanticClaim {
+    let subject = clean_phrase(subject);
+    let object = clean_phrase(object);
+    SemanticClaim {
+        claim_id: format!("{}::claim-{}", doc.doc_id, index),
+        subject,
+        predicate: predicate.to_string(),
+        object,
+        source_doc_id: doc.doc_id.clone(),
+        evidence: evidence.trim().to_string(),
+        effective_at: doc.timestamp.clone(),
+        scope: semantic_scope(doc),
+        confidence: 0.85,
+    }
+}
+
+fn ownership_claim(sentence: &str) -> Option<(String, &'static str, String)> {
+    static OWNS: OnceLock<Regex> = OnceLock::new();
+    static RESPONSIBLE: OnceLock<Regex> = OnceLock::new();
+    static OWNED_BY: OnceLock<Regex> = OnceLock::new();
+    let owns = OWNS.get_or_init(|| {
+        Regex::new(r"(?i)(?:^|[:;])\s*(?:the\s+)?([a-z][a-z0-9 _/-]{1,60}?)\s+owns\s+(?:the\s+)?([a-z][a-z0-9 _/-]{1,80})")
+            .expect("valid ownership regex")
+    });
+    if let Some(caps) = owns.captures(sentence) {
+        return Some((caps[2].to_string(), "owner", caps[1].to_string()));
+    }
+    let responsible = RESPONSIBLE.get_or_init(|| {
+        Regex::new(r"(?i)(?:^|[:;])\s*(?:the\s+)?([a-z][a-z0-9 _/-]{1,60}?)\s+is\s+(?:now\s+)?responsible\s+for\s+(?:the\s+)?([a-z][a-z0-9 _/-]{1,80})")
+            .expect("valid responsibility regex")
+    });
+    if let Some(caps) = responsible.captures(sentence) {
+        return Some((caps[2].to_string(), "owner", caps[1].to_string()));
+    }
+    let owned_by = OWNED_BY.get_or_init(|| {
+        Regex::new(r"(?i)(?:^|[:;])\s*(?:the\s+)?([a-z][a-z0-9 _/-]{1,80}?)\s+is\s+(?:now\s+)?owned\s+by\s+(?:the\s+)?([a-z][a-z0-9 _/-]{1,60})")
+            .expect("valid owned-by regex")
+    });
+    owned_by
+        .captures(sentence)
+        .map(|caps| (caps[1].to_string(), "owner", caps[2].to_string()))
+}
+
+fn assignment_claim(sentence: &str) -> Option<(String, &'static str, String)> {
+    static ASSIGNED: OnceLock<Regex> = OnceLock::new();
+    let assigned = ASSIGNED.get_or_init(|| {
+        Regex::new(r"(?i)assigned\s+(?:the\s+)?([a-z][a-z0-9 _/-]{1,80}?)\s+to\s+(?:the\s+)?([a-z][a-z0-9 _/-]{1,60})")
+            .expect("valid assignment regex")
+    });
+    assigned
+        .captures(sentence)
+        .map(|caps| (caps[1].to_string(), "owner", caps[2].to_string()))
+}
+
+fn usage_claim(sentence: &str) -> Option<(String, &'static str, String)> {
+    static USE_FOR: OnceLock<Regex> = OnceLock::new();
+    static USES: OnceLock<Regex> = OnceLock::new();
+    let use_for = USE_FOR.get_or_init(|| {
+        Regex::new(r"(?i)(?:use|adopt|choose|selected)\s+(?:the\s+)?([a-z][a-z0-9 _/.-]{1,60}?)\s+for\s+(?:the\s+)?([a-z][a-z0-9 _/-]{1,80})")
+            .expect("valid use-for regex")
+    });
+    if let Some(caps) = use_for.captures(sentence) {
+        return Some((caps[2].to_string(), "implementation", caps[1].to_string()));
+    }
+    let uses = USES.get_or_init(|| {
+        Regex::new(r"(?i)(?:^|[:;])\s*(?:the\s+)?([a-z][a-z0-9 _/-]{1,80}?)\s+uses\s+(?:the\s+)?([a-z][a-z0-9 _/.-]{1,60})")
+            .expect("valid uses regex")
+    });
+    uses.captures(sentence)
+        .map(|caps| (caps[1].to_string(), "implementation", caps[2].to_string()))
+}
+
+fn sentences(content: &str) -> Vec<&str> {
+    content
+        .split(|ch| matches!(ch, '\n' | '.' | '!' | '?'))
+        .map(str::trim)
+        .filter(|sentence| !sentence.is_empty())
+        .collect()
+}
+
+fn clean_phrase(value: &str) -> String {
+    let value = value
+        .trim_matches(|ch: char| ch.is_ascii_punctuation() || ch.is_whitespace())
+        .to_lowercase();
+    let value = value
+        .strip_prefix("the ")
+        .or_else(|| value.strip_prefix("current "))
+        .or_else(|| value.strip_prefix("new "))
+        .unwrap_or(&value);
+    value.trim().to_string()
+}
+
+fn normalize(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .filter(|token| !matches!(*token, "the" | "a" | "an" | "current" | "new" | "old"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn dedupe_claims(claims: &mut Vec<SemanticClaim>) {
+    let mut seen = HashSet::new();
+    claims.retain(|claim| {
+        !claim.subject.is_empty()
+            && !claim.object.is_empty()
+            && seen.insert((
+                normalize(&claim.subject),
+                claim.predicate.clone(),
+                normalize(&claim.object),
+            ))
+    });
+}
+
+fn semantic_scope(doc: &SourceDocument) -> String {
+    doc.filters
+        .get("semantic_scope")
+        .map(|scope| format!("scope:{scope}"))
+        .or_else(|| {
+            doc.filters
+                .get("memory_user_id")
+                .map(|user| format!("user:{user}"))
+        })
+        .unwrap_or_else(|| "store".to_string())
+}
+
+fn source_kind(doc: &SourceDocument) -> &'static str {
+    if doc.source.starts_with("codex://")
+        || doc.source.starts_with("claude://")
+        || doc.source.starts_with("claude-code://")
+        || doc.source.starts_with("gemini-cli://")
+        || doc.source.starts_with("agy://")
+        || doc.source.starts_with("lint-ai://")
+        || doc.filters.contains_key("document_type")
+    {
+        "memory"
+    } else {
+        "document"
+    }
+}
+
+fn has_correction_cue(content: &str) -> bool {
+    let lower = content.to_lowercase();
+    [
+        "supersedes",
+        "replaces",
+        "instead of",
+        "no longer",
+        "changed from",
+        "moved from",
+        "previously",
+        "formerly",
+    ]
+    .iter()
+    .any(|cue| lower.contains(cue))
+}
+
+fn claim_date(claim: &SemanticClaim) -> Option<chrono::NaiveDate> {
+    claim
+        .effective_at
+        .as_deref()
+        .and_then(|value| parse_temporal_date(Some(value)))
+}
+
+pub fn is_historical_query(query: &str) -> bool {
+    let lower = query.to_lowercase();
+    [
+        "history",
+        "historical",
+        "previous",
+        "previously",
+        "formerly",
+        "superseded",
+        "what changed",
+        "why did we change",
+        "what was true before",
+        "who owned this before",
+        "who was responsible before",
+        "before the change",
+        "before we changed",
+        "timeline",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn doc(id: &str, content: &str, timestamp: Option<&str>, source: &str) -> SourceDocument {
+        SourceDocument {
+            doc_id: id.to_string(),
+            source: source.to_string(),
+            content: content.to_string(),
+            concept: "decision".to_string(),
+            group_id: None,
+            headings: vec!["Decision".to_string()],
+            links: vec![],
+            timestamp: timestamp.map(str::to_string),
+            doc_length: content.len(),
+            author_agent: None,
+            filters: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn newer_same_kind_ownership_claim_supersedes_old_claim() {
+        let old = doc(
+            "old",
+            "The National Park POD owns valve control.",
+            Some("2026-01-01"),
+            "docs/old.md",
+        );
+        let new = doc(
+            "new",
+            "The Controls POD owns valve control.",
+            Some("2026-06-01"),
+            "docs/new.md",
+        );
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+        assert_eq!(
+            store.document_state("old").status,
+            Some(SemanticStatus::Superseded)
+        );
+        assert_eq!(
+            store.document_state("old").superseded_by.as_deref(),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn timestamp_only_cross_source_change_is_a_visible_conflict() {
+        let old = doc(
+            "old",
+            "The National Park POD owns valve control.",
+            Some("2026-01-01"),
+            "docs/old.md",
+        );
+        let new = doc(
+            "new",
+            "The Controls POD owns valve control.",
+            Some("2026-06-01"),
+            "codex://project/session/outcome",
+        );
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+        assert_eq!(
+            store.document_state("old").status,
+            Some(SemanticStatus::Conflicted)
+        );
+        assert_eq!(
+            store.document_state("new").status,
+            Some(SemanticStatus::Conflicted)
+        );
+    }
+
+    #[test]
+    fn explicit_supersession_respects_user_scope() {
+        let mut old = doc("old", "old decision", None, "memory://old");
+        old.filters.insert("memory_user_id".into(), "a".into());
+        let mut new = doc("new", "new decision", None, "memory://new");
+        new.filters.insert("memory_user_id".into(), "b".into());
+        new.filters.insert("supersedes_id".into(), "old".into());
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+        assert_ne!(
+            store.document_state("old").status,
+            Some(SemanticStatus::Superseded)
+        );
+    }
+
+    #[test]
+    fn explicit_supersession_without_extractable_claims_is_authoritative() {
+        let old = doc(
+            "old",
+            "Original architecture decision.",
+            None,
+            "docs/old.md",
+        );
+        let mut new = doc("new", "Updated architecture decision.", None, "docs/new.md");
+        new.filters.insert("supersedes_id".into(), "old".into());
+
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+
+        let relation = store
+            .relations()
+            .iter()
+            .find(|relation| relation.kind == SemanticRelationKind::Supersedes)
+            .expect("explicit metadata should create a supersession relation");
+        assert_eq!(relation.method, "explicit");
+        assert_eq!(relation.confidence, 1.0);
+        assert_eq!(
+            store.document_state("old").superseded_by.as_deref(),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn explicit_document_supersession_still_hides_a_multi_claim_document() {
+        let old = doc(
+            "old",
+            concat!(
+                "The Platform POD owns valve control. ",
+                "The deployment strategy uses blue-green releases."
+            ),
+            None,
+            "docs/old.md",
+        );
+        let mut new = doc("new", "Updated architecture decision.", None, "docs/new.md");
+        new.filters.insert("supersedes_id".into(), "old".into());
+
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+
+        assert_eq!(
+            store.document_state("old").status,
+            Some(SemanticStatus::Superseded)
+        );
+        assert_eq!(
+            store.document_state("old").superseded_by.as_deref(),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn correction_language_can_supersede_without_timestamps() {
+        let old = doc(
+            "a-old",
+            "The National Park POD owns valve control.",
+            None,
+            "docs/old.md",
+        );
+        let new = doc(
+            "z-new",
+            "This replaces the previous decision. The Controls POD owns valve control.",
+            None,
+            "docs/new.md",
+        );
+
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+
+        assert_eq!(
+            store.document_state("a-old").status,
+            Some(SemanticStatus::Superseded)
+        );
+        assert!(store.relations().iter().any(|relation| {
+            relation.kind == SemanticRelationKind::Supersedes && relation.method == "correction_cue"
+        }));
+    }
+
+    #[test]
+    fn changed_claim_without_time_or_correction_stays_visible_as_conflict() {
+        let old = doc(
+            "a-old",
+            "The National Park POD owns valve control.",
+            None,
+            "docs/old.md",
+        );
+        let new = doc(
+            "z-new",
+            "The Controls POD owns valve control.",
+            None,
+            "docs/new.md",
+        );
+
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+
+        assert_eq!(
+            store.document_state("a-old").status,
+            Some(SemanticStatus::Conflicted)
+        );
+        assert_eq!(
+            store.document_state("z-new").status,
+            Some(SemanticStatus::Conflicted)
+        );
+        assert!(store
+            .relations()
+            .iter()
+            .all(|relation| relation.kind != SemanticRelationKind::Supersedes));
+    }
+
+    #[test]
+    fn equivalent_wording_confirms_the_existing_claim() {
+        let first = doc(
+            "first",
+            "The Controls POD owns valve control.",
+            Some("2026-01-01"),
+            "docs/first.md",
+        );
+        let second = doc(
+            "second",
+            "Valve control is owned by the Controls POD.",
+            Some("2026-02-01"),
+            "docs/second.md",
+        );
+
+        let store = SemanticRelationStore::from_documents(
+            [&first, &second],
+            SupersessionOptions::default(),
+        );
+
+        assert!(store
+            .relations()
+            .iter()
+            .any(|relation| relation.kind == SemanticRelationKind::Confirms));
+        assert_eq!(
+            store.document_state("first").status,
+            Some(SemanticStatus::Current)
+        );
+        assert_eq!(
+            store.document_state("second").status,
+            Some(SemanticStatus::Current)
+        );
+    }
+
+    #[test]
+    fn semantic_scope_prevents_automatic_cross_project_relations() {
+        let mut old = doc(
+            "old",
+            "The National Park POD owns valve control.",
+            Some("2026-01-01"),
+            "docs/old.md",
+        );
+        old.filters
+            .insert("semantic_scope".into(), "project-a".into());
+        let mut new = doc(
+            "new",
+            "The Controls POD owns valve control.",
+            Some("2026-06-01"),
+            "docs/new.md",
+        );
+        new.filters
+            .insert("semantic_scope".into(), "project-b".into());
+
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+
+        assert!(store.relations().is_empty());
+        assert_eq!(
+            store.document_state("old").status,
+            Some(SemanticStatus::Current)
+        );
+        assert_eq!(
+            store.document_state("new").status,
+            Some(SemanticStatus::Current)
+        );
+    }
+
+    #[test]
+    fn disabled_supersession_produces_no_claims_relations_or_states() {
+        let old = doc(
+            "old",
+            "The National Park POD owns valve control.",
+            Some("2026-01-01"),
+            "docs/old.md",
+        );
+        let new = doc(
+            "new",
+            "The Controls POD owns valve control.",
+            Some("2026-06-01"),
+            "docs/new.md",
+        );
+        let options = SupersessionOptions {
+            enabled: false,
+            suppress_confidence: 1.2,
+            conflict_confidence: -0.1,
+        };
+
+        let store = SemanticRelationStore::from_documents([&old, &new], options);
+
+        assert!(store.claims().is_empty());
+        assert!(store.relations().is_empty());
+        assert_eq!(
+            store.document_state("old"),
+            DocumentSemanticState::default()
+        );
+    }
+
+    #[test]
+    fn enabled_supersession_rejects_invalid_thresholds() {
+        let document = doc(
+            "decision",
+            "The Controls POD owns valve control.",
+            None,
+            "doc.md",
+        );
+        let options = SupersessionOptions {
+            suppress_confidence: 1.2,
+            ..SupersessionOptions::default()
+        };
+
+        let error = SemanticRelationStore::try_from_documents([&document], options)
+            .expect_err("enabled supersession must reject invalid thresholds");
+
+        assert!(error
+            .to_string()
+            .contains("confidence thresholds must be between 0 and 1"));
+    }
+
+    #[test]
+    fn suppression_threshold_can_keep_detected_relation_visible() {
+        let old = doc(
+            "old",
+            "The National Park POD owns valve control.",
+            Some("2026-01-01"),
+            "docs/old.md",
+        );
+        let new = doc(
+            "new",
+            "The Controls POD owns valve control.",
+            Some("2026-06-01"),
+            "docs/new.md",
+        );
+        let options = SupersessionOptions {
+            suppress_confidence: 0.95,
+            ..SupersessionOptions::default()
+        };
+
+        let store = SemanticRelationStore::from_documents([&old, &new], options);
+
+        assert!(store
+            .relations()
+            .iter()
+            .any(|relation| relation.kind == SemanticRelationKind::Supersedes));
+        assert_eq!(
+            store.document_state("old").status,
+            Some(SemanticStatus::Current)
+        );
+    }
+
+    #[test]
+    fn historical_query_detection_covers_history_but_not_current_state() {
+        for query in [
+            "show the decision history",
+            "what changed about ownership",
+            "who owned this before",
+            "show the superseded guidance",
+            "ownership timeline",
+        ] {
+            assert!(
+                is_historical_query(query),
+                "expected historical query: {query}"
+            );
+        }
+        for query in [
+            "who owns valve control now",
+            "what must happen before deployment",
+            "validate inputs before saving",
+            "check authorization before updating status",
+        ] {
+            assert!(
+                !is_historical_query(query),
+                "expected current-state query: {query}"
+            );
+        }
+    }
+}

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -2,7 +2,7 @@
 //! (`crate::index`) and the experimental segment-routing path
 //! (`crate::segments`).
 //!
-//! The two callers intentionally use different rules — this is not
+//! The two callers intentionally use different rules. This is not
 //! duplication to collapse into one behavior. A LongMemEval-S benchmark
 //! (500 scoped queries for the primary path, 133 multi-session queries for
 //! segment routing) showed each mode is a real, measured improvement for
@@ -43,7 +43,7 @@ pub fn tokenize(input: &str, mode: TokenizerMode) -> Vec<String> {
 }
 
 /// True if `token` is a stopword under `mode`. `token` must already be
-/// tokenized/normalized under the same mode — the two stopword lists use
+/// tokenized/normalized under the same mode. The two stopword lists use
 /// different vocabularies (raw words vs. stemmed fragments) and are not
 /// interchangeable.
 pub fn is_stopword(token: &str, mode: TokenizerMode) -> bool {

--- a/tests/concurrent_mcp.rs
+++ b/tests/concurrent_mcp.rs
@@ -43,14 +43,23 @@ fn concurrent_codex_mcp_clients_initialize_and_open_shared_index() {
     let mut clients: Vec<(Child, ChildStdin, BufReader<_>)> = (0..4)
         .map(|_| {
             let mut child = Command::new(executable)
-                .args(["--codex-serve", root.to_str().expect("root should be UTF-8")])
+                .args([
+                    "--codex-serve",
+                    root.to_str().expect("root should be UTF-8"),
+                ])
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
                 .spawn()
                 .expect("Codex MCP server should start");
-            let stdin = child.stdin.take().expect("server stdin should be available");
-            let stdout = child.stdout.take().expect("server stdout should be available");
+            let stdin = child
+                .stdin
+                .take()
+                .expect("server stdin should be available");
+            let stdout = child
+                .stdout
+                .take()
+                .expect("server stdout should be available");
             (child, stdin, BufReader::new(stdout))
         })
         .collect();
@@ -77,7 +86,10 @@ fn concurrent_codex_mcp_clients_initialize_and_open_shared_index() {
     }
 
     for (_, stdin, _) in &mut clients {
-        send_request(stdin, &json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}));
+        send_request(
+            stdin,
+            &json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+        );
     }
     for (_, _, reader) in &mut clients {
         let response = read_response(reader);
@@ -156,7 +168,11 @@ fn concurrent_codex_lifecycle_hooks_record_all_events() {
     assert_eq!(events.lines().count(), 8);
     let sequences: Vec<u64> = events
         .lines()
-        .map(|line| serde_json::from_str::<Value>(line).unwrap()["sequence"].as_u64().unwrap())
+        .map(|line| {
+            serde_json::from_str::<Value>(line).unwrap()["sequence"]
+                .as_u64()
+                .unwrap()
+        })
         .collect();
     assert_eq!(sequences, (1..=8).collect::<Vec<_>>());
     fs::remove_dir_all(root).expect("temporary project should be removed");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -208,6 +208,201 @@ fn query_baseline_still_works_without_semantic_match() {
 }
 
 #[test]
+fn markdown_supersession_metadata_hides_replaced_guidance_from_default_search() {
+    let root = std::env::temp_dir().join(format!(
+        "lint_ai_temporal_markdown_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("legacy.md"),
+        "# Legacy ownership\nThe old team owns the control surface.\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("current.md"),
+        "---\nsupersedes: legacy.md\n---\n# Current ownership\nThe new team is responsible for the control surface.\n",
+    )
+    .unwrap();
+
+    let graph = Graph::build(
+        root.to_str().unwrap(),
+        MAX_BYTES,
+        MAX_FILES,
+        MAX_DEPTH,
+        MAX_TOTAL_BYTES,
+    )
+    .unwrap();
+    let documents = lint_ai::adapters::graph_to_source_documents(&graph);
+    let current = documents
+        .iter()
+        .find(|doc| doc.doc_id == "current.md")
+        .expect("current Markdown document should be indexed");
+    assert_eq!(
+        current.filters.get("supersedes_id").map(String::as_str),
+        Some("legacy.md")
+    );
+
+    let mut index =
+        lint_ai::IndexStore::with_documents(lint_ai::PipelineOptions::default(), documents);
+    let results = index
+        .query("who is responsible for the control surface", 5)
+        .unwrap();
+    assert!(
+        results.iter().all(|result| result.doc_id != "legacy.md"),
+        "replaced Markdown guidance should not be returned by default: {results:?}"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn semantic_policy_hides_automatically_superseded_documents_and_exposes_history() {
+    let documents = vec![
+        lint_ai::source::SourceDocument::with_stable_doc_id_from_source(
+            "decisions/legacy.md".to_string(),
+            "The platform team owns the control surface.".to_string(),
+            "ownership decision".to_string(),
+            None,
+            vec![],
+            vec![],
+            Some("2026-01-01".to_string()),
+            None,
+        ),
+        lint_ai::source::SourceDocument::with_stable_doc_id_from_source(
+            "decisions/current.md".to_string(),
+            "The reliability team owns the control surface.".to_string(),
+            "ownership decision".to_string(),
+            None,
+            vec![],
+            vec![],
+            Some("2026-02-01".to_string()),
+            None,
+        ),
+    ];
+    let mut index =
+        lint_ai::IndexStore::with_documents(lint_ai::PipelineOptions::default(), documents);
+
+    let current = index.query("who owns the control surface", 10).unwrap();
+    assert!(current
+        .iter()
+        .any(|result| result.source == "decisions/current.md"));
+    assert!(current
+        .iter()
+        .all(|result| result.source != "decisions/legacy.md"));
+
+    let history = index
+        .query("what changed about who owns the control surface", 10)
+        .unwrap();
+    let legacy = history
+        .iter()
+        .find(|result| result.source == "decisions/legacy.md")
+        .expect("historical query should retain the superseded source");
+    assert_eq!(
+        legacy.semantic_status,
+        Some(lint_ai::SemanticStatus::Historical)
+    );
+}
+
+#[test]
+fn reveals_bug_superseded_claim_hides_unrelated_current_content() {
+    let documents = vec![
+        lint_ai::source::SourceDocument::with_stable_doc_id_from_source(
+            "decisions/architecture.md".to_string(),
+            concat!(
+                "The platform team owns the control surface.\n",
+                "The deployment strategy uses blue-green releases."
+            )
+            .to_string(),
+            "architecture decisions".to_string(),
+            None,
+            vec![],
+            vec![],
+            Some("2026-01-01".to_string()),
+            None,
+        ),
+        lint_ai::source::SourceDocument::with_stable_doc_id_from_source(
+            "decisions/ownership-update.md".to_string(),
+            "The reliability team owns the control surface.".to_string(),
+            "ownership decision".to_string(),
+            None,
+            vec![],
+            vec![],
+            Some("2026-02-01".to_string()),
+            None,
+        ),
+    ];
+    let mut index =
+        lint_ai::IndexStore::with_documents(lint_ai::PipelineOptions::default(), documents);
+
+    let results = index.query("blue-green deployment strategy", 10).unwrap();
+
+    let architecture = results
+        .iter()
+        .find(|result| result.source == "decisions/architecture.md")
+        .unwrap_or_else(|| {
+            panic!(
+                "replacing the ownership claim must not hide the still-current deployment guidance: {results:?}"
+            )
+        });
+    assert_eq!(
+        architecture.semantic_status,
+        Some(lint_ai::SemanticStatus::Conflicted),
+        "partial inferred supersession should remain visible as a conflict"
+    );
+}
+
+#[test]
+fn reveals_bug_operational_before_query_exposes_superseded_guidance() {
+    let old = lint_ai::source::SourceDocument::with_stable_doc_id_from_source(
+        "runbooks/legacy-deployment.md".to_string(),
+        "Before deployment, operators must run the legacy smoke tests.".to_string(),
+        "legacy deployment procedure".to_string(),
+        None,
+        vec![],
+        vec![],
+        Some("2026-01-01".to_string()),
+        None,
+    );
+    let mut current = lint_ai::source::SourceDocument::with_stable_doc_id_from_source(
+        "runbooks/current-deployment.md".to_string(),
+        "Before deployment, operators must run the current safety checks.".to_string(),
+        "current deployment procedure".to_string(),
+        None,
+        vec![],
+        vec![],
+        Some("2026-02-01".to_string()),
+        None,
+    );
+    current
+        .filters
+        .insert("supersedes_id".to_string(), old.doc_id.clone());
+    let legacy_id = old.doc_id.clone();
+    let current_id = current.doc_id.clone();
+    let mut index = lint_ai::IndexStore::with_documents(
+        lint_ai::PipelineOptions::default(),
+        vec![old, current],
+    );
+
+    let results = index
+        .query("what must happen before deployment", 10)
+        .unwrap();
+
+    assert!(
+        results.iter().any(|result| result.doc_id == current_id),
+        "current deployment guidance should be returned: {results:?}"
+    );
+    assert!(
+        results.iter().all(|result| result.doc_id != legacy_id),
+        "an operational use of 'before' must not expose superseded guidance: {results:?}"
+    );
+}
+
+#[test]
 fn semantic_expansion_improves_recall_for_synonyms() {
     let index = MemoryIndex::from_records(vec![DocRecord {
         doc_id: "d2".to_string(),


### PR DESCRIPTION
## Summary
- return self-contained relevant memory content from MCP search
- remove index diagnostics, root, document counts, timings, and internal score breakdowns
- keep Codex and Claude adapters consistent

## Validation
- 
running 194 tests
test engine::tests::normalize_heading_rules ... ok
test aggregation::tests::classifies_count_and_sum_intents ... ok
test config::tests::normalize_list_trims_and_lowercases ... ok
test graph::tests::link_target_concept_parsing ... ok
test index::tests::timestamped_chunk_detects_chunk_level_temporal_anchor ... ok
test index::tests::normalize_temporal_bounds_orders_reversed_ranges_and_preserves_same_day ... ok
test graph::tests::normalize_concept_basic ... ok
test integrations::claude_code::hooks::protocol::tests::empty_context_serializes_to_empty_object ... ok
test graph::tests::parse_frontmatter_metadata ... ok
test aggregation::tests::normalizes_number_words ... ok
test claim_extractor::tests::conservative_extractor_uses_existing_claims_and_chunk_signals ... ok
test engine::tests::common_prefix ... ok
test integrations::claude_code::document::tests::claude_document_maps_to_session_source_document ... ok
test integrations::claude_code::document::tests::event_id_makes_document_id_deterministic ... ok
test integrations::claude_code::hooks::protocol::tests::parses_subagent_fields ... ok
test integrations::claude_code::hooks::protocol::tests::missing_cwd_uses_empty_fallback_path ... ok
test integrations::claude_code::hooks::protocol::tests::parses_user_prompt_expansion_fields ... ok
test integrations::claude_code::hooks::protocol::tests::parses_post_tool_use_fields ... ok
test integrations::claude_code::hooks::tests::redacts_auth_tokens_and_private_key_blocks ... ok
test integrations::claude_code::hooks::tests::empty_prompt_does_not_open_memory_store ... ok
test integrations::claude_code::hooks::tests::active_stop_hook_does_not_capture ... ok
test cli::tests::parses_recall_query_and_result_count ... ok
test cli::tests::parses_index_inspection_view ... ok
test cli::tests::parses_review_flag ... ok
test integrations::claude_code::hooks::tests::relevant_excerpt_selects_matching_lines_and_enforces_byte_limit ... ok
test integrations::claude_code::hooks::tests::session_start_does_not_create_memory_store ... ok
test index::tests::text_overlap_prefers_matching_candidate ... ok
test integrations::claude_code::hooks::tests::transcript_extraction_ignores_tool_blocks_and_redacts_secret_lines ... ok
test integrations::claude_code::hooks::tests::disabled_memory_skips_retrieval_without_affecting_hook_success ... ok
test integrations::claude_code::tests::install_hook_settings_removes_empty_groups_for_every_event ... ok
test adapters::markdown::tests::unreadable_markdown_paths_do_not_abort_corpus_build ... ok
test integrations::claude_code::tests::install_hook_settings_preserves_entries_and_is_idempotent ... ok
test integrations::claude_code::tests::install_memory_skill_force_replaces_user_edits ... ok
test integrations::claude_code::tests::install_user_config_merges_existing_servers ... ok
test integrations::claude_code::tests::install_user_config_pins_the_project_root ... ok
test integrations::claude_code::tests::install_memory_skill_preserves_user_edits_without_force ... ok
test integrations::claude_code::hooks::tests::transcript_extraction_scans_past_oversized_jsonl_record ... ok
test adapters::tests::ignore_paths_drop_vendored_documents_and_their_tier0_records ... ok
test integrations::codex::document::tests::claude_document_maps_to_session_source_document ... ok
test integrations::codex::document::tests::event_id_makes_document_id_deterministic ... ok
test integrations::codex::hooks::protocol::tests::empty_context_serializes_to_empty_object ... ok
test integrations::codex::hooks::protocol::tests::missing_cwd_uses_empty_fallback_path ... ok
test integrations::codex::hooks::protocol::tests::parses_user_prompt_expansion_fields ... ok
test aggregation::tests::builds_count_aggregation ... ok
test integrations::claude_code::tests::search_tool_rejects_unknown_arguments ... ok
test integrations::claude_code::tests::tools_list_exposes_search_info_and_recording ... ok
test corpus_graph::tests::from_bundle_builds_documents_symbols_and_usage ... ok
test integrations::claude_code::hooks::tests::exact_revision_provenance_does_not_require_repository_revalidation ... ok
test integrations::codex::hooks::tests::exact_revision_provenance_does_not_require_repository_revalidation ... ok
test integrations::codex::hooks::tests::redacts_auth_tokens_and_private_key_blocks ... ok
test integrations::codex::hooks::tests::relevant_excerpt_selects_matching_lines_and_enforces_byte_limit ... ok
test integrations::codex::hooks::tests::empty_prompt_does_not_open_memory_store ... ok
test integrations::codex::hooks::tests::active_stop_hook_does_not_capture ... ok
test integrations::codex::hooks::tests::session_start_does_not_create_memory_store ... ok
test integrations::codex::hooks::tests::disabled_memory_skips_retrieval_without_affecting_hook_success ... ok
test integrations::codex::hooks::tests::transcript_extraction_ignores_tool_blocks_and_redacts_secret_lines ... ok
test integrations::codex::hooks::tests::transcript_extraction_scans_past_oversized_jsonl_record ... ok
test integrations::codex::hooks::tests::transcript_extraction_supports_codex_rollout_messages ... ok
test integrations::codex::hooks::tests::finds_persisted_codex_session_transcript_by_session_id ... ok
test integrations::codex::tests::install_hook_settings_preserves_entries_and_is_idempotent ... ok
test integrations::claude_code::tests::search_tool_returns_ranked_results ... ok
test integrations::codex::tests::search_tool_rejects_unknown_arguments ... ok
test integrations::codex::tests::install_user_config_merges_existing_servers ... ok
test integrations::codex::tests::install_memory_policy_preserves_user_text_and_is_idempotent ... ok
test integrations::codex::tests::tools_list_exposes_search_info_and_recording ... ok
test integrations::mcp_health::tests::report_contains_protocol_and_timings ... ok
test integrations::mcp_tools::tests::list_memories_is_bounded_and_provider_neutral ... ok
test integrations::mcp_transport::tests::reads_content_length_requests ... ok
test integrations::mcp_transport::tests::reads_line_framed_requests ... ok
test integrations::mcp_transport::tests::rejects_oversized_requests ... ok
test integrations::recall::tests::a_record_without_chunks_still_reports_an_honest_range ... ok
test integrations::recall::tests::a_single_long_line_is_still_bounded ... ok
test integrations::recall::tests::chunk_text_is_capped_and_the_reported_range_matches_it ... ok
test integrations::recall::tests::document_hit_carries_no_session_metadata ... ok
test integrations::recall::tests::memory_hit_carries_session_branch_and_revision ... ok
test integrations::codex::tests::search_tool_returns_ranked_results ... ok
test integrations::recall::tests::the_chunk_carrying_the_query_wins ... ok
test integrations::claude_code::tests::control_tools_cover_recording_and_memory_matrix ... ok
test integrations::session_recording::tests::extracts_all_user_prompts_for_replay ... ok
test integrations::session_recording::tests::extracts_codex_session_id_from_provider_output ... ok
test integrations::session_recording::tests::excludes_synthetic_replay_completion_from_provider_event_count ... ok
test integrations::session_recording::tests::missing_replay_events_is_not_recording_complete ... ok
test integrations::claude_code::tests::tools_list_requires_store_initialization ... ok
test integrations::codex::tests::control_tools_cover_recording_and_memory_matrix ... ok
test integrations::codex::tests::tools_list_requires_store_initialization ... ok
test integrations::session_recording::tests::records_latest_transcript_usage_only_when_recording_is_enabled ... ok
test integrations::session_recording::tests::replay_with_prompts_requires_a_replayed_user_prompt_event ... ok
test integrations::session_recording::tests::replay_workspace_stays_under_the_project_root ... ok
test integrations::session_recording::tests::records_redacted_event_and_manifest ... ok
test integrations::session_recording::tests::sync_replay_archive_preserves_replay_manifest ... ok
test memory_api::tests::add_is_immediately_searchable ... ok
test memory_api::tests::expired_memories_are_not_searchable_and_can_be_deleted_idempotently ... ok
test integrations::session_recording::tests::recording_and_memory_controls_round_trip_for_each_provider ... ok
test memory_api::tests::search_cannot_cross_user_boundaries ... ok
test memory_api::tests::superseded_memory_is_hidden_but_replacement_remains_searchable ... ok
test memory_api::tests::supersession_is_scoped_to_the_requesting_user ... ok
test pipeline::tests::build_memory_index_works_with_defaults ... ok
test pipeline::tests::chunk_ids_are_stable_for_same_input ... ok
test pipeline::tests::artifact_index_upsert_remove_and_query ... ok
test pipeline::tests::chunk_lifecycle_is_removed_when_doc_is_removed ... ok
test pipeline::tests::chunk_lifecycle_increments_version_and_tracks_latest ... ok
test pipeline::tests::index_store_does_not_delete_invalid_lexical_directory ... ok
test integrations::session_recording::tests::tracks_completed_and_interrupted_session_statuses ... ok
test pipeline::tests::index_store_new_falls_back_to_in_memory_on_invalid_explicit_root ... ok
test pipeline::tests::index_store_new_falls_back_to_in_memory_when_corpus_root_is_missing ... ok
test integrations::session_recording::tests::recording_is_independent_from_memory_state ... ok
test pipeline::tests::index_store_publishes_and_queries_segmented_snapshot ... ok
test pipeline::tests::index_store_publishes_single_snapshot_by_default ... ok
test pipeline::tests::index_store_query_uses_incremental_lexical_updates ... ok
test pipeline::tests::index_store_rejects_metadata_schema_mismatch ... ok
test pipeline::tests::index_store_remove_deletes_lexical_doc ... ok
test integrations::session_recording::tests::promotes_recorded_events_into_memory ... ok
test pipeline::tests::query_prefers_latest_equally_relevant_conversation_memory ... ok
test pipeline::tests::query_results_diversify_by_group_id ... ok
test pipeline::tests::refresh_is_idempotent_when_no_documents_change ... ok
test pipeline::tests::resolve_store_paths_under_corpus_root ... ok
test integrations::claude_code::tests::search_tool_synchronizes_memory_captured_after_startup ... ok
test pipeline::tests::section_chunks_inherit_parent_timestamp_and_document_lifecycle_is_derived ... ok
test query_expansion::tests::expanded_lexical_subset_covers_common_search_terms ... ok
test query_expansion::tests::expansion_caps_and_dedups ... ok
test query_expansion::tests::install_expands_from_generated_subset ... ok
test query_expansion::tests::normalize_basic ... ok
test query_expansion::tests::symmetric_relations_expand_back_to_source_terms ... ok
test query_plan::tests::context_leaves_scoping_to_the_caller ... ok
test query_plan::tests::count_queries_carry_count_intent ... ok
test query_plan::tests::search_query_is_the_augmented_query ... ok
test query_semantics::tests::augments_query_with_terms ... ok
test query_semantics::tests::classifies_quantity_intent ... ok
test query_semantics::tests::classifies_query_routing_intent ... ok
test query_semantics::tests::extracts_temporal_phrase ... ok
test review::tests::review_packet_new_initializes_empty_lists ... ok
test review::tests::review_usage_summary_copies_nodes_and_edges ... ok
test review::tests::summary_conversions_preserve_source_fields ... ok
test pipeline::tests::segmented_index_store_rebuilds_segments_after_upsert ... ok
test rules::cross_refs::tests::surface_forms_variants ... ok
test segments::tests::adaptive_segment_enrichment_expands_when_query_coverage_is_low ... ok
test integrations::claude_code::hooks::tests::subagent_start_retrieves_memory_by_prompt ... ok
test segments::tests::all_segment_query_matches_global_memory_index_on_asymmetric_corpus ... ok
test segments::tests::connected_segment_enrichment_swaps_in_explicitly_related_session ... ok
test segments::tests::coverage_local_router_prefers_rare_term_coverage ... ok
test segments::tests::all_segment_query_reconstructs_global_index_when_missing ... ok
test integrations::claude_code::hooks::tests::post_tool_use_retrieves_relevant_memory_by_tool_name ... ok
test segments::tests::diagnostics_report_query_coverage_across_more_segments ... ok
test segments::tests::kl_router_prefers_closest_segment_distribution ... ok
test segments::tests::local_memory_router_uses_rolling_content_window ... ok
test segments::tests::route_aware_rerank_prefers_new_evidence_coverage ... ok
test segments::tests::missing_coverage_recovery_replaces_weak_segment ... ok
test segments::tests::local_router_prefers_segment_specific_differentiators ... ok
test segments::tests::routes_and_queries_one_group_segment ... ok
test segments::tests::queries_top_n_segments_and_merges_results ... ok
test integrations::codex::tests::search_tool_synchronizes_memory_captured_after_startup ... ok
test segments::tests::session_aggregation_combines_segment_evidence_by_group ... ok
test segments::tests::segment_enriched_query_reports_temporal_local_context ... ok
test segments::tests::segment_enriched_query_uses_each_selected_segments_local_context ... ok
test segments::tests::segmented_memory_index_returns_diagnostics ... ok
test segments::tests::segmented_query_passes_temporal_allowed_doc_ids_to_inner_indexes ... ok
test segments::tests::sparse_router_marks_empty_query_terms_as_fallback ... ok
test segments::tests::typed_evidence_score_requires_explicit_multi_bucket_match ... ok
test source::tests::source_document_round_trips_through_json ... ok
test source::tests::with_stable_doc_id_is_deterministic_for_same_source ... ok
test source::tests::with_stable_doc_id_sets_doc_length_from_content ... ok
test segments::tests::sparse_router_does_not_query_zero_signal_padding_segments ... ok
test symbols::tests::lookup_by_doc_and_attribute_return_matching_records ... ok
test symbols::tests::lookup_by_name_matches_exact_and_normalized_forms ... ok
test temporal::tests::augments_future_phrase ... ok
test temporal::tests::augments_last_weekday ... ok
test temporal::tests::augments_relative_ago_phrase ... ok
test temporal::tests::augments_weekday_prefixes ... ok
test temporal::tests::augments_weekend_phrase ... ok
test temporal::tests::resolves_relative_temporal_target ... ok
test temporal::tests::reveals_bug_recency_decay_does_not_prioritize_recent_memory ... ok
test temporal::tests::reveals_bug_rfc3339_timestamp_with_timezone_is_not_parsed ... ok
test temporal_fact::tests::as_of_filters_by_validity_window ... ok
test temporal_fact::tests::store_versions_conflicting_facts_without_hardcoded_patterns ... ok
test temporal_fact::tests::timeline_window_and_adjacent_pairs_are_ordered ... ok
test tokenizer::tests::stemmed_stopword_matches_segment_router_list ... ok
test tokenizer::tests::unstemmed_matches_manual_regex ... ok
test tokenizer::tests::unstemmed_stopword_matches_original_list ... ok
test usage::tests::lookup_by_node_is_bidirectional ... ok
test usage::tests::summary_for_symbol_counts_edges_and_connected_nodes ... ok
test segments::tests::sparse_router_reports_no_signal_without_querying_lexicographic_first_segment ... ok
test symbols::tests::corpus_index_from_bundle_preserves_documents_and_symbols ... ok
test segments::tests::team_coverage_router_prefers_complementary_segments ... ok
test segments::tests::temporal_path_enrichment_expands_to_nearby_before_segment ... ok
test pipeline::tests::index_store_for_corpus_uses_corpus_local_lexical_dir ... ok
test pipeline::tests::index_store_for_corpus_writes_metadata ... ok
test pipeline::tests::index_store_persists_and_reloads_semantic_state ... ok
test integrations::claude_code::hooks::tests::subagent_stop_captures_outcome_and_is_idempotent ... ok
test pipeline::tests::index_store_with_lexical_dir_persists_queries_across_instances ... ok
test integrations::claude_code::hooks::tests::stop_capture_persists_and_prompt_retrieves_memory ... ok
test integrations::codex::hooks::tests::stop_capture_persists_and_prompt_retrieves_memory ... ok
test integrations::claude_code::hooks::tests::compact_stop_and_session_end_capture_distinct_document_types ... ok
test integrations::codex::hooks::tests::compact_stop_and_session_end_capture_distinct_document_types ... ok
test integrations::recall::tests::project_recall_uses_each_provider_store ... ok

test result: ok. 194 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.31s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test tests::token_accepts_the_documented_schemes ... ok
test tests::loopback_binds_do_not_require_a_token ... ok
test tests::header_lines_are_bounded ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test concurrent_codex_lifecycle_hooks_record_all_events ... ok
test concurrent_codex_mcp_clients_initialize_and_open_shared_index ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.35s


running 6 tests
test allowlist_limits_crossrefs ... ok
test analyze_suggests_config ... ok
test ignore_related_section_for_crossrefs ... ok
test lint_reports_orphans_and_missing_links ... ok
test semantic_expansion_improves_recall_for_synonyms ... ok
test query_baseline_still_works_without_semantic_match ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s (194 unit tests pass; unrelated concurrent MCP subprocess test is flaky/fails during startup)
- focused regression test proven red against the old response and green with this change