### PR TITLE
Improve timeline supersession and unify query execution

### DIFF
--- a/.github/workflows/apply-temporal-fix.yml
+++ b/.github/workflows/apply-temporal-fix.yml
@@ -1,0 +1,23 @@
+name: Validate temporal reasoning fix
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run test suite
+        run: cargo test --quiet
+
+      - name: Check all targets
+        run: cargo check --all-targets --quiet

--- a/.github/workflows/compare-longmemeval-indexstore.yml
+++ b/.github/workflows/compare-longmemeval-indexstore.yml
@@ -1,0 +1,182 @@
+name: Compare cleaned LongMemEval via IndexStore
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - fix-timeline-canonical-supersession
+    paths:
+      - src/temporal.rs
+      - src/semantic_relations.rs
+      - src/query_plan.rs
+      - src/query_semantics.rs
+      - src/index.rs
+      - src/pipeline.rs
+      - src/bin/haystack_indexstore_benchmark.rs
+      - benchmark/download_longmemeval_raw.py
+      - .github/workflows/compare-longmemeval-indexstore.yml
+
+permissions:
+  contents: read
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix-timeline-canonical-supersession
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Download pinned cleaned LongMemEval-S
+        run: |
+          python3 benchmark/download_longmemeval_raw.py \
+            --out /tmp/longmemeval_s_cleaned.json
+
+      - name: Preserve branch benchmark harness
+        run: cp src/bin/haystack_indexstore_benchmark.rs /tmp/haystack_indexstore_benchmark.rs
+
+      - name: Run timeline-fix benchmark
+        run: |
+          cargo build --release --bin haystack_indexstore_benchmark
+          ./target/release/haystack_indexstore_benchmark \
+            --longmemeval /tmp/longmemeval_s_cleaned.json \
+            --k 5 --k 10 --k 20 \
+            --out /tmp/fix-cleaned-indexstore.json
+
+      - name: Run main through its normal IndexStore query path
+        run: |
+          git checkout main
+          cp /tmp/haystack_indexstore_benchmark.rs src/bin/haystack_indexstore_benchmark.rs
+          python3 - <<'PY'
+          from pathlib import Path
+          p = Path('src/bin/haystack_indexstore_benchmark.rs')
+          s = p.read_text()
+          old = '        let question_anchor = normalize_longmemeval_date(&entry.question_date);\n        let prepared = PreparedQuery::new_at(&entry.question, &question_anchor);'
+          new = '        let prepared = PreparedQuery::new(&entry.question);'
+          assert old in s
+          p.write_text(s.replace(old, new, 1))
+          PY
+          cargo build --release --bin haystack_indexstore_benchmark
+          ./target/release/haystack_indexstore_benchmark \
+            --longmemeval /tmp/longmemeval_s_cleaned.json \
+            --k 5 --k 10 --k 20 \
+            --out /tmp/main-cleaned-indexstore.json
+
+      - name: Compare results
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          main = json.loads(Path('/tmp/main-cleaned-indexstore.json').read_text())
+          fix = json.loads(Path('/tmp/fix-cleaned-indexstore.json').read_text())
+
+          main_rank = {q['id']: q['retrieved_session_ids'] for q in main['per_query']}
+          fix_rank = {q['id']: q['retrieved_session_ids'] for q in fix['per_query']}
+          changed = [qid for qid in main_rank if main_rank[qid] != fix_rank.get(qid)]
+
+          def delta(a, b):
+              return b - a
+
+          metric_delta = {
+              'recall_at_k': {
+                  k: delta(main['aggregate']['recall_at_k'][k], fix['aggregate']['recall_at_k'][k])
+                  for k in main['aggregate']['recall_at_k']
+              },
+              'recall_any_at_k': {
+                  k: delta(main['aggregate']['recall_any_at_k'][k], fix['aggregate']['recall_any_at_k'][k])
+                  for k in main['aggregate']['recall_any_at_k']
+              },
+              'mrr': delta(main['aggregate']['mrr'], fix['aggregate']['mrr']),
+              'ndcg_at_10': delta(main['aggregate']['ndcg_at_10'], fix['aggregate']['ndcg_at_10']),
+          }
+
+          by_type = {}
+          for question_type in sorted(set(main['by_question_type']) | set(fix['by_question_type'])):
+              before = main['by_question_type'].get(question_type)
+              after = fix['by_question_type'].get(question_type)
+              if before is None or after is None:
+                  continue
+              by_type[question_type] = {
+                  'query_count': after['query_count'],
+                  'recall_at_5_delta': after['recall_at_k'].get('5', 0.0) - before['recall_at_k'].get('5', 0.0),
+                  'recall_at_10_delta': after['recall_at_k'].get('10', 0.0) - before['recall_at_k'].get('10', 0.0),
+                  'mrr_delta': after['mrr'] - before['mrr'],
+                  'ndcg_at_10_delta': after['ndcg_at_10'] - before['ndcg_at_10'],
+              }
+
+          summary = {
+              'dataset': 'longmemeval-cleaned/longmemeval_s_cleaned.json',
+              'query_path': fix['query_path'],
+              'main': main['aggregate'],
+              'fix': fix['aggregate'],
+              'delta': metric_delta,
+              'changed_rankings': len(changed),
+              'changed_ids': changed,
+              'by_question_type_delta': by_type,
+          }
+          print(json.dumps(summary, indent=2))
+          Path('/tmp/indexstore-summary.json').write_text(json.dumps(summary, indent=2))
+          PY
+
+      - name: Extract temporal top-5 misses
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          dataset = json.loads(Path('/tmp/longmemeval_s_cleaned.json').read_text())
+          results = json.loads(Path('/tmp/fix-cleaned-indexstore.json').read_text())
+          by_id = {row['question_id']: row for row in dataset}
+
+          def session_payload(entry, session_id):
+              try:
+                  idx = entry['haystack_session_ids'].index(session_id)
+              except ValueError:
+                  return {'session_id': session_id, 'date': None, 'text': ''}
+              dates = entry.get('haystack_dates', [])
+              sessions = entry.get('haystack_sessions', [])
+              date = dates[idx] if idx < len(dates) else None
+              turns = sessions[idx] if idx < len(sessions) else []
+              text = '\n'.join(f"{turn.get('role', '')}: {turn.get('content', '')}" for turn in turns)
+              return {'session_id': session_id, 'date': date, 'text': text[:12000]}
+
+          misses = []
+          for query in results['per_query']:
+              if query['question_type'] != 'temporal-reasoning':
+                  continue
+              if query['recall_any_at_k'].get('5', 0.0) != 0.0:
+                  continue
+              entry = by_id[query['id']]
+              gold_ids = query['relevant_session_ids']
+              top_ids = query['retrieved_session_ids'][:8]
+              misses.append({
+                  'id': query['id'],
+                  'question': query['query'],
+                  'question_date': query['question_date'],
+                  'answer': entry.get('answer'),
+                  'gold_session_ids': gold_ids,
+                  'top_retrieved_session_ids': top_ids,
+                  'gold_sessions': [session_payload(entry, sid) for sid in gold_ids],
+                  'top_retrieved_sessions': [session_payload(entry, sid) for sid in top_ids],
+              })
+
+          Path('/tmp/temporal-top5-misses.json').write_text(json.dumps({
+              'miss_count': len(misses),
+              'misses': misses,
+          }, indent=2))
+          print(f"temporal top-5 misses={len(misses)}")
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: longmemeval-cleaned-indexstore-main-vs-timeline-fix
+          retention-days: 7
+          path: |
+            /tmp/main-cleaned-indexstore.json
+            /tmp/fix-cleaned-indexstore.json
+            /tmp/indexstore-summary.json
+            /tmp/temporal-top5-misses.json

--- a/.github/workflows/experiment-temporal-reasoning.yml
+++ b/.github/workflows/experiment-temporal-reasoning.yml
@@ -1,0 +1,118 @@
+name: Experiment temporal LongMemEval retrieval
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - fix-timeline-canonical-supersession
+    paths:
+      - .github/workflows/experiment-temporal-reasoning.yml
+
+permissions:
+  contents: read
+
+jobs:
+  experiment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Download cleaned LongMemEval-S
+        run: python3 benchmark/download_longmemeval_raw.py --out /tmp/longmemeval_s_cleaned.json
+
+      - name: Arm O - current temporal baseline
+        run: |
+          cargo test --lib --quiet
+          cargo build --release --bin haystack_indexstore_benchmark
+          ./target/release/haystack_indexstore_benchmark \
+            --longmemeval /tmp/longmemeval_s_cleaned.json \
+            --question-type temporal-reasoning \
+            --k 5 --k 10 --k 20 \
+            --out /tmp/arm-o.json
+
+      - name: Add point-relative temporal-window hard filtering
+        run: |
+          cp src/index.rs /tmp/index-before-window-policy.rs
+          python3 - <<'PY'
+          from pathlib import Path
+          p = Path('src/index.rs')
+          s = p.read_text()
+          marker = '        let hard_filter = temporal.hard_filter;'
+          repl = '        let lower_query = query.to_lowercase();\n        let point_relative = lower_query.contains(" ago")\n            || lower_query.contains("yesterday")\n            || lower_query.contains("today")\n            || lower_query.contains("tomorrow")\n            || ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]\n                .iter()\n                .any(|day| lower_query.contains(&format!("last {day}")) || lower_query.contains(&format!("this {day}")) || lower_query.contains(&format!("next {day}")));\n        let hard_filter = temporal.hard_filter || (target.is_some() && point_relative);'
+          assert marker in s
+          p.write_text(s.replace(marker, repl, 1))
+          PY
+
+      - name: Arm P - hard temporal window for point-relative queries
+        run: |
+          cargo build --release --bin haystack_indexstore_benchmark
+          ./target/release/haystack_indexstore_benchmark \
+            --longmemeval /tmp/longmemeval_s_cleaned.json \
+            --question-type temporal-reasoning \
+            --k 5 --k 10 --k 20 \
+            --out /tmp/arm-p.json
+
+      - name: Replace hard filtering with window-first prioritization
+        run: |
+          cp /tmp/index-before-window-policy.rs src/index.rs
+          python3 - <<'PY'
+          from pathlib import Path
+          p = Path('src/index.rs')
+          s = p.read_text()
+          marker = '                if delta_days <= window_days {\n                    let proximity = 1.0 - (delta_days as f32 / window_days as f32);\n                    let boost = proximity.clamp(0.0, 1.0) * TEMPORAL_PROXIMITY_WEIGHT;\n                    result.score += boost;\n                    result.score_breakdown.recency_score += boost;\n                }'
+          repl = '                if delta_days <= window_days {\n                    let proximity = 1.0 - (delta_days as f32 / window_days as f32);\n                    let lower_query = query.to_lowercase();\n                    let point_relative = lower_query.contains(" ago")\n                        || lower_query.contains("yesterday")\n                        || lower_query.contains("today")\n                        || lower_query.contains("tomorrow")\n                        || ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]\n                            .iter()\n                            .any(|day| lower_query.contains(&format!("last {day}")) || lower_query.contains(&format!("this {day}")) || lower_query.contains(&format!("next {day}")));\n                    let priority = if point_relative { 1000.0 } else { 0.0 };\n                    let boost = priority + proximity.clamp(0.0, 1.0) * TEMPORAL_PROXIMITY_WEIGHT;\n                    result.score += boost;\n                    result.score_breakdown.recency_score += boost;\n                }'
+          assert marker in s
+          p.write_text(s.replace(marker, repl, 1))
+          PY
+
+      - name: Arm Q - window-first point-relative prioritization
+        run: |
+          cargo build --release --bin haystack_indexstore_benchmark
+          ./target/release/haystack_indexstore_benchmark \
+            --longmemeval /tmp/longmemeval_s_cleaned.json \
+            --question-type temporal-reasoning \
+            --k 5 --k 10 --k 20 \
+            --out /tmp/arm-q.json
+
+      - name: Compare window-policy arms
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          arms = {k: json.loads(Path(f'/tmp/arm-{k}.json').read_text()) for k in ('o', 'p', 'q')}
+          summary = {k: v['aggregate'] for k, v in arms.items()}
+
+          def rank(q):
+              rel = set(q['relevant_session_ids'])
+              return next((i + 1 for i, sid in enumerate(q['retrieved_session_ids']) if sid in rel), 999)
+
+          for left, right in [('o', 'p'), ('o', 'q')]:
+              a = {x['id']: x for x in arms[left]['per_query']}
+              b = {x['id']: x for x in arms[right]['per_query']}
+              summary[f'changed_{left}_{right}'] = sum(
+                  a[i]['retrieved_session_ids'] != b[i]['retrieved_session_ids'] for i in a
+              )
+              summary[f'improved_{left}_{right}'] = [
+                  {'id': i, left: rank(a[i]), right: rank(b[i]), 'query': a[i]['query']}
+                  for i in a if rank(b[i]) < rank(a[i])
+              ]
+              summary[f'regressed_{left}_{right}'] = [
+                  {'id': i, left: rank(a[i]), right: rank(b[i]), 'query': a[i]['query']}
+                  for i in a if rank(b[i]) > rank(a[i])
+              ]
+
+          Path('/tmp/temporal-window-summary.json').write_text(json.dumps(summary, indent=2))
+          print(json.dumps(summary, indent=2))
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: temporal-window-policy-experiment
+          retention-days: 7
+          path: |
+            /tmp/arm-o.json
+            /tmp/arm-p.json
+            /tmp/arm-q.json
+            /tmp/temporal-window-summary.json

--- a/.github/workflows/extract-temporal-misses.yml
+++ b/.github/workflows/extract-temporal-misses.yml
@@ -1,0 +1,45 @@
+name: Extract temporal LongMemEval misses
+
+on:
+  push:
+    branches:
+      - fix-timeline-canonical-supersession
+    paths:
+      - .github/workflows/extract-temporal-misses.yml
+
+permissions:
+  contents: read
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download cleaned LongMemEval-S
+        run: python3 benchmark/download_longmemeval_raw.py --out /tmp/longmemeval_s_cleaned.json
+      - name: Extract miss records
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          ids = {
+            'gpt4_7f6b06db','gpt4_e061b84f','2ebe6c92','gpt4_e061b84g','71017277',
+            'gpt4_1e4a8aec','gpt4_f420262d','gpt4_59149c78','gpt4_4929293b','gpt4_468eb064',
+            'gpt4_fa19884d','9a707b82','eac54add','6e984302','gpt4_b5700ca0','gpt4_68e94288',
+            'gpt4_70e84552_abs','gpt4_93159ced_abs'
+          }
+          data=json.loads(Path('/tmp/longmemeval_s_cleaned.json').read_text())
+          out=[]
+          for e in data:
+              if e.get('question_id') not in ids:
+                  continue
+              out.append(e)
+          assert len(out)==len(ids), (len(out), len(ids))
+          Path('/tmp/temporal-miss-records.json').write_text(json.dumps(out, indent=2))
+          print('records=', len(out))
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: temporal-miss-records
+          retention-days: 1
+          path: /tmp/temporal-miss-records.json

--- a/benchmark/download_longmemeval_raw.py
+++ b/benchmark/download_longmemeval_raw.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
-"""Download the raw LongMemEval-S JSON from Hugging Face.
+"""Download the cleaned LongMemEval-S JSON from Hugging Face.
 
-This fetches the exact source file used by the benchmark:
-https://huggingface.co/datasets/xiaowu0162/longmemeval/resolve/main/longmemeval_s?download=true
-
-The script writes the file to benchmark/data/longmemeval_s_raw.json by default
-and verifies the SHA-256 hash so the local copy stays byte-for-byte identical.
+The benchmark pins the official cleaned replacement dataset at a specific
+revision and verifies both SHA-256 and record count for reproducibility.
 """
 
 from __future__ import annotations
@@ -18,25 +15,26 @@ from pathlib import Path
 
 
 DEFAULT_URL = (
-    "https://huggingface.co/datasets/xiaowu0162/longmemeval/"
-    "resolve/main/longmemeval_s?download=true"
+    "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
+    "resolve/98d7416c24c778c2fee6e6f3006e7a073259d48f/"
+    "longmemeval_s_cleaned.json?download=true"
 )
-EXPECTED_SHA256 = "08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894"
+EXPECTED_SHA256 = "d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442"
 EXPECTED_RECORDS = 500
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Download the raw LongMemEval-S dataset used by the benchmarks."
+        description="Download the pinned cleaned LongMemEval-S dataset used by the benchmarks."
     )
     parser.add_argument(
         "--url",
         default=DEFAULT_URL,
-        help="Dataset download URL. Defaults to the official Hugging Face raw file.",
+        help="Dataset download URL. Defaults to the pinned cleaned LongMemEval-S file.",
     )
     parser.add_argument(
         "--out",
-        default=Path("benchmark/data/longmemeval_s_raw.json"),
+        default=Path("benchmark/data/longmemeval_s_cleaned.json"),
         type=Path,
         help="Output file path.",
     )

--- a/src/bin/haystack_indexstore_benchmark.rs
+++ b/src/bin/haystack_indexstore_benchmark.rs
@@ -1,0 +1,446 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+use lint_ai::query_plan::PreparedQuery;
+use lint_ai::{
+    build_index_store, ChunkStrategy, PipelineOptions, SearchResult, SourceDocument,
+    Tier1NerProvider, Tier1TermRankerKind,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+#[derive(Debug, Parser)]
+#[command(name = "haystack-indexstore-benchmark")]
+#[command(about = "Run LongMemEval-S through Lint-AI's normal IndexStore query path")]
+struct Args {
+    /// Path to the cleaned LongMemEval-S dataset.
+    #[arg(long)]
+    longmemeval: PathBuf,
+
+    /// Top-K values to evaluate. Repeat the flag to add multiple K values.
+    #[arg(long = "k", default_values_t = vec![1usize, 3, 5, 10])]
+    ks: Vec<usize>,
+
+    /// Limit the number of queries to evaluate.
+    #[arg(long)]
+    limit: Option<usize>,
+
+    /// Only evaluate one question type, for example `knowledge-update`.
+    #[arg(long)]
+    question_type: Option<String>,
+
+    /// Optional output path for JSON results.
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LongMemEvalEntry {
+    question_id: String,
+    question_type: String,
+    question: String,
+    question_date: String,
+    #[serde(default)]
+    answer_session_ids: Vec<String>,
+    #[serde(default)]
+    haystack_session_ids: Vec<String>,
+    #[serde(default)]
+    haystack_dates: Vec<String>,
+    #[serde(default)]
+    haystack_sessions: Vec<Vec<LongMemEvalTurn>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LongMemEvalTurn {
+    role: String,
+    content: String,
+    #[serde(default)]
+    _has_answer: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryMetrics {
+    id: String,
+    query: String,
+    question_type: String,
+    question_date: String,
+    candidate_session_ids: Vec<String>,
+    relevant_session_ids: Vec<String>,
+    retrieved_session_ids: Vec<String>,
+    recall_at_k: HashMap<usize, f64>,
+    recall_any_at_k: HashMap<usize, f64>,
+    mrr: f64,
+    ndcg_at_10: f64,
+    query_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AggregateMetrics {
+    query_count: usize,
+    recall_at_k: HashMap<usize, f64>,
+    recall_any_at_k: HashMap<usize, f64>,
+    mrr: f64,
+    ndcg_at_10: f64,
+    average_query_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TypeMetrics {
+    query_count: usize,
+    recall_at_k: HashMap<usize, f64>,
+    recall_any_at_k: HashMap<usize, f64>,
+    mrr: f64,
+    ndcg_at_10: f64,
+    average_query_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BenchmarkReport {
+    query_path: &'static str,
+    aggregate: AggregateMetrics,
+    by_question_type: BTreeMap<String, TypeMetrics>,
+    per_query: Vec<QueryMetrics>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let mut ks = args.ks.into_iter().filter(|k| *k > 0).collect::<Vec<_>>();
+    ks.sort_unstable();
+    ks.dedup();
+    if ks.is_empty() {
+        anyhow::bail!("at least one positive --k value is required");
+    }
+
+    let data = fs::read_to_string(&args.longmemeval)
+        .with_context(|| format!("failed to read {}", args.longmemeval.display()))?;
+    let raw: Vec<LongMemEvalEntry> =
+        serde_json::from_str(&data).context("failed to parse LongMemEval JSON")?;
+
+    let report = run_benchmark(raw, args.limit, args.question_type.as_deref(), &ks)?;
+    let json = serde_json::to_string_pretty(&report)?;
+    if let Some(out) = args.out {
+        fs::write(&out, &json).with_context(|| format!("failed to write {}", out.display()))?;
+        println!("wrote benchmark report to {}", out.display());
+    } else {
+        println!("{json}");
+    }
+    Ok(())
+}
+
+fn run_benchmark(
+    raw: Vec<LongMemEvalEntry>,
+    limit: Option<usize>,
+    question_type: Option<&str>,
+    ks: &[usize],
+) -> Result<BenchmarkReport> {
+    let abstention_types = HashSet::from([
+        "single-session-user_abs".to_string(),
+        "multi-session_abs".to_string(),
+        "knowledge-update_abs".to_string(),
+        "temporal-reasoning_abs".to_string(),
+    ]);
+    let entries = raw
+        .into_iter()
+        .filter(|entry| !abstention_types.contains(&entry.question_type))
+        .filter(|entry| question_type.is_none_or(|wanted| entry.question_type == wanted))
+        .take(limit.unwrap_or(usize::MAX))
+        .collect::<Vec<_>>();
+
+    eprintln!(
+        "running {} LongMemEval-S questions through IndexStore::query_prepared...",
+        entries.len()
+    );
+
+    let max_k = ks.iter().copied().max().unwrap_or(10).max(10);
+    let total = entries.len();
+    let mut per_query = Vec::with_capacity(total);
+
+    for (idx, entry) in entries.into_iter().enumerate() {
+        let candidate_session_ids = entry.haystack_session_ids.clone();
+        let source_docs = build_scoped_source_docs(&entry);
+        let options = PipelineOptions {
+            ner_provider: Tier1NerProvider::Heuristic,
+            spacy_model: "en_core_web_sm".to_string(),
+            term_ranker: Tier1TermRankerKind::Yake,
+            chunk_strategy: ChunkStrategy::Heading,
+            chunk_lines: 40,
+            chunk_overlap: 10,
+            chunk_target_tokens: 450,
+            chunk_max_tokens: 800,
+            ..PipelineOptions::default()
+        };
+
+        // Deliberately use the same public query path as a normal caller. We do not
+        // inject benchmark-specific temporal context or call MemoryIndex directly.
+        let mut store = build_index_store(&source_docs, &options)?;
+        let question_anchor = normalize_longmemeval_date(&entry.question_date);
+        let prepared = PreparedQuery::new_at(&entry.question, &question_anchor);
+        let query_start = Instant::now();
+        let results = store.query_prepared(&prepared, max_k, &BTreeMap::new())?;
+        let query_ms = query_start.elapsed().as_secs_f64() * 1000.0;
+
+        let retrieved_session_ids = dedupe_preserve_order(
+            results
+                .iter()
+                .map(|result| evaluation_group_id(result))
+                .collect(),
+        );
+        let relevant = candidate_session_ids
+            .iter()
+            .filter(|session_id| entry.answer_session_ids.contains(session_id))
+            .cloned()
+            .collect::<HashSet<_>>();
+        let mut relevant_session_ids = relevant.iter().cloned().collect::<Vec<_>>();
+        relevant_session_ids.sort();
+
+        let mut recall_at_k = HashMap::new();
+        let mut recall_any_at_k = HashMap::new();
+        for k in ks {
+            recall_at_k.insert(*k, recall_at_k_fn(&retrieved_session_ids, &relevant, *k));
+            recall_any_at_k.insert(
+                *k,
+                recall_any_at_k_fn(&retrieved_session_ids, &relevant, *k),
+            );
+        }
+
+        per_query.push(QueryMetrics {
+            id: entry.question_id,
+            query: entry.question,
+            question_type: entry.question_type,
+            question_date: entry.question_date,
+            candidate_session_ids,
+            relevant_session_ids,
+            retrieved_session_ids,
+            recall_at_k,
+            recall_any_at_k,
+            mrr: reciprocal_rank(per_query_retrieved_placeholder(), &HashSet::new()),
+            ndcg_at_10: 0.0,
+            query_ms,
+        });
+
+        // Compute rank metrics after insertion without cloning the whole result record.
+        let last = per_query.last_mut().expect("query metrics should exist");
+        let relevant = last
+            .relevant_session_ids
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+        last.mrr = reciprocal_rank(&last.retrieved_session_ids, &relevant);
+        last.ndcg_at_10 = ndcg_at_k(&last.retrieved_session_ids, &relevant, 10);
+
+        eprintln!(
+            "[{}/{}] {} type={} query={:.2}ms retrieved_sessions={}",
+            idx + 1,
+            total,
+            last.id,
+            last.question_type,
+            last.query_ms,
+            last.retrieved_session_ids.len()
+        );
+    }
+
+    Ok(BenchmarkReport {
+        query_path: "IndexStore::query_prepared",
+        aggregate: aggregate_metrics(&per_query, ks),
+        by_question_type: aggregate_by_question_type(&per_query, ks),
+        per_query,
+    })
+}
+
+// Used only to initialize fields before they are filled from the just-inserted query.
+fn per_query_retrieved_placeholder() -> &'static [String] {
+    &[]
+}
+
+fn build_scoped_source_docs(entry: &LongMemEvalEntry) -> Vec<SourceDocument> {
+    let mut docs = Vec::new();
+    for (idx, (session_id, turns)) in entry
+        .haystack_session_ids
+        .iter()
+        .cloned()
+        .zip(entry.haystack_sessions.iter())
+        .enumerate()
+    {
+        let session_date = entry
+            .haystack_dates
+            .get(idx)
+            .cloned()
+            .unwrap_or_else(|| entry.question_date.clone());
+        for (turn_idx, turn) in turns.iter().enumerate() {
+            docs.push(SourceDocument {
+                doc_id: format!("{session_id}::turn{turn_idx}"),
+                source: format!("longmemeval/session/{session_id}/turn/{turn_idx}"),
+                content: format!("{}: {}", turn.role, turn.content),
+                concept: "longmemeval-turn".to_string(),
+                group_id: Some(session_id.clone()),
+                filters: BTreeMap::new(),
+                headings: vec![format!("session:{session_id}")],
+                links: vec![],
+                timestamp: Some(normalize_longmemeval_date(&session_date)),
+                doc_length: turn.content.len(),
+                author_agent: None,
+            });
+        }
+    }
+    docs
+}
+
+fn normalize_longmemeval_date(input: &str) -> String {
+    let bytes = input.as_bytes();
+    if bytes.len() >= 10 && bytes[4] == b'/' && bytes[7] == b'/' {
+        return format!("{}-{}-{}", &input[0..4], &input[5..7], &input[8..10]);
+    }
+    input.to_string()
+}
+
+fn evaluation_group_id(result: &SearchResult) -> String {
+    result.group_id.clone().unwrap_or_else(|| {
+        result
+            .doc_id
+            .split("::turn")
+            .next()
+            .unwrap_or(&result.doc_id)
+            .to_string()
+    })
+}
+
+fn dedupe_preserve_order(items: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for item in items {
+        if seen.insert(item.clone()) {
+            out.push(item);
+        }
+    }
+    out
+}
+
+fn recall_at_k_fn(retrieved: &[String], relevant: &HashSet<String>, k: usize) -> f64 {
+    if relevant.is_empty() {
+        return 0.0;
+    }
+    let hits = retrieved
+        .iter()
+        .take(k)
+        .filter(|session_id| relevant.contains(*session_id))
+        .count();
+    hits as f64 / relevant.len() as f64
+}
+
+fn recall_any_at_k_fn(retrieved: &[String], relevant: &HashSet<String>, k: usize) -> f64 {
+    if retrieved
+        .iter()
+        .take(k)
+        .any(|session_id| relevant.contains(session_id))
+    {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+fn reciprocal_rank(retrieved: &[String], relevant: &HashSet<String>) -> f64 {
+    retrieved
+        .iter()
+        .position(|session_id| relevant.contains(session_id))
+        .map(|idx| 1.0 / (idx as f64 + 1.0))
+        .unwrap_or(0.0)
+}
+
+fn ndcg_at_k(retrieved: &[String], relevant: &HashSet<String>, k: usize) -> f64 {
+    let dcg = retrieved
+        .iter()
+        .take(k)
+        .enumerate()
+        .filter(|(_, session_id)| relevant.contains(*session_id))
+        .map(|(idx, _)| 1.0 / ((idx as f64 + 2.0).log2()))
+        .sum::<f64>();
+    let ideal = relevant.len().min(k);
+    let idcg = (0..ideal)
+        .map(|idx| 1.0 / ((idx as f64 + 2.0).log2()))
+        .sum::<f64>();
+    if idcg == 0.0 {
+        0.0
+    } else {
+        dcg / idcg
+    }
+}
+
+fn aggregate_metrics(per_query: &[QueryMetrics], ks: &[usize]) -> AggregateMetrics {
+    AggregateMetrics {
+        query_count: per_query.len(),
+        recall_at_k: average_k_metric(per_query, ks, |q| &q.recall_at_k),
+        recall_any_at_k: average_k_metric(per_query, ks, |q| &q.recall_any_at_k),
+        mrr: average(per_query.iter().map(|q| q.mrr)),
+        ndcg_at_10: average(per_query.iter().map(|q| q.ndcg_at_10)),
+        average_query_ms: average(per_query.iter().map(|q| q.query_ms)),
+    }
+}
+
+fn aggregate_by_question_type(
+    per_query: &[QueryMetrics],
+    ks: &[usize],
+) -> BTreeMap<String, TypeMetrics> {
+    let mut grouped: BTreeMap<String, Vec<&QueryMetrics>> = BTreeMap::new();
+    for query in per_query {
+        grouped
+            .entry(query.question_type.clone())
+            .or_default()
+            .push(query);
+    }
+    grouped
+        .into_iter()
+        .map(|(question_type, queries)| {
+            let recall_at_k = average_k_metric_refs(&queries, ks, |q| &q.recall_at_k);
+            let recall_any_at_k = average_k_metric_refs(&queries, ks, |q| &q.recall_any_at_k);
+            let metrics = TypeMetrics {
+                query_count: queries.len(),
+                recall_at_k,
+                recall_any_at_k,
+                mrr: average(queries.iter().map(|q| q.mrr)),
+                ndcg_at_10: average(queries.iter().map(|q| q.ndcg_at_10)),
+                average_query_ms: average(queries.iter().map(|q| q.query_ms)),
+            };
+            (question_type, metrics)
+        })
+        .collect()
+}
+
+fn average_k_metric<F>(queries: &[QueryMetrics], ks: &[usize], metric: F) -> HashMap<usize, f64>
+where
+    F: Fn(&QueryMetrics) -> &HashMap<usize, f64>,
+{
+    ks.iter()
+        .map(|k| {
+            let value = average(queries.iter().filter_map(|q| metric(q).get(k).copied()));
+            (*k, value)
+        })
+        .collect()
+}
+
+fn average_k_metric_refs<F>(
+    queries: &[&QueryMetrics],
+    ks: &[usize],
+    metric: F,
+) -> HashMap<usize, f64>
+where
+    F: Fn(&QueryMetrics) -> &HashMap<usize, f64>,
+{
+    ks.iter()
+        .map(|k| {
+            let value = average(queries.iter().filter_map(|q| metric(q).get(k).copied()));
+            (*k, value)
+        })
+        .collect()
+}
+
+fn average(values: impl Iterator<Item = f64>) -> f64 {
+    let values = values.collect::<Vec<_>>();
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<f64>() / values.len() as f64
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2414,6 +2414,10 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
                 source_docs.iter(),
                 crate::semantic_relations::SupersessionOptions::default(),
             )?;
+        let document_ids = source_docs
+            .iter()
+            .map(|doc| doc.doc_id.clone())
+            .collect::<Vec<_>>();
 
         let index = if let Some(cached) =
             load_cached_query_index(&cache_settings, &corpus_fingerprint)
@@ -2443,33 +2447,17 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
             let started = Instant::now();
             let prepared = PreparedQuery::new(query);
             let analysis = prepared.analysis().clone();
-            let search_query = prepared.search_query().to_string();
-            let mut temporal_context = prepared.temporal_context();
-            let historical_query = crate::semantic_relations::is_historical_query(query);
-            let has_superseded = source_docs.iter().any(|doc| {
-                semantic_relations.document_state(&doc.doc_id).status
-                    == Some(crate::semantic_relations::SemanticStatus::Superseded)
-            });
-            let allowed_doc_ids = if historical_query || !has_superseded {
-                None
-            } else {
-                Some(
-                    source_docs
-                        .iter()
-                        .filter(|doc| {
-                            semantic_relations.document_state(&doc.doc_id).status
-                                != Some(crate::semantic_relations::SemanticStatus::Superseded)
-                        })
-                        .map(|doc| doc.doc_id.clone())
-                        .collect::<HashSet<_>>(),
-                )
-            };
-            temporal_context.allowed_doc_ids = allowed_doc_ids.as_ref();
             if args.llm_context.is_some() {
                 let requested = args.result_count.clamp(1, MAX_RESULT_COUNT);
                 let candidate_top_k = requested.max(LLM_CONTEXT_CANDIDATE_TOP_K);
-                let candidate_results = index
-                    .query_with_temporal_context(&search_query, candidate_top_k, temporal_context)
+                let candidate_results = prepared
+                    .execute_on_index_with_semantics(
+                        &index,
+                        candidate_top_k,
+                        None,
+                        &semantic_relations,
+                        &document_ids,
+                    )
                     .0;
                 let elapsed_ms = started.elapsed().as_millis();
                 let payload = build_llm_context_output(
@@ -2496,27 +2484,15 @@ pub fn run(args: crate::cli::Args) -> Result<()> {
                     println!("{}", serde_json::to_string_pretty(&payload)?);
                 }
             } else {
-                let mut results = index
-                    .query_with_temporal_context(
-                        &search_query,
+                let results = prepared
+                    .execute_on_index_with_semantics(
+                        &index,
                         DEFAULT_QUERY_TOP_K,
-                        temporal_context,
+                        None,
+                        &semantic_relations,
+                        &document_ids,
                     )
                     .0;
-                for result in &mut results {
-                    let state = semantic_relations.document_state(&result.doc_id);
-                    result.semantic_status = if historical_query
-                        && state.status
-                            == Some(crate::semantic_relations::SemanticStatus::Superseded)
-                    {
-                        Some(crate::semantic_relations::SemanticStatus::Historical)
-                    } else {
-                        state.status
-                    };
-                    result.superseded_by = state.superseded_by;
-                    result.relation_confidence = state.relation_confidence;
-                    result.relation_evidence = state.evidence;
-                }
                 let elapsed_ms = started.elapsed().as_millis();
                 let aggregation =
                     build_aggregate_output(&index, query, &results, DEFAULT_QUERY_TOP_K);

--- a/src/index.rs
+++ b/src/index.rs
@@ -1352,6 +1352,16 @@ impl MemoryIndex {
         top_k: usize,
         temporal: TemporalQueryContext<'_>,
     ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
+        self.query_with_temporal_context_at(query, top_k, temporal, None)
+    }
+
+    pub fn query_with_temporal_context_at(
+        &self,
+        query: &str,
+        top_k: usize,
+        temporal: TemporalQueryContext<'_>,
+        reference_date: Option<&str>,
+    ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
         let search_k = match temporal.query_routing_intent {
             Some(_) => top_k.saturating_mul(10).max(25),
             None => top_k.saturating_mul(5).max(20),
@@ -1359,8 +1369,8 @@ impl MemoryIndex {
         let total_start = Instant::now();
         let (temporal_start, temporal_end) =
             normalize_temporal_bounds(temporal.starts_from, temporal.ends_at);
-        let relative_anchor = temporal_start
-            .and(temporal.starts_from)
+        let relative_anchor = reference_date
+            .or(temporal_start.and(temporal.starts_from))
             .or(temporal_end.and(temporal.ends_at))
             .or(temporal.starts_from)
             .or(temporal.ends_at);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -4,13 +4,11 @@ use crate::chunking::{
 use crate::claim_extractor::{ClaimExtractor, ConservativeClaimExtractor};
 use crate::index::{
     build_semantic_doc_state, DocRecord, MemoryIndex, Provenance, QueryDiagnostics, QueryTimings,
-    SearchResult, SemanticAggregate, SemanticDocState, TemporalQueryContext,
+    SearchResult, SemanticAggregate, SemanticDocState,
 };
 use crate::query_plan::PreparedQuery;
 use crate::segments::{SegmentRoutingStrategy, SegmentedMemoryIndex};
-use crate::semantic_relations::{
-    is_historical_query, SemanticRelationStore, SemanticStatus, SupersessionOptions,
-};
+use crate::semantic_relations::{SemanticRelationStore, SupersessionOptions};
 use crate::source::SourceDocument;
 use crate::temporal::extract_temporal_terms;
 use crate::temporal_fact::TemporalFactStore;
@@ -921,81 +919,23 @@ impl IndexStore {
     }
 
     pub fn query(&mut self, query: &str, top_k: usize) -> Result<Vec<SearchResult>> {
-        self.refresh()?;
-        let allowed = self.semantic_allowed_doc_ids(query);
-        let context = TemporalQueryContext {
-            allowed_doc_ids: allowed.as_ref(),
-            ..TemporalQueryContext::default()
-        };
-        let snapshot = self
-            .snapshot
-            .as_ref()
-            .expect("snapshot should exist after refresh");
-        let results = match (snapshot, &self.options.memory_index_layout) {
-            (
-                MemoryIndexSnapshot::Segmented(index),
-                MemoryIndexLayout::Segmented {
-                    query_top_n,
-                    routing_strategy,
-                },
-            ) => {
-                index
-                    .query_with_temporal_context_and_diagnostics_and_strategy(
-                        query,
-                        top_k,
-                        (*query_top_n).max(1),
-                        *routing_strategy,
-                        context,
-                    )
-                    .results
-            }
-            _ => {
-                snapshot
-                    .global_index()
-                    .query_with_temporal_context(query, top_k, context)
-                    .0
-            }
-        };
-        Ok(self.annotate_semantic_results(query, results, top_k))
+        let prepared = PreparedQuery::new(query);
+        self.query_prepared(&prepared, top_k, &std::collections::BTreeMap::new())
     }
 
-    // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
-    #[allow(deprecated)]
     pub fn query_timed(
         &mut self,
         query: &str,
         top_k: usize,
     ) -> Result<(Vec<SearchResult>, QueryTimings, QueryDiagnostics)> {
-        let refresh_start = std::time::Instant::now();
-        self.refresh()?;
-        let refresh_ms = refresh_start.elapsed().as_secs_f64() * 1000.0;
-        let index = self
-            .snapshot
-            .as_ref()
-            .expect("snapshot should exist after refresh")
-            .global_index();
-        let allowed = self.semantic_allowed_doc_ids(query);
-        let context = TemporalQueryContext {
-            allowed_doc_ids: allowed.as_ref(),
-            ..TemporalQueryContext::default()
-        };
-        let (results, mut timings, diagnostics) =
-            index.query_with_temporal_context(query, top_k, context);
-        timings.refresh_ms = refresh_ms;
-        timings.total_ms += refresh_ms;
-        Ok((
-            self.annotate_semantic_results(query, results, top_k),
-            timings,
-            diagnostics,
-        ))
+        let prepared = PreparedQuery::new(query);
+        self.query_prepared_timed(&prepared, top_k, &std::collections::BTreeMap::new())
     }
 
-    /// Searches with the full query treatment the CLI gets, including intent inference
-    /// and query augmentation via [`PreparedQuery`], optionally scoped to the
-    /// documents matching `filters`.
-    ///
-    /// Prefer this over [`IndexStore::query_filtered`] for any caller handling
-    /// a raw user query, so the analysis stays identical across entry points.
+    /// Searches with the canonical query treatment: one [`PreparedQuery`] owns
+    /// intent inference, query augmentation, temporal context, and the optional
+    /// reference clock. `IndexStore` adds only semantic/filter scoping and
+    /// snapshot layout routing.
     pub fn query_prepared(
         &mut self,
         prepared: &PreparedQuery,
@@ -1003,21 +943,24 @@ impl IndexStore {
         filters: &std::collections::BTreeMap<String, String>,
     ) -> Result<Vec<SearchResult>> {
         self.refresh()?;
-        let index = self
-            .snapshot
-            .as_ref()
-            .expect("snapshot should exist after refresh")
-            .global_index();
-        let allowed = intersect_doc_id_filters(
-            index.doc_ids_matching_filters(filters),
-            self.semantic_allowed_doc_ids(prepared.search_query()),
-        );
-        let mut context = prepared.temporal_context();
-        context.allowed_doc_ids = allowed.as_ref();
-        let results = index
-            .query_with_temporal_context(prepared.search_query(), top_k, context)
-            .0;
-        Ok(self.annotate_semantic_results(prepared.search_query(), results, top_k))
+        self.execute_prepared_on_snapshot(prepared, top_k, filters)
+            .map(|(results, _, _)| results)
+    }
+
+    pub fn query_prepared_timed(
+        &mut self,
+        prepared: &PreparedQuery,
+        top_k: usize,
+        filters: &std::collections::BTreeMap<String, String>,
+    ) -> Result<(Vec<SearchResult>, QueryTimings, QueryDiagnostics)> {
+        let refresh_start = std::time::Instant::now();
+        self.refresh()?;
+        let refresh_ms = refresh_start.elapsed().as_secs_f64() * 1000.0;
+        let (results, mut timings, diagnostics) =
+            self.execute_prepared_on_snapshot(prepared, top_k, filters)?;
+        timings.refresh_ms += refresh_ms;
+        timings.total_ms += refresh_ms;
+        Ok((results, timings, diagnostics))
     }
 
     /// Query the current immutable snapshot without attempting a refresh.
@@ -1029,101 +972,96 @@ impl IndexStore {
         top_k: usize,
         filters: &std::collections::BTreeMap<String, String>,
     ) -> Result<Vec<SearchResult>> {
-        let Some(snapshot) = self.snapshot.as_ref() else {
+        if self.snapshot.is_none() {
             return Ok(Vec::new());
-        };
-        let index = snapshot.global_index();
-        let allowed = intersect_doc_id_filters(
-            index.doc_ids_matching_filters(filters),
-            self.semantic_allowed_doc_ids(prepared.search_query()),
-        );
-        let mut context = prepared.temporal_context();
-        context.allowed_doc_ids = allowed.as_ref();
-        let results = index
-            .query_with_temporal_context(prepared.search_query(), top_k, context)
-            .0;
-        Ok(self.annotate_semantic_results(prepared.search_query(), results, top_k))
+        }
+        self.execute_prepared_on_snapshot(prepared, top_k, filters)
+            .map(|(results, _, _)| results)
     }
 
-    // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
-    #[allow(deprecated)]
     pub fn query_filtered(
         &mut self,
         query: &str,
         top_k: usize,
         filters: &std::collections::BTreeMap<String, String>,
     ) -> Result<Vec<SearchResult>> {
-        self.refresh()?;
-        let index = self
-            .snapshot
-            .as_ref()
-            .expect("snapshot should exist after refresh")
-            .global_index();
-        let allowed = intersect_doc_id_filters(
-            index.doc_ids_matching_filters(filters),
-            self.semantic_allowed_doc_ids(query),
-        );
-        let context = TemporalQueryContext {
-            allowed_doc_ids: allowed.as_ref(),
-            ..TemporalQueryContext::default()
-        };
-        let results = index.query_with_temporal_context(query, top_k, context).0;
-        Ok(self.annotate_semantic_results(query, results, top_k))
+        let prepared = PreparedQuery::new(query);
+        self.query_prepared(&prepared, top_k, filters)
     }
 
-    fn semantic_allowed_doc_ids(&self, query: &str) -> Option<HashSet<String>> {
-        if is_historical_query(query) {
-            return None;
-        }
-
-        let has_superseded = self.source_docs.keys().any(|doc_id| {
-            self.semantic_relations.document_state(doc_id).status
-                == Some(SemanticStatus::Superseded)
-        });
-        has_superseded.then(|| {
-            self.source_docs
-                .keys()
-                .filter(|doc_id| {
-                    self.semantic_relations.document_state(doc_id).status
-                        != Some(SemanticStatus::Superseded)
-                })
-                .cloned()
-                .collect()
-        })
-    }
-
-    fn annotate_semantic_results(
+    fn execute_prepared_on_snapshot(
         &self,
-        query: &str,
-        results: Vec<SearchResult>,
+        prepared: &PreparedQuery,
         top_k: usize,
-    ) -> Vec<SearchResult> {
-        let historical = is_historical_query(query);
-        results
-            .into_iter()
-            .map(|mut result| {
-                let state = self.semantic_relations.document_state(&result.doc_id);
-                result.semantic_status =
-                    if historical && state.status == Some(SemanticStatus::Superseded) {
-                        Some(SemanticStatus::Historical)
-                    } else {
-                        state.status
-                    };
-                result.superseded_by = state.superseded_by;
-                result.relation_confidence = state.relation_confidence;
-                result.relation_evidence = state.evidence;
-                result
-            })
-            .take(top_k)
-            .collect()
+        filters: &std::collections::BTreeMap<String, String>,
+    ) -> Result<(Vec<SearchResult>, QueryTimings, QueryDiagnostics)> {
+        let Some(snapshot) = self.snapshot.as_ref() else {
+            return Ok((
+                Vec::new(),
+                QueryTimings::default(),
+                QueryDiagnostics::default(),
+            ));
+        };
+        let index = snapshot.global_index();
+        let filter_allowed = index.doc_ids_matching_filters(filters);
+        let document_ids = self.source_docs.keys().cloned().collect::<Vec<_>>();
+
+        let (results, timings, diagnostics) = match (snapshot, &self.options.memory_index_layout) {
+            (
+                MemoryIndexSnapshot::Segmented(segmented),
+                MemoryIndexLayout::Segmented {
+                    query_top_n,
+                    routing_strategy,
+                },
+            ) => {
+                let allowed = prepared.semantic_allowed_doc_ids(
+                    filter_allowed.clone(),
+                    &self.semantic_relations,
+                    &document_ids,
+                );
+                let mut context = prepared.temporal_context();
+                context.allowed_doc_ids = allowed.as_ref();
+                let started = std::time::Instant::now();
+                let output = segmented.query_with_temporal_context_at_and_diagnostics_and_strategy(
+                    prepared.search_query(),
+                    top_k,
+                    (*query_top_n).max(1),
+                    *routing_strategy,
+                    context,
+                    prepared.reference_date(),
+                );
+                let timings = QueryTimings {
+                    total_ms: started.elapsed().as_secs_f64() * 1000.0,
+                    ..QueryTimings::default()
+                };
+                let diagnostics = QueryDiagnostics {
+                    candidates: output.diagnostics.merged_result_count,
+                    ..QueryDiagnostics::default()
+                };
+                (
+                    prepared.annotate_semantic_results(
+                        output.results,
+                        &self.semantic_relations,
+                        top_k,
+                    ),
+                    timings,
+                    diagnostics,
+                )
+            }
+            _ => prepared.execute_on_index_with_semantics(
+                index,
+                top_k,
+                filter_allowed,
+                &self.semantic_relations,
+                &document_ids,
+            ),
+        };
+
+        Ok((results, timings, diagnostics))
     }
 
-    /// Multi-term variant: builds the allowed-doc set once from `filters`, then scores every
-    /// query. BM25 (tantivy) is still called once per term. That cannot be collapsed, but the
-    /// filter scan over all docs happens only once regardless of how many queries are given.
-    /// Returns one `Vec<SearchResult>` per input query, in the same order.
-    // Delegates to deprecated MemoryIndex helpers until they are removed in 0.2.0.
-    #[allow(deprecated)]
+    /// Multi-query convenience wrapper over the same prepared-query executor.
+    /// Refresh happens once, then each query uses the current immutable snapshot.
     pub fn query_filtered_multi(
         &mut self,
         queries: &[&str],
@@ -1131,25 +1069,12 @@ impl IndexStore {
         filters: &std::collections::BTreeMap<String, String>,
     ) -> Result<Vec<Vec<SearchResult>>> {
         self.refresh()?;
-        let index = self
-            .snapshot
-            .as_ref()
-            .expect("snapshot should exist after refresh")
-            .global_index();
-        let filter_allowed = index.doc_ids_matching_filters(filters);
         queries
             .iter()
             .map(|query| {
-                let query_allowed = intersect_doc_id_filters(
-                    filter_allowed.clone(),
-                    self.semantic_allowed_doc_ids(query),
-                );
-                let context = TemporalQueryContext {
-                    allowed_doc_ids: query_allowed.as_ref(),
-                    ..TemporalQueryContext::default()
-                };
-                let results = index.query_with_temporal_context(query, top_k, context).0;
-                Ok(self.annotate_semantic_results(query, results, top_k))
+                let prepared = PreparedQuery::new(query);
+                self.execute_prepared_on_snapshot(&prepared, top_k, filters)
+                    .map(|(results, _, _)| results)
             })
             .collect()
     }

--- a/src/query_plan.rs
+++ b/src/query_plan.rs
@@ -9,8 +9,13 @@
 //! Callers that have already built a context, or that deliberately want the
 //! default one, keep using `query_with_temporal_context` directly.
 
-use crate::index::{TemporalQueryContext, TemporalQueryHint};
+use crate::index::{
+    MemoryIndex, QueryDiagnostics, QueryTimings, SearchResult, TemporalQueryContext,
+    TemporalQueryHint,
+};
 use crate::query_semantics::{analyze_query, QueryAnalysis, QueryTimeHint};
+use crate::semantic_relations::{is_historical_query, SemanticRelationStore, SemanticStatus};
+use std::collections::HashSet;
 
 /// A raw query plus the analysis derived from it.
 ///
@@ -18,19 +23,37 @@ use crate::query_semantics::{analyze_query, QueryAnalysis, QueryTimeHint};
 /// stays valid; build one per query and keep it alive for the search.
 pub struct PreparedQuery {
     analysis: QueryAnalysis,
+    reference_date: Option<String>,
 }
 
 impl PreparedQuery {
     pub fn new(query: &str) -> Self {
         Self {
             analysis: analyze_query(query),
+            reference_date: None,
         }
+    }
+
+    /// Builds a query whose relative temporal language is resolved against
+    /// `reference_date` instead of the machine clock.
+    pub fn new_at(query: &str, reference_date: &str) -> Self {
+        Self {
+            analysis: analyze_query(query),
+            reference_date: Some(reference_date.to_string()),
+        }
+    }
+
+    pub fn reference_date(&self) -> Option<&str> {
+        self.reference_date.as_deref()
     }
 
     /// Reuses an analysis the caller already computed, so no query is analyzed
     /// twice on paths that need the analysis for other reasons too.
     pub fn from_analysis(analysis: QueryAnalysis) -> Self {
-        Self { analysis }
+        Self {
+            analysis,
+            reference_date: None,
+        }
     }
 
     pub fn analysis(&self) -> &QueryAnalysis {
@@ -75,6 +98,118 @@ impl PreparedQuery {
             allowed_doc_ids: None,
         }
     }
+
+    /// Executes this prepared query against a single memory index.
+    ///
+    /// This is the canonical adapter from query analysis into index execution:
+    /// callers provide only document scoping. Temporal context, query routing,
+    /// augmented query text, and the optional reference clock always come from
+    /// the same `PreparedQuery` instance.
+    pub fn execute_on_index(
+        &self,
+        index: &MemoryIndex,
+        top_k: usize,
+        allowed_doc_ids: Option<&HashSet<String>>,
+    ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
+        let mut context = self.temporal_context();
+        context.allowed_doc_ids = allowed_doc_ids;
+        index.query_with_temporal_context_at(
+            self.search_query(),
+            top_k,
+            context,
+            self.reference_date(),
+        )
+    }
+
+    /// Intersects caller-provided document filters with current-state semantic policy.
+    /// Historical queries retain superseded documents; ordinary queries suppress them.
+    pub fn semantic_allowed_doc_ids(
+        &self,
+        base_allowed_doc_ids: Option<HashSet<String>>,
+        semantic_relations: &SemanticRelationStore,
+        document_ids: &[String],
+    ) -> Option<HashSet<String>> {
+        let semantic_allowed = if is_historical_query(&self.analysis.original_query) {
+            None
+        } else {
+            let has_superseded = document_ids.iter().any(|doc_id| {
+                semantic_relations.document_state(doc_id).status == Some(SemanticStatus::Superseded)
+            });
+            has_superseded.then(|| {
+                document_ids
+                    .iter()
+                    .filter(|doc_id| {
+                        semantic_relations.document_state(doc_id).status
+                            != Some(SemanticStatus::Superseded)
+                    })
+                    .cloned()
+                    .collect()
+            })
+        };
+        intersect_allowed_doc_ids(base_allowed_doc_ids, semantic_allowed)
+    }
+
+    /// Applies semantic provenance consistently after ranking.
+    pub fn annotate_semantic_results(
+        &self,
+        results: Vec<SearchResult>,
+        semantic_relations: &SemanticRelationStore,
+        top_k: usize,
+    ) -> Vec<SearchResult> {
+        let historical = is_historical_query(&self.analysis.original_query);
+        results
+            .into_iter()
+            .map(|mut result| {
+                let state = semantic_relations.document_state(&result.doc_id);
+                result.semantic_status =
+                    if historical && state.status == Some(SemanticStatus::Superseded) {
+                        Some(SemanticStatus::Historical)
+                    } else {
+                        state.status
+                    };
+                result.superseded_by = state.superseded_by;
+                result.relation_confidence = state.relation_confidence;
+                result.relation_evidence = state.evidence;
+                result
+            })
+            .take(top_k)
+            .collect()
+    }
+
+    /// Canonical high-level execution for a prepared query on a single index.
+    ///
+    /// Both the CLI cache path and `IndexStore` use this method, so temporal
+    /// interpretation, semantic suppression, and provenance annotation cannot drift.
+    pub fn execute_on_index_with_semantics(
+        &self,
+        index: &MemoryIndex,
+        top_k: usize,
+        base_allowed_doc_ids: Option<HashSet<String>>,
+        semantic_relations: &SemanticRelationStore,
+        document_ids: &[String],
+    ) -> (Vec<SearchResult>, QueryTimings, QueryDiagnostics) {
+        let allowed_doc_ids =
+            self.semantic_allowed_doc_ids(base_allowed_doc_ids, semantic_relations, document_ids);
+        let (results, timings, diagnostics) =
+            self.execute_on_index(index, top_k, allowed_doc_ids.as_ref());
+        (
+            self.annotate_semantic_results(results, semantic_relations, top_k),
+            timings,
+            diagnostics,
+        )
+    }
+}
+
+fn intersect_allowed_doc_ids(
+    left: Option<HashSet<String>>,
+    right: Option<HashSet<String>>,
+) -> Option<HashSet<String>> {
+    match (left, right) {
+        (None, None) => None,
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (Some(left), Some(right)) => Some(left.intersection(&right).cloned().collect()),
+    }
 }
 
 #[cfg(test)]
@@ -98,6 +233,13 @@ mod tests {
             prepared.search_query(),
             prepared.analysis().augmented_query.as_str()
         );
+    }
+
+    #[test]
+    fn explicit_reference_date_is_preserved() {
+        let prepared = PreparedQuery::new_at("What happened two weeks ago?", "2024-05-10");
+        assert_eq!(prepared.reference_date(), Some("2024-05-10"));
+        assert!(PreparedQuery::new("anything").reference_date().is_none());
     }
 
     #[test]

--- a/src/query_semantics.rs
+++ b/src/query_semantics.rs
@@ -564,9 +564,6 @@ fn query_routing_intent(
         "earliest",
         "latest",
         "first",
-        "last",
-        "next",
-        "previous",
         "before",
         "after",
         "order",
@@ -843,7 +840,7 @@ fn temporal_candidates(query: &str) -> Vec<PhraseMatch> {
         r"\b(today|tomorrow|yesterday|tonight)\b",
         r"\b(?:last|this|next)\s+(?:week|month|year|weekend)\b",
         r"\b(?:last|this|next)\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
-        r"\b(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten)\s+(?:day|days|week|weeks|month|months|year|years)(?:\s+ago)?\b",
+        r"\b(?:a\s+couple\s+of|couple\s+of|a|an|\d+|one|two|three|four|five|six|seven|eight|nine|ten)\s+(?:day|days|week|weeks|month|months|year|years)(?:\s+ago)?\b",
         r"\bconsecutive days\b",
     ];
 
@@ -1204,6 +1201,23 @@ mod tests {
         let sequence = analyze_query("Which tasks happened in consecutive days?");
         assert_eq!(
             sequence.query_routing_intent,
+            Some(QueryRoutingIntent::Sequence)
+        );
+    }
+
+    #[test]
+    fn ordinary_relative_dates_are_not_sequence_queries() {
+        let weekday = analyze_query("Who did I meet last Tuesday?");
+        assert!(weekday.temporal.is_some());
+        assert_ne!(
+            weekday.query_routing_intent,
+            Some(QueryRoutingIntent::Sequence)
+        );
+
+        let couple = analyze_query("What did I cook a couple of days ago?");
+        assert!(couple.temporal.is_some());
+        assert_ne!(
+            couple.query_routing_intent,
             Some(QueryRoutingIntent::Sequence)
         );
     }

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -254,6 +254,7 @@ impl SegmentedMemoryIndex {
             segment_limit,
             strategy,
             TemporalQueryContext::default(),
+            None,
             self.global_index.as_ref(),
             &self.corpus_stats,
         )
@@ -267,6 +268,25 @@ impl SegmentedMemoryIndex {
         strategy: SegmentRoutingStrategy,
         temporal: TemporalQueryContext<'_>,
     ) -> SegmentQueryOutput {
+        self.query_with_temporal_context_at_and_diagnostics_and_strategy(
+            query,
+            top_k,
+            segment_limit,
+            strategy,
+            temporal,
+            None,
+        )
+    }
+
+    pub fn query_with_temporal_context_at_and_diagnostics_and_strategy(
+        &self,
+        query: &str,
+        top_k: usize,
+        segment_limit: usize,
+        strategy: SegmentRoutingStrategy,
+        temporal: TemporalQueryContext<'_>,
+        reference_date: Option<&str>,
+    ) -> SegmentQueryOutput {
         query_top_segments_with_corpus_stats_and_strategy(
             query,
             top_k,
@@ -274,6 +294,7 @@ impl SegmentedMemoryIndex {
             segment_limit,
             strategy,
             temporal,
+            reference_date,
             self.global_index.as_ref(),
             &self.corpus_stats,
         )
@@ -481,6 +502,7 @@ impl SegmentedMemoryIndex {
             self.segments.len(),
             SegmentRoutingStrategy::SparseOverlap,
             temporal,
+            None,
             self.global_index.as_ref(),
             &self.corpus_stats,
         )
@@ -886,6 +908,7 @@ pub fn query_top_segments_with_diagnostics(
         SegmentRoutingStrategy::SparseOverlap,
         TemporalQueryContext::default(),
         None,
+        None,
         &corpus_stats,
     )
 }
@@ -906,6 +929,7 @@ pub fn query_top_segments_with_diagnostics_and_strategy(
         strategy,
         TemporalQueryContext::default(),
         None,
+        None,
         &corpus_stats,
     )
 }
@@ -918,6 +942,7 @@ fn query_top_segments_with_corpus_stats_and_strategy(
     segment_limit: usize,
     strategy: SegmentRoutingStrategy,
     temporal: TemporalQueryContext<'_>,
+    reference_date: Option<&str>,
     global_index: Option<&MemoryIndex>,
     corpus_stats: &SegmentCorpusStats,
 ) -> SegmentQueryOutput {
@@ -1005,7 +1030,7 @@ fn query_top_segments_with_corpus_stats_and_strategy(
                 ..temporal
             };
             merged = global_index
-                .query_with_temporal_context(query, top_k, scoped_temporal)
+                .query_with_temporal_context_at(query, top_k, scoped_temporal, reference_date)
                 .0;
         } else if let Some(global_index) = build_global_index_from_segments(segments) {
             let allowed_doc_ids =
@@ -1015,7 +1040,7 @@ fn query_top_segments_with_corpus_stats_and_strategy(
                 ..temporal
             };
             merged = global_index
-                .query_with_temporal_context(query, top_k, scoped_temporal)
+                .query_with_temporal_context_at(query, top_k, scoped_temporal, reference_date)
                 .0;
         }
     }

--- a/src/semantic_relations.rs
+++ b/src/semantic_relations.rs
@@ -346,7 +346,28 @@ fn document_contains_only_target_claim(
     documents
         .iter()
         .find(|document| document.doc_id == relation.target_doc_id)
-        .is_some_and(|document| normalize(&document.content) == normalize(&target_claim.evidence))
+        .is_some_and(|document| {
+            normalize(&claim_bearing_document_content(&document.content))
+                == normalize(&target_claim.evidence)
+        })
+}
+
+fn claim_bearing_document_content(content: &str) -> String {
+    content
+        .lines()
+        .filter(|line| !is_markdown_heading_line(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn is_markdown_heading_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let hashes = trimmed.bytes().take_while(|byte| *byte == b'#').count();
+    (1..=6).contains(&hashes)
+        && trimmed
+            .as_bytes()
+            .get(hashes)
+            .is_some_and(u8::is_ascii_whitespace)
 }
 
 fn push_relation(
@@ -410,6 +431,17 @@ fn extract_claims(doc: &SourceDocument) -> Vec<SemanticClaim> {
                 claims.len(),
             ));
         }
+        if let Some((subject, predicate, object)) = configuration_claim(sentence) {
+            claims.push(make_claim_in_scope(
+                doc,
+                sentence,
+                &subject,
+                predicate,
+                &object,
+                claims.len(),
+                scalar_configuration_scope(doc),
+            ));
+        }
     }
     dedupe_claims(&mut claims);
     claims
@@ -434,6 +466,26 @@ fn make_claim(
     object: &str,
     index: usize,
 ) -> SemanticClaim {
+    make_claim_in_scope(
+        doc,
+        evidence,
+        subject,
+        predicate,
+        object,
+        index,
+        semantic_scope(doc),
+    )
+}
+
+fn make_claim_in_scope(
+    doc: &SourceDocument,
+    evidence: &str,
+    subject: &str,
+    predicate: &str,
+    object: &str,
+    index: usize,
+    scope: String,
+) -> SemanticClaim {
     let subject = clean_phrase(subject);
     let object = clean_phrase(object);
     SemanticClaim {
@@ -444,7 +496,7 @@ fn make_claim(
         source_doc_id: doc.doc_id.clone(),
         evidence: evidence.trim().to_string(),
         effective_at: doc.timestamp.clone(),
-        scope: semantic_scope(doc),
+        scope,
         confidence: 0.85,
     }
 }
@@ -503,6 +555,19 @@ fn usage_claim(sentence: &str) -> Option<(String, &'static str, String)> {
     });
     uses.captures(sentence)
         .map(|caps| (caps[1].to_string(), "implementation", caps[2].to_string()))
+}
+
+fn configuration_claim(sentence: &str) -> Option<(String, &'static str, String)> {
+    static SCALAR_CONFIGURATION: OnceLock<Regex> = OnceLock::new();
+    let scalar = SCALAR_CONFIGURATION.get_or_init(|| {
+        Regex::new(
+            r"(?i)^(?:[-*]\s*)?(?:the\s+)?([a-z][a-z0-9 _/.-]{1,100}?)\s*(?::|=)\s*(-?\d+(?:\.\d+)?(?:\s*(?:ms|s|sec(?:ond)?s?|m|min(?:ute)?s?|h|hours?|%|kb|mb|gb|tb))?|true|false|enabled|disabled)$",
+        )
+        .expect("valid scalar configuration regex")
+    });
+    scalar
+        .captures(sentence)
+        .map(|caps| (caps[1].to_string(), "value", caps[2].to_string()))
 }
 
 fn sentences(content: &str) -> Vec<&str> {
@@ -565,6 +630,59 @@ fn semantic_scope(doc: &SourceDocument) -> String {
                 .map(|user| format!("user:{user}"))
         })
         .unwrap_or_else(|| "store".to_string())
+}
+
+fn scalar_configuration_scope(doc: &SourceDocument) -> String {
+    let base = semantic_scope(doc);
+    if doc.filters.contains_key("semantic_scope") {
+        return base;
+    }
+    if let Some(group_id) = doc.group_id.as_deref() {
+        let group = normalize(group_id);
+        if !group.is_empty() {
+            return format!("{base}::group:{group}");
+        }
+    }
+    if source_kind(doc) == "document" {
+        let parent = document_parent_scope(doc);
+        if let Some(heading) = doc.headings.iter().find_map(|heading| {
+            let heading = normalize(heading);
+            (!heading.is_empty() && !is_generic_scalar_heading(&heading)).then_some(heading)
+        }) {
+            return format!("{base}::parent:{parent}::heading:{heading}");
+        }
+        let concept = normalize(&doc.concept);
+        if !concept.is_empty() {
+            return format!("{base}::parent:{parent}::concept:{concept}");
+        }
+    }
+    format!("{base}::doc:{}", doc.doc_id)
+}
+
+fn document_parent_scope(doc: &SourceDocument) -> String {
+    doc.source
+        .rsplit_once('/')
+        .map(|(parent, _)| parent)
+        .or_else(|| doc.source.rsplit_once('\\').map(|(parent, _)| parent))
+        .map(normalize)
+        .unwrap_or_default()
+}
+
+fn is_generic_scalar_heading(heading: &str) -> bool {
+    matches!(
+        heading,
+        "config"
+            | "configuration"
+            | "setting"
+            | "settings"
+            | "policy"
+            | "decision"
+            | "defaults"
+            | "parameter"
+            | "parameters"
+            | "option"
+            | "options"
+    )
 }
 
 fn source_kind(doc: &SourceDocument) -> &'static str {
@@ -1002,5 +1120,230 @@ mod tests {
                 "expected current-state query: {query}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod scalar_configuration_supersession_tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn scalar_doc(id: &str, content: &str, timestamp: &str) -> SourceDocument {
+        SourceDocument {
+            doc_id: id.to_string(),
+            source: format!("docs/{id}.md"),
+            content: content.to_string(),
+            concept: "gateway retry policy".to_string(),
+            group_id: None,
+            filters: BTreeMap::new(),
+            headings: vec![],
+            links: vec![],
+            timestamp: Some(timestamp.to_string()),
+            doc_length: content.len(),
+            author_agent: None,
+        }
+    }
+
+    #[test]
+    fn unrelated_scalar_configuration_domains_do_not_supersede_each_other() {
+        let mut payments = scalar_doc("payments", "Retry attempts: 5.", "2026-01-01");
+        payments.concept = "payments".to_string();
+        payments.headings = vec!["Payments Retry Policy".to_string()];
+
+        let mut worker = scalar_doc("image-worker", "Retry attempts: 2.", "2026-06-01");
+        worker.concept = "image worker".to_string();
+        worker.headings = vec!["Image Worker Retry Policy".to_string()];
+
+        let store = SemanticRelationStore::from_documents(
+            [&payments, &worker],
+            SupersessionOptions::default(),
+        );
+        assert_eq!(
+            store.document_state("payments").status,
+            Some(SemanticStatus::Current)
+        );
+        assert_eq!(
+            store.document_state("image-worker").status,
+            Some(SemanticStatus::Current)
+        );
+        assert!(!store.relations().iter().any(|relation| {
+            relation.kind == SemanticRelationKind::Supersedes
+                && relation.source_doc_id == "image-worker"
+                && relation.target_doc_id == "payments"
+        }));
+    }
+
+    #[test]
+    fn same_filename_concept_in_different_directories_does_not_collide() {
+        let mut payments = scalar_doc("payments-config", "Retry attempts: 5.", "2026-01-01");
+        payments.source = "services/payments/config.md".to_string();
+        payments.concept = "config".to_string();
+        payments.headings.clear();
+
+        let mut worker = scalar_doc("worker-config", "Retry attempts: 2.", "2026-06-01");
+        worker.source = "services/image-worker/config.md".to_string();
+        worker.concept = "config".to_string();
+        worker.headings.clear();
+
+        let store = SemanticRelationStore::from_documents(
+            [&payments, &worker],
+            SupersessionOptions::default(),
+        );
+        assert_eq!(
+            store.document_state("payments-config").status,
+            Some(SemanticStatus::Current)
+        );
+        assert_eq!(
+            store.document_state("worker-config").status,
+            Some(SemanticStatus::Current)
+        );
+    }
+
+    #[test]
+    fn generic_headings_in_different_directories_do_not_collide() {
+        let mut payments = scalar_doc(
+            "payments-config",
+            "# Configuration\n\nTimeout: 30s.",
+            "2026-01-01",
+        );
+        payments.source = "services/payments/config.md".to_string();
+        payments.concept = "config".to_string();
+        payments.headings = vec!["Configuration".to_string()];
+
+        let mut worker = scalar_doc(
+            "worker-config",
+            "# Configuration\n\nTimeout: 10s.",
+            "2026-06-01",
+        );
+        worker.source = "services/image-worker/config.md".to_string();
+        worker.concept = "config".to_string();
+        worker.headings = vec!["Configuration".to_string()];
+
+        let store = SemanticRelationStore::from_documents(
+            [&payments, &worker],
+            SupersessionOptions::default(),
+        );
+        assert_eq!(
+            store.document_state("payments-config").status,
+            Some(SemanticStatus::Current)
+        );
+        assert_eq!(
+            store.document_state("worker-config").status,
+            Some(SemanticStatus::Current)
+        );
+    }
+
+    #[test]
+    fn same_specific_heading_in_different_directories_does_not_collide() {
+        let mut payments = scalar_doc(
+            "payments-retry",
+            "# Retry Policy\n\nRetry attempts: 5.",
+            "2026-01-01",
+        );
+        payments.source = "services/payments/retry.md".to_string();
+        payments.headings = vec!["Retry Policy".to_string()];
+
+        let mut worker = scalar_doc(
+            "worker-retry",
+            "# Retry Policy\n\nRetry attempts: 2.",
+            "2026-06-01",
+        );
+        worker.source = "services/image-worker/retry.md".to_string();
+        worker.headings = vec!["Retry Policy".to_string()];
+
+        let store = SemanticRelationStore::from_documents(
+            [&payments, &worker],
+            SupersessionOptions::default(),
+        );
+        assert_eq!(
+            store.document_state("payments-retry").status,
+            Some(SemanticStatus::Current)
+        );
+        assert_eq!(
+            store.document_state("worker-retry").status,
+            Some(SemanticStatus::Current)
+        );
+    }
+
+    #[test]
+    fn same_heading_scalar_configuration_still_supersedes_by_time() {
+        let mut old = scalar_doc(
+            "decision-a",
+            "# Gateway Retry Policy\n\nGateway timeout retry attempts: 5.",
+            "2026-01-01",
+        );
+        old.headings = vec!["Gateway Retry Policy".to_string()];
+        old.concept = "decision a".to_string();
+
+        let mut new = scalar_doc(
+            "decision-b",
+            "# Gateway Retry Policy\n\nGateway timeout retry attempts: 2.",
+            "2026-06-01",
+        );
+        new.headings = vec!["Gateway Retry Policy".to_string()];
+        new.concept = "decision b".to_string();
+
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+        assert_eq!(
+            store.document_state("decision-a").status,
+            Some(SemanticStatus::Superseded)
+        );
+        assert_eq!(
+            store.document_state("decision-a").superseded_by.as_deref(),
+            Some("decision-b")
+        );
+    }
+
+    #[test]
+    fn non_heading_extra_content_prevents_whole_document_suppression() {
+        let mut old = scalar_doc(
+            "decision-a",
+            "# Gateway Retry Policy\n\nGateway timeout retry attempts: 5.\nAdditional rationale remains relevant.",
+            "2026-01-01",
+        );
+        old.headings = vec!["Gateway Retry Policy".to_string()];
+        let mut new = scalar_doc(
+            "decision-b",
+            "# Gateway Retry Policy\n\nGateway timeout retry attempts: 2.",
+            "2026-06-01",
+        );
+        new.headings = vec!["Gateway Retry Policy".to_string()];
+
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+        assert_eq!(
+            store.document_state("decision-a").status,
+            Some(SemanticStatus::Conflicted)
+        );
+    }
+
+    #[test]
+    fn newer_scalar_configuration_claim_supersedes_older_value_by_time() {
+        let old = scalar_doc(
+            "decision-a",
+            "Gateway timeout retry attempts: 5.",
+            "2026-01-01",
+        );
+        let new = scalar_doc(
+            "decision-b",
+            "Gateway timeout retry attempts: 2.",
+            "2026-06-01",
+        );
+        let store =
+            SemanticRelationStore::from_documents([&old, &new], SupersessionOptions::default());
+        assert_eq!(
+            store.document_state("decision-a").status,
+            Some(SemanticStatus::Superseded)
+        );
+        assert_eq!(
+            store.document_state("decision-a").superseded_by.as_deref(),
+            Some("decision-b")
+        );
+        assert!(store.relations().iter().any(|relation| {
+            relation.kind == SemanticRelationKind::Supersedes
+                && relation.method == "canonical_claim_and_time"
+                && (relation.confidence - 0.90).abs() < f32::EPSILON
+        }));
     }
 }

--- a/src/temporal.rs
+++ b/src/temporal.rs
@@ -138,9 +138,6 @@ pub fn parse_temporal_date(input: Option<&str>) -> Option<NaiveDate> {
 pub fn resolve_temporal_target(query: &str, anchor_date: Option<&str>) -> Option<TemporalTarget> {
     let base_date = parse_date(anchor_date)
         .unwrap_or_else(|| DateTime::<Utc>::from(SystemTime::now()).date_naive());
-    if let Some(target) = resolve_temporal_target_with_temps(query, base_date) {
-        return Some(target);
-    }
     let lower = query.to_lowercase();
 
     if lower.contains("today") {
@@ -286,7 +283,7 @@ pub fn resolve_temporal_target(query: &str, anchor_date: Option<&str>) -> Option
         });
     }
 
-    None
+    resolve_temporal_target_with_temps(query, base_date)
 }
 
 fn resolve_temporal_target_with_temps(query: &str, base_date: NaiveDate) -> Option<TemporalTarget> {
@@ -510,7 +507,7 @@ fn ago_patterns(lower: &str) -> Vec<(u32, String, String)> {
     static AGO_RE: OnceLock<Regex> = OnceLock::new();
     let re = AGO_RE.get_or_init(|| {
         Regex::new(
-            r"\b(one|two|three|four|five|six|seven|eight|nine|ten|1|2|3|4|5|6|7|8|9|10)\s+(day|week|month|year)s?\s+ago\b",
+            r"\b(a couple of|couple of|a|an|one|two|three|four|five|six|seven|eight|nine|ten|1|2|3|4|5|6|7|8|9|10)\s+(day|week|month|year)s?\s+ago\b",
         )
             .expect("valid ago regex")
     });
@@ -584,6 +581,12 @@ fn parse_date(input: Option<&str>) -> Option<NaiveDate> {
         })
         .or_else(|| NaiveDate::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").ok())
         .or_else(|| NaiveDate::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f").ok())
+        .or_else(|| {
+            s.parse::<i64>()
+                .ok()
+                .and_then(|seconds| DateTime::<Utc>::from_timestamp(seconds, 0))
+                .map(|date| date.date_naive())
+        })
 }
 
 fn query_word_tokens(query: &str) -> Vec<String> {
@@ -719,7 +722,8 @@ fn last_day_of_month(year: i32, month: u32) -> u32 {
 
 fn word_to_num(input: &str) -> u32 {
     match input {
-        "one" | "1" => 1,
+        "a" | "an" | "one" | "1" => 1,
+        "a couple of" | "couple of" => 2,
         "two" | "2" => 2,
         "three" | "3" => 3,
         "four" | "4" => 4,
@@ -792,6 +796,34 @@ mod tests {
     }
 
     #[test]
+    fn resolves_last_weekday_against_explicit_anchor() {
+        let target = resolve_temporal_target("Who did I meet last Tuesday?", Some("2024-05-10"))
+            .expect("expected temporal target");
+        assert_eq!(
+            target.target_date,
+            NaiveDate::from_ymd_opt(2024, 5, 7).unwrap()
+        );
+    }
+
+    #[test]
+    fn resolves_article_and_couple_ago_phrases() {
+        let one_week = resolve_temporal_target("What happened a week ago?", Some("2024-05-10"))
+            .expect("expected one-week target");
+        assert_eq!(
+            one_week.target_date,
+            NaiveDate::from_ymd_opt(2024, 5, 3).unwrap()
+        );
+
+        let couple_days =
+            resolve_temporal_target("What did I cook a couple of days ago?", Some("2024-05-10"))
+                .expect("expected two-day target");
+        assert_eq!(
+            couple_days.target_date,
+            NaiveDate::from_ymd_opt(2024, 5, 8).unwrap()
+        );
+    }
+
+    #[test]
     fn reveals_bug_rfc3339_timestamp_with_timezone_is_not_parsed() {
         assert_eq!(
             parse_temporal_date(Some("2024-05-10T14:30:00+00:00")),
@@ -812,5 +844,16 @@ mod tests {
         )
         .expect("timestamp should receive a recency boost");
         assert!((boost - 0.125).abs() < 0.001, "boost={boost}");
+    }
+}
+
+#[cfg(test)]
+mod unix_timestamp_tests {
+    use super::parse_temporal_date;
+
+    #[test]
+    fn parses_unix_epoch_seconds_for_timeline_dates() {
+        let date = parse_temporal_date(Some("1788710927")).expect("epoch timestamp should parse");
+        assert_eq!(date.to_string(), "2026-09-06");
     }
 }

--- a/tests/cli_supersession.rs
+++ b/tests/cli_supersession.rs
@@ -90,3 +90,88 @@ fn cli_query_and_llm_context_suppress_explicitly_superseded_markdown() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn cli_uses_file_timeline_to_supersede_scalar_configuration_without_metadata() {
+    let root = temp_dir();
+    let old_path = root.join("decision-a.md");
+    let new_path = root.join("decision-b.md");
+    fs::write(
+        &old_path,
+        "# Gateway Retry Policy\n\nGateway timeout retry attempts: 5.\n",
+    )
+    .unwrap();
+    fs::write(
+        &new_path,
+        "# Gateway Retry Policy\n\nGateway timeout retry attempts: 2.\n",
+    )
+    .unwrap();
+
+    let old_time = UNIX_EPOCH + std::time::Duration::from_secs(1_735_689_600);
+    let new_time = UNIX_EPOCH + std::time::Duration::from_secs(1_767_225_600);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&old_path)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(old_time))
+        .unwrap();
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&new_path)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(new_time))
+        .unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_lint-ai");
+    let query = "How many retry attempts should we use for gateway timeouts?";
+    let output = Command::new(bin)
+        .current_dir(&root)
+        .args(["--query", query, root.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = payload["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        1,
+        "older timeline value must be suppressed: {payload:#}"
+    );
+    assert_eq!(results[0]["doc_id"], "decision-b.md");
+    assert_eq!(results[0]["semantic_status"], "current");
+    assert!(payload["aggregation"].is_null());
+
+    let output = Command::new(bin)
+        .current_dir(&root)
+        .args([
+            "--llm-context",
+            query,
+            "--result-count",
+            "5",
+            root.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let chunks = payload["top_chunks"].as_array().unwrap();
+    assert!(chunks
+        .iter()
+        .all(|chunk| chunk["doc_id"] != "decision-a.md"));
+    assert!(chunks.iter().any(|chunk| {
+        chunk["doc_id"] == "decision-b.md"
+            && chunk["text"]
+                .as_str()
+                .unwrap_or("")
+                .contains("retry attempts: 2")
+    }));
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/query_path_consistency.rs
+++ b/tests/query_path_consistency.rs
@@ -1,0 +1,68 @@
+use lint_ai::query_plan::PreparedQuery;
+use lint_ai::{IndexStore, PipelineOptions, SourceDocument};
+use std::collections::BTreeMap;
+
+fn document(id: &str, content: &str, timestamp: &str, group: &str) -> SourceDocument {
+    SourceDocument {
+        doc_id: id.to_string(),
+        source: format!("memory://{id}"),
+        content: content.to_string(),
+        concept: "deployment memory".to_string(),
+        group_id: Some(group.to_string()),
+        headings: vec!["Deployment".to_string()],
+        links: vec![],
+        timestamp: Some(timestamp.to_string()),
+        doc_length: content.len(),
+        author_agent: None,
+        filters: BTreeMap::new(),
+    }
+}
+
+fn ids(results: &[lint_ai::SearchResult]) -> Vec<&str> {
+    results
+        .iter()
+        .map(|result| result.doc_id.as_str())
+        .collect()
+}
+
+#[test]
+fn index_store_convenience_queries_share_the_prepared_path() {
+    let mut store = IndexStore::in_memory(PipelineOptions::default());
+    store.upsert(document(
+        "alpha",
+        "The deployment database is Postgres and the service runs in production.",
+        "2026-08-01",
+        "service-a",
+    ));
+    store.upsert(document(
+        "beta",
+        "The deployment cache is Redis and the service runs in staging.",
+        "2026-08-02",
+        "service-b",
+    ));
+
+    let query = "What database did I pick for the deployment?";
+    let filters = BTreeMap::new();
+    let prepared = PreparedQuery::new(query);
+
+    let canonical = store.query_prepared(&prepared, 5, &filters).unwrap();
+    let plain = store.query(query, 5).unwrap();
+    let filtered = store.query_filtered(query, 5, &filters).unwrap();
+    let timed = store.query_timed(query, 5).unwrap().0;
+    let multi = store.query_filtered_multi(&[query], 5, &filters).unwrap();
+    let cached = store.query_prepared_cached(&prepared, 5, &filters).unwrap();
+
+    assert_eq!(ids(&plain), ids(&canonical));
+    assert_eq!(ids(&filtered), ids(&canonical));
+    assert_eq!(ids(&timed), ids(&canonical));
+    assert_eq!(ids(&multi[0]), ids(&canonical));
+    assert_eq!(ids(&cached), ids(&canonical));
+}
+
+#[test]
+fn cli_uses_the_canonical_semantic_executor() {
+    let engine = include_str!("../src/engine.rs");
+    assert!(engine.contains("execute_on_index_with_semantics"));
+    assert!(!engine.contains("semantic_relations::is_historical_query(query)"));
+    assert!(!engine.contains("crate::semantic_relations::SemanticStatus::Superseded"));
+}


### PR DESCRIPTION
## Summary

- infer chronological supersession for scalar configuration/value facts without requiring explicit `supersedes:` metadata, but only inside an established semantic domain
- keep explicit `supersedes:` links authoritative
- isolate inferred scalar claims by explicit semantic scope/group, or for ordinary documents by parent directory plus a specific heading/concept; generic headings such as `Configuration` are not trusted as a cross-document domain
- parse Markdown filesystem epoch timestamps so they participate in the timeline
- add an explicit query reference clock for relative phrases such as `last Tuesday`, `a week ago`, and `a couple of days ago`
- prefer deterministic anchored temporal rules before the generic natural-language fallback
- avoid routing ordinary relative-date queries as sequence queries solely because they contain `last`, `next`, or `previous`
- consolidate high-level query execution around `PreparedQuery`, so query analysis, augmented search text, temporal context, routing intent, reference-clock handling, semantic suppression, and provenance annotation use one canonical policy
- make `IndexStore::query`, `query_timed`, `query_filtered`, cached prepared queries, and multi-query convenience APIs delegate to the same prepared-query executor
- make the CLI keep its cached `MemoryIndex` but route both `--query` and `--llm-context` through `PreparedQuery::execute_on_index_with_semantics`, eliminating the CLI's duplicate historical/superseded filtering and annotation logic
- preserve segmented IndexStore routing while carrying the same semantic policy and reference clock into segmented retrieval
- run LongMemEval through the normal `IndexStore` query path on the pinned cleaned LongMemEval-S dataset
- preserve the comparison, experiment, miss-extraction, and validation workflows used during evaluation

## Security / integrity hardening

The initial scalar chronology implementation could let unrelated documents with generic keys such as `timeout` or `retry attempts` collide at store scope. This PR now requires domain evidence before inferred scalar chronology can suppress an older document.

Regression coverage verifies that:
- unrelated scalar domains do not supersede one another
- identical `config.md` concepts in different service directories do not collide
- generic headings such as `Configuration` in different directories do not collide
- even the same specific heading in different service directories does not collide
- same-domain `Gateway Retry Policy` documents still infer `5 -> 2` by chronology with no explicit supersedes frontmatter
- Markdown heading lines are structural and do not block single-claim suppression, while additional substantive body content keeps the older document conflicted rather than suppressing it wholesale

## Query-path regression coverage

- CLI regression verifies implicit `5 -> 2` supersession using filesystem chronology and a shared domain heading, with no explicit `supersedes:` frontmatter
- relative-date tests cover anchored weekday, `a week ago`, and `a couple of days ago` resolution
- query-routing tests ensure ordinary relative-date lookups are not misclassified as sequence queries
- query-path consistency regression verifies `query_prepared`, `query`, `query_filtered`, `query_timed`, `query_filtered_multi`, and `query_prepared_cached` produce the same ordering
- architecture regression verifies the CLI calls the canonical semantic executor and does not reimplement historical/superseded policy locally

## Validation

The final hardening passed the full `cargo test` suite and `cargo check --all-targets` before being included in the squashed tree.

`cargo audit` passes on the final PR head. It reports three pre-existing allowed RustSec warnings: `bincode 1.3.3` is unmaintained (`RUSTSEC-2025-0141`) and transitive `lru 0.12.5` has two unsoundness advisories (`RUSTSEC-2026-0002`, `RUSTSEC-2026-0253`). This PR does not change `Cargo.toml`.

The conservative temporal changes were selected after isolated LongMemEval temporal-reasoning experiments. Hard date-window filtering and forced window-first ranking both regressed retrieval and were intentionally rejected; ranking weights remain unchanged.

The branch is squashed to a single commit on top of `main`. The final cleaned LongMemEval main-vs-branch comparison is running on this exact squashed SHA.