### PR TITLE
Refresh README positioning and add real terminal demo

### DIFF
--- a/.github/workflows/demo-real-terminal.yml
+++ b/.github/workflows/demo-real-terminal.yml
@@ -1,0 +1,80 @@
+name: Record real terminal demo
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - demo-real-terminal-recording
+
+permissions:
+  contents: read
+
+jobs:
+  record:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build merged Lint-AI code
+        run: cargo build --release --bin lint-ai
+
+      - name: Install terminal recording tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y asciinema ffmpeg jq
+          cargo install --locked --git https://github.com/asciinema/agg --tag v1.9.0
+
+      - name: Establish chronology
+        run: |
+          set -euo pipefail
+          touch -d '2026-01-01T00:00:00Z' examples/demo-real-terminal/decision-a.md
+          touch -d '2026-02-01T00:00:00Z' examples/demo-real-terminal/decision-b.md
+          ! grep -Rqi '^supersedes:' examples/demo-real-terminal
+
+      - name: Record actual terminal session
+        run: |
+          set -euo pipefail
+          mkdir -p demo-artifacts
+          chmod +x scripts/run_real_terminal_demo.sh
+          TERM=xterm-256color asciinema rec \
+            --overwrite \
+            --cols 100 \
+            --rows 30 \
+            -c 'bash scripts/run_real_terminal_demo.sh' \
+            demo-artifacts/lint-ai-real-terminal.cast
+
+      - name: Verify recorded behavior independently
+        shell: bash
+        run: |
+          set -euo pipefail
+          QUERY='How many retry attempts should we use for gateway timeouts?'
+          ./target/release/lint-ai --query "$QUERY" examples/demo-real-terminal > demo-artifacts/raw-query.json
+          ./target/release/lint-ai --llm-context "$QUERY" --result-count 5 examples/demo-real-terminal > demo-artifacts/llm-context.json
+          python3 - <<'PY'
+          import json
+          q=json.load(open('demo-artifacts/raw-query.json'))
+          c=json.load(open('demo-artifacts/llm-context.json'))
+          assert [r['doc_id'] for r in q['results']] == ['decision-b.md'], q
+          assert q['results'][0].get('semantic_status') == 'current', q
+          assert q.get('aggregation') is None, q
+          chunks=c['top_chunks']
+          assert all(x['doc_id'] != 'decision-a.md' for x in chunks), c
+          assert any(x['doc_id']=='decision-b.md' and 'retry attempts: 2' in x.get('text','') for x in chunks), c
+          assert all('retry attempts: 5' not in x.get('text','') for x in chunks), c
+          PY
+
+      - name: Render recording to GIF and MP4
+        run: |
+          set -euo pipefail
+          agg demo-artifacts/lint-ai-real-terminal.cast demo-artifacts/lint-ai-real-terminal.gif
+          ffmpeg -y -i demo-artifacts/lint-ai-real-terminal.gif \
+            -movflags +faststart -pix_fmt yuv420p \
+            -vf 'scale=trunc(iw/2)*2:trunc(ih/2)*2' \
+            demo-artifacts/lint-ai-real-terminal.mp4
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lint-ai-real-terminal-recording
+          path: demo-artifacts/
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,162 +1,155 @@
 # Lint-AI
 
-Lint-AI is for teams building agent memory and semantic review over large, fast-changing corpora: assistant sessions, task notes, traces, reports, decisions, code, and documentation that accumulate faster than any team can review manually.
+**Current-state memory for AI agents.**
 
-It is a good fit for people who maintain:
-- long-running agent memory over conversations, notes, and decisions
-- markdown knowledge bases with lots of cross-links
-- internal docs where terminology drifts over time
-- codebases where symbols, ownership, usage, and review context matter
-- corpora where “what changed?” and “what is current?” matter as much as keyword search
+> Relevant context is not always true.
 
-Use Lint-AI when plain search is not enough and memory recall needs evidence. It treats stored context as a network of facts, concepts, links, symbols, ownership facts, and timestamps, then surfaces misalignment, missing context, and retrieval results suited for downstream review or LLM grounding.
+Lint-AI turns project history — sessions, documents, decisions, traces, notes, and code — into **current, evidence-backed context** when an agent needs it.
 
-The problem it solves is **system-level consistency**: reading individual documents is not enough when terminology drifts, definitions conflict, ownership changes, or outdated claims persist across a growing corpus. Lint-AI analyzes corpora collectively, not in isolation, to catch these issues before they spread.
+Search can find the right topic. Lint-AI helps an agent distinguish **what is relevant** from **what is still true**.
 
-Why people use it:
-- to recover the right past session or note when an agent needs context
-- to catch contradictions before they spread
-- to detect terminology drift across documents
-- to find orphaned or weakly linked pages
-- to ask corpus-level questions over facts, entities, symbols, and time
-- to build review packets from changed files and related semantic context
-- to feed grounded context into an LLM instead of raw text blobs
+It is built for long-running AI workflows where old decisions remain semantically relevant even after newer evidence has replaced them.
 
-## Benchmark
+**Works with Claude Code, Codex, Gemini CLI, and Antigravity CLI (AGY)** through project-scoped memory, lifecycle hooks, and MCP tools.
 
-Evaluated on **LongMemEval-S** (500 questions), a public benchmark for long-context agent memory retrieval over multi-session conversation corpora. The scoped variant is used: each query searches only the sessions attached to that question, matching the realistic setting where a system knows which sessions are candidates for a given user. No embedding vectors are used anywhere in the pipeline.
+[Documentation](https://rooagi.github.io/Lint-AI/) · [Quickstart](docs/quickstart.md) · [Agent integrations](docs/agents.md) · [Benchmark methodology](docs/benchmark.md)
 
-The section below shows both the rust-bert POS/NER branch result and the default heuristic release result.
+---
 
-### Rust-BERT POS/NER Branch
+## The problem: your agent retrieved the right document — and still got the wrong answer
 
-**Aggregate (n=500):**
+Imagine your project contains two versions of the same decision:
 
-| metric | value |
+**Older — `decision-a.md`**
+
+```md
+# Gateway Retry Policy
+
+Gateway timeout retry attempts: 5.
+```
+
+**Newer — `decision-b.md`**
+
+```md
+# Gateway Retry Policy
+
+Gateway timeout retry attempts: 2.
+```
+
+Both documents are relevant to:
+
+```text
+How many retry attempts should we use for gateway timeouts?
+```
+
+A normal retriever can return either one — or both — and leave the model to guess which value is current.
+
+Lint-AI uses **relevance + time + semantic relationships** to keep the newer value in current-state retrieval while preserving the older document as history.
+
+There is no required `supersedes:` frontmatter in this example. For simple configuration/value claims, Lint-AI can infer chronological replacement when the documents establish the same semantic domain. Inferred supersession is domain-scoped so unrelated settings such as two different services' `timeout` values do not suppress one another. Explicit supersession metadata remains authoritative when you provide it.
+
+```bash
+lint-ai --query \
+  "How many retry attempts should we use for gateway timeouts?" \
+  examples/demo-real-terminal
+```
+
+Current-state retrieval returns the newer decision with `semantic_status: current`, and `--llm-context` excludes the stale value.
+
+### Real terminal demo
+
+The repository includes a reproducible **asciinema PTY recording** that builds the real `lint-ai` binary, sets deterministic file mtimes, runs the neutral query above, verifies the result, and renders the captured terminal session.
+
+```bash
+bash scripts/run_real_terminal_demo.sh
+```
+
+See [`examples/demo-real-terminal/`](examples/demo-real-terminal/) and [`.github/workflows/demo-real-terminal.yml`](.github/workflows/demo-real-terminal.yml).
+
+---
+
+## Why Lint-AI?
+
+Agent memory is not only a retrieval problem. It is a **state problem**.
+
+A useful memory layer has to answer:
+
+1. **Relevance** — is this about the question?
+2. **Recency** — when was this evidence true?
+3. **Supersession** — did something newer replace it?
+4. **Temporal intent** — is the user asking about now, last Tuesday, or a historical state?
+5. **Evidence** — where did the answer come from?
+
+| Ordinary retrieval | Lint-AI |
 |---|---|
-| recall@5 | 86.9% |
-| recall@10 | 93.8% |
-| recall@20 | 94.4% |
-| recall_any@5 | 94.8% |
-| recall_any@10 | 98.2% |
-| MRR | 87.1% |
-| NDCG@10 | 86.0% |
-| avg query latency | 5.1 ms |
+| Finds topically similar text | Ranks relevant **and current** evidence |
+| Can surface stale decisions as if they are current | Tracks time and supersession |
+| Treats relative time as mostly query text | Resolves temporal intent against a reference clock |
+| Returns passages | Returns context with source and relationship evidence |
+| Treats documents mostly in isolation | Connects facts, entities, links, symbols, ownership, and time |
+| Leaves corpus drift hidden | Surfaces contradictions, stale claims, terminology drift, orphan pages, and missing links |
 
-`recall@k` is fractional recall over all gold sessions. `recall_any@k` counts 1.0 if any gold session appears in the top k. Latency is measured on a single CPU core with no GPU.
+Historical evidence is not deleted. A historical query can still retrieve superseded material as history rather than presenting it as current state.
 
-**By question type:**
-
-| question type | n | recall@5 | recall@10 | recall_any@5 | MRR | NDCG@10 |
-|---|---|---|---|---|---|---|
-| single-session-assistant | 56 | 100.0% | 100.0% | 100.0% | 99.1% | 99.3% |
-| single-session-user | 70 | 97.1% | 98.6% | 97.1% | 86.8% | 89.8% |
-| knowledge-update | 78 | 96.8% | 98.7% | 100.0% | 95.2% | 94.4% |
-| single-session-preference | 30 | 80.0% | 96.7% | 80.0% | 64.7% | 72.3% |
-| temporal-reasoning | 133 | 81.1% | 92.0% | 91.7% | 84.1% | 82.3% |
-| multi-session | 133 | 77.7% | 87.1% | 94.7% | 85.3% | 80.2% |
-
-Results file: `benchmark/data/lintai_longmemeval_scoped_results_0512.json`
-
-### Heuristic Release Backend
-
-**Aggregate (n=500):**
-
-| metric | value |
-|---|---|
-| recall@5 | 83.5% |
-| recall@10 | 89.5% |
-| recall@20 | 91.1% |
-| recall_any@5 | 92.4% |
-| recall_any@10 | 95.6% |
-| recall_any@20 | 97.0% |
-| MRR | 84.0% |
-| NDCG@10 | 81.8% |
-| avg query latency | 1.9 ms |
-
-`recall@k` is fractional recall over all gold sessions. `recall_any@k` counts 1.0 if any gold session appears in the top k. Latency is measured on a single CPU core with no GPU.
-
-**By question type:**
-
-| question type | n | recall@5 | recall@10 | recall_any@5 | MRR | NDCG@10 |
-|---|---|---|---|---|---|---|
-| single-session-assistant | 56 | 100.0% | 100.0% | 100.0% | 98.2% | 98.7% |
-| single-session-user | 70 | 94.3% | 98.6% | 94.3% | 77.4% | 82.6% |
-| knowledge-update | 78 | 94.2% | 96.8% | 98.7% | 94.6% | 92.4% |
-| single-session-preference | 30 | 80.0% | 93.3% | 80.0% | 65.8% | 72.2% |
-| temporal-reasoning | 133 | 77.0% | 85.7% | 86.5% | 81.8% | 78.2% |
-| multi-session | 133 | 72.5% | 79.3% | 93.2% | 82.7% | 74.3% |
-
-Results file: `benchmark/data/lintai_longmemeval_scoped_results.json`
+---
 
 ## Quickstart
 
-See [docs/quickstart.md](docs/quickstart.md) for the shortest path to build, run, query, and use the crate from Rust.
-
-## Claude Code and Codex integrations
-
-Lint-AI provides provider-specific integrations for Claude Code, Codex, and Gemini CLI. Each
-integration is opt-in at build time and combines lifecycle hooks with a
-project-scoped memory layer:
-
-| Feature | Claude Code | Codex |
-|---|---:|---:|
-| Project-scoped MCP server | Yes | Yes |
-| Lifecycle memory retrieval and capture | Yes | Yes |
-| Segmented persistent memory | Yes | Yes |
-| `search` and `info` MCP tools | Yes | Yes |
-| `record_session` control | Yes | Yes |
-| Enable/disable Lint-AI at runtime | Yes | Yes |
-| Session status reporting | Native status line plus MCP | MCP plus terminal status line |
-| Replay with Lint-AI enabled or disabled | Yes | Yes |
-| Session import into provider memory | Yes | Yes |
-
-Gemini CLI uses the opt-in `gemini-cli` feature and its documented JSON hooks:
+Install directly from GitHub:
 
 ```bash
-cargo build --release --features gemini-cli
-./lint-ai --gemini-cli-install /path/to/project
+cargo install --git https://github.com/RooAGI/Lint-AI
 ```
 
-Gemini records hook events, injects project memory, and exposes the shared MCP
-tools through `SessionStart`, `BeforeAgent`, model, tool, compression, and
-session-end events. See [docs/gemini-cli.md](docs/gemini-cli.md) for details.
-
-Antigravity CLI (`agy`) uses the opt-in `agy` feature and the same
-Gemini-compatible MCP and lifecycle-hook protocol:
+Lint or index a local corpus:
 
 ```bash
-cargo build --release --features agy
-./lint-ai --agy-install /path/to/project
+lint-ai /path/to/repo
 ```
 
-See [docs/agy.md](docs/agy.md) for configuration paths and session recording.
+Query it:
 
-Build and install both integrations:
+```bash
+lint-ai --query "what is the current retry policy?" /path/to/repo/docs
+```
+
+Get LLM-ready context:
+
+```bash
+lint-ai --llm-context "what is the current retry policy?" /path/to/repo/docs
+```
+
+For Docker, HTTP, Python, Rust, and MCP setup, see the [full quickstart](docs/quickstart.md).
+
+---
+
+## Agent integrations
+
+Lint-AI provides opt-in integrations for major coding-agent clients.
+
+| Integration | Project memory | Lifecycle capture | MCP tools | Replay / comparison |
+|---|---:|---:|---:|---:|
+| [Claude Code](docs/claude-code.md) | Yes | Yes | Yes | Yes |
+| [Codex](docs/codex.md) | Yes | Yes | Yes | Yes |
+| [Gemini CLI](docs/gemini-cli.md) | Yes | Yes | Yes | — |
+| [Antigravity CLI / AGY](docs/agy.md) | Yes | Yes | Yes | — |
+
+Build the Claude Code and Codex integrations:
 
 ```bash
 cargo build --release --features claude-code,codex
-./lint-ai --claude-code-install /path/to/project
-./lint-ai --codex-install /path/to/project
+./target/release/lint-ai --claude-code-install /path/to/project
+./target/release/lint-ai --codex-install /path/to/project
 ```
 
-Each installer writes lifecycle hooks and an MCP server entry into that agent's
-own configuration, which is global, and a memory policy into the named project:
-a project skill for Claude Code and AGY, plus a delimited block in `AGENTS.md` for Codex. The MCP
-entry carries no project root. The server resolves the project it is launched
-in, so installing for a second project does not repoint the first.
-
-```bash
-```
-
-Provider memory remains isolated:
+Provider memory remains isolated by project and provider:
 
 ```text
 /path/to/project/.lint-ai/claude-memory/
 /path/to/project/.lint-ai/codex-memory/
 ```
 
-The MCP controls are available inside either client:
+The shared MCP controls include session recording, memory listing, and runtime enable/disable controls:
 
 ```text
 mcp__lint-ai__record_session       {"action":"start|stop|status"}
@@ -166,128 +159,155 @@ mcp__lint-ai__disable_lint_ai      {}
 mcp__lint-ai__lint_ai_status        {}
 ```
 
-Enabling Lint-AI enables recording by default. Recording can then be stopped
-independently, so memory retrieval and full session capture remain separate
-choices. Recording is local, bounded, redacted, and capture-only; it does not
-inject memory by itself.
+See [agent integrations](docs/agents.md) and the [MCP guide](docs/mcp.md) for the complete setup.
 
-For a baseline/replay A/B comparison:
+---
 
-```bash
-./lint-ai --replay-session <session-id> \
-  --session-provider codex \
-  --replay-disable-lint-ai
-./lint-ai --replay-session <session-id> \
-  --session-provider codex \
-  --replay-enable-lint-ai
+## Benchmark highlights
+
+Lint-AI is evaluated on **LongMemEval-S**, a public benchmark for long-context agent-memory retrieval over multi-session conversations.
+
+The current release benchmark uses the **official cleaned LongMemEval-S dataset**, runs queries through the normal production-style `IndexStore` path, and uses no embedding vectors.
+
+**500 questions · heuristic release backend · single CPU · no GPU**
+
+| Metric | Result |
+|---|---:|
+| Recall@5 | **83.6%** |
+| Recall@10 | **89.7%** |
+| Recall@20 | **91.2%** |
+| Recall-any@10 | **95.8%** |
+| MRR | **84.1%** |
+| NDCG@10 | **81.8%** |
+| Average query latency | **~4.7 ms** |
+
+`Recall@k` is fractional recall over all gold sessions. `Recall-any@k` counts a query as successful when any gold session appears in the top *k*.
+
+The repository keeps the cleaned-dataset downloader, production-style benchmark binary, main-vs-branch comparison workflow, and temporal-reasoning experiment harnesses so results can be reproduced and changes can be evaluated without silently changing the query path.
+
+See [benchmark methodology](docs/benchmark.md), [benchmark results](docs/benchmark-results.md), and [comparison methodology](docs/comparison.md).
+
+<details>
+<summary><strong>Experimental rust-bert POS/NER branch</strong></summary>
+
+<br>
+
+An experimental model-backed POS/NER branch has also reached higher retrieval metrics, but it is intentionally kept separate from the audited heuristic release dependency graph. See the benchmark documentation for its results and conditions.
+
+</details>
+
+### Integration smoke measurements
+
+The repository also includes reproducible Claude Code and Codex replay/performance tests. These are diagnostic one-run measurements, **not universal performance guarantees**.
+
+| Provider / arm | Continuation | Input tokens | Tool calls | Recall | Hook time |
+|---|---:|---:|---:|---:|---:|
+| Claude native memory | 22.47 s | 123,536 | 4 | 2/3 | 0 ms |
+| Claude Lint-AI only | 7.05 s | 15,914 | 0 | 3/3 | 1.40 s |
+| Codex native memory | 38.13 s | 151,000 | 5 | 2/3 | 0 ms |
+| Codex Lint-AI only | 18.53 s | 62,478 | 2 | 2/3 | 1.33 s |
+
+Read the full conditions and limitations:
+
+- [Claude Code performance tests](docs/claude-code-performance-tests.md)
+- [Codex performance tests](docs/codex-performance-tests.md)
+- [Comparison methodology](docs/comparison.md)
+- [Session metrics](metrics/README.md)
+
+---
+
+## What Lint-AI can do
+
+- Recover the right past session or project note when an agent needs context
+- Rank current evidence ahead of superseded guidance
+- Infer simple chronological configuration updates inside an established semantic domain
+- Preserve historical evidence for historical questions
+- Resolve relative-time queries against an explicit reference date when one is available
+- Catch contradictions before they spread
+- Detect terminology drift across documents
+- Find orphaned or weakly linked pages
+- Query facts, entities, symbols, ownership, and time
+- Build review packets from changed files and related semantic context
+- Feed grounded context into an LLM instead of raw text blobs
+- Keep agent memory inspectable and local to the project
+
+---
+
+## How it works
+
+Lint-AI treats project memory as more than a bag of text.
+
+```text
+Sessions · docs · code · traces
+            │
+            ▼
+        1. Ingest
+            │
+            ▼
+ Facts · entities · symbols · time
+            │
+            ▼
+      2. Understand
+            │
+            ▼
+ Links · ownership · supersession
+            │
+            ▼
+       3. Connect
+            │
+            ▼
+ Ranked · sourced · current context
+            │
+            ▼
+       4. Retrieve
 ```
 
-Each replay receives a new `replay-*` session ID and a separate archive. The
-comparison workflow measures task quality, token usage, latency, tool
-activity, memory retrieval, and recording completeness.
+Under the hood, Lint-AI builds a lexical index plus sparse entity/term tables and overlays graph structure for links, symbols, ownership, semantic relations, and time.
 
-### Integration benchmark
+A single prepared-query path owns query analysis, augmented search text, temporal context, routing intent, reference-clock handling, semantic suppression, and provenance annotation. The CLI and `IndexStore` use the same semantic/temporal query policy so current-state behavior does not depend on which high-level entry point you call.
 
-These are the latest validated smoke-run measurements for the segmented-routing
-scenario: one repetition, continuation phase only. They are diagnostic results
-for the stated run, not universal performance guarantees.
+The same corpus model powers review-oriented checks such as missing cross-references, orphan pages, low-confidence claims, stale knowledge, and semantic drift.
 
-| Provider / arm | Continuation | Input tokens | Cached input | Output tokens | Tool calls | Recall | Hook time |
-|---|---:|---:|---:|---:|---:|---:|---:|
-| Claude native memory | 22.47 s | 123,536 | 123,526 | 1,239 | 4 | 2/3 | 0 ms |
-| Claude Lint-AI only | 7.05 s | 15,914 | 15,912 | 376 | 0 | 3/3 | 1.40 s |
-| Claude both layers | 7.17 s | 15,914 | 15,912 | 271 | 0 | 3/3 | 1.36 s |
-| Codex native memory | 38.13 s | 151,000 | 99,840 | 1,505 | 5 | 2/3 | 0 ms |
-| Codex Lint-AI only | 18.53 s | 62,478 | 43,264 | 604 | 2 | 2/3 | 1.33 s |
-| Codex both layers | 13.98 s | 31,684 | 25,088 | 454 | 1 | 2/3 | 1.39 s |
+For implementation details, see:
 
-The corresponding reports and run conditions are documented in the [Claude
-Code performance tests](docs/claude-code-performance-tests.md) and [Codex
-performance tests](docs/codex-performance-tests.md). Both documents describe
-the one-run limitation and the provider/model/repository versions used.
+- [Chunk strategy](docs/chunk-strategy.md)
+- [Lexical data](docs/lexical-data.md)
+- [Artifact indexing](docs/artifact-indexing.md)
+- [Shared integration architecture](src/integrations/README.md)
 
-MCP-path smoke validation measured 47.09 s for Claude MCP-only and 9.38 s for
-Codex with Lint-AI MCP. The Codex run recorded 13,246 input tokens, 77 output
-tokens, 2/3 recall, and 1.35 s hook time; the Claude run recorded 189,022
-input tokens, 3,678 output tokens, and one Lint-AI MCP call. A separate direct
-Claude MCP search check returned results in approximately 220 ms; it did not
-measure agent search-selection behavior.
+---
 
-More detail: [Claude Code integration](docs/claude-code.md), [Codex
-integration](docs/codex.md), [shared integration architecture](src/integrations/README.md),
-and the [integration test strategy](docs/integration-test-strategy.md).
-and [session metrics](metrics/README.md).
-
-## How It Works
-
-Lint-AI ingests sessions, notes, traces, documents, and code-oriented artifacts, builds a lexical index plus sparse entity/term tables, and overlays graph structure for links, symbols, ownership, and co-occurrence. Queries are analyzed for intent, entities, and temporal hints, then scored with a blend of lexical, semantic, claim, topic, timestamp, and graph signals. The same corpus analysis also powers misalignment checks such as missing cross-refs, orphan pages, low-confidence claims, and review-oriented packet generation.
-
-If you want the deeper implementation view, see:
-- `docs/chunk-strategy.md`
-- `docs/lexical-data.md`
-- `docs/artifact-indexing.md`
-
-## How To Use
-
-Query semantics currently use the heuristic backend in the release build.
-The model-backed POS/NER path was used in the experimental rust-bert branch and is kept separate from the audited release graph.
+## Use Lint-AI from your stack
 
 ### CLI
 
-Lint a corpus:
-
 ```bash
-./lint-ai /path/to/repo
+lint-ai --query "what is the current retry policy?" /path/to/repo
 ```
 
-If you prefer `cargo run`:
+### Docker / HTTP
 
 ```bash
-cargo run --bin lint-ai -- /path/to/repo
+export SERVER_TOKEN=local-dev-token
+docker compose up --build -d
+curl http://127.0.0.1:8080/health
 ```
 
-Query the corpus:
+See the [HTTP server guide](docs/server.md).
 
-```bash
-./lint-ai --query "docker install linux" /path/to/repo/docs
+### Python
+
+Build the optional Python extension with `maturin`, then use the same in-memory index from Python:
+
+```python
+import lint_ai
+
+store = lint_ai.IndexStore()
+store.upsert("doc-1", "Docker install guide for Ubuntu hosts")
+print(store.query("docker ubuntu", 5))
 ```
 
-Get LLM-ready retrieval context:
-
-```bash
-./lint-ai --llm-context "docker install linux" /path/to/repo/docs
-```
-
-Inspect the derived inventory:
-
-```bash
-./lint-ai /path/to/repo/docs --show-concepts
-./lint-ai /path/to/repo/docs --show-headings
-```
-
-Show the main query-oriented modes:
-
-```bash
-./lint-ai --index /path/to/repo/docs
-./lint-ai --show-tier0 /path/to/repo
-./lint-ai --show-tier1-entities /path/to/repo
-./lint-ai --show-tier1-terms /path/to/repo --tier1-term-ranker yake
-```
-
-Use spaCy for Tier 1 entities if available:
-
-```bash
-./lint-ai /path/to/repo --show-tier1-entities --tier1-ner-provider spacy --spacy-model en_core_web_sm
-```
-
-For optional Claude Code support, build with `--features claude-code` and see
-[docs/claude-code.md](docs/claude-code.md) for the MCP, hooks, and install flow.
-
-Common graph exports, chunking knobs, lexical subset regeneration, and artifact indexing details are documented in `docs/`.
-
-### Rust Library
-
-Use `IndexStore` when you want mutable ingestion, `MemoryIndex` when you want an immutable query snapshot, and `SourceDocument` to add content. For the broader semantic graph, use `CorpusGraph`, `SymbolStore`, `UsageGraph`, and the review model types that are re-exported from the crate root.
+### Rust
 
 ```rust
 use lint_ai::{IndexStore, PipelineOptions, SourceDocument};
@@ -295,18 +315,16 @@ use lint_ai::{IndexStore, PipelineOptions, SourceDocument};
 fn main() -> anyhow::Result<()> {
     let mut index = IndexStore::in_memory(PipelineOptions::default());
 
-    index.upsert(SourceDocument {
-        doc_id: "artifact-1".to_string(),
-        source: "artifact://artifact-1".to_string(),
-        content: "docker install guide for linux hosts".to_string(),
-        concept: "docker install".to_string(),
-        group_id: None,
-        headings: vec!["Overview".to_string()],
-        links: vec![],
-        timestamp: None,
-        doc_length: 36,
-        author_agent: None,
-    });
+    index.upsert(SourceDocument::with_stable_doc_id_from_source(
+        "docs/install.md".to_string(),
+        "Docker install guide for Linux hosts".to_string(),
+        "docker install".to_string(),
+        None,
+        vec!["Overview".to_string()],
+        vec![],
+        None,
+        None,
+    ));
 
     let results = index.query("docker install", 5)?;
     println!("{}", serde_json::to_string_pretty(&results)?);
@@ -314,139 +332,36 @@ fn main() -> anyhow::Result<()> {
 }
 ```
 
-For corpus-local persistence under `.lint-ai/`, use:
+See [docs/quickstart.md](docs/quickstart.md) for complete examples.
 
-```rust
-use std::path::Path;
-use lint_ai::{IndexStore, PipelineOptions};
+---
 
-let index = IndexStore::for_corpus(Path::new("/path/to/corpus"), PipelineOptions::default())?;
-```
+## When is Lint-AI a good fit?
 
-If you already have prepared `DocRecord` values and want the built search structure directly, use `lint_ai::index::MemoryIndex`.
+Lint-AI is especially useful when you maintain:
 
-For symbol and review workflows, the crate root also re-exports:
+- Long-running agent memory over conversations, notes, and decisions
+- Markdown knowledge bases with many cross-links
+- Internal documentation where terminology and decisions drift over time
+- Codebases where symbols, ownership, usage, and review context matter
+- Fast-changing corpora where freshness matters as much as relevance
 
-- `CorpusGraph` for querying documents, symbols, and usage together
-- `SymbolRecord` / `SymbolStore` for symbol indexing
-- `OwnershipRecord` / `OwnershipSummary` for ownership facts and summaries
-- `UsageGraph` / `UsageEdge` / `UsageNode` for symbol and ownership relationship tracing
-- `ReviewPacket` / `ReviewFinding` / `ReviewDiff` for structured review output
+If your only requirement is simple keyword search over a static set of documents, Lint-AI is probably more machinery than you need.
 
-## Advanced
+---
 
-By default the linter skips files larger than 5MB and stops after 50k files. Override these limits:
+## Project status
 
-```bash
-./lint-ai /path/to/repo --max-bytes 10000000 --max-files 100000
-```
+Lint-AI is under active development. The release query path uses the heuristic backend; experimental model-backed query semantics remain separate from the audited release dependency graph.
 
-Limit directory traversal depth:
+The security audit workflow runs `cargo audit`. The current release has no newly introduced blocking RustSec vulnerability from the current-state query changes; known dependency warnings are documented in the repository's audit workflow and dependency history.
 
-```bash
-./lint-ai /path/to/repo --max-depth 10
-```
+Issues, benchmark reproductions, integration feedback, and contributions are welcome.
 
-Limit total bytes read across the corpus:
+- [Open an issue](https://github.com/RooAGI/Lint-AI/issues)
+- [Join a discussion](https://github.com/RooAGI/Lint-AI/discussions)
+- [Read the documentation](https://rooagi.github.io/Lint-AI/)
 
-```bash
-./lint-ai /path/to/repo --max-total-bytes 100000000
-```
+## License
 
-The tool automatically scopes to `/path/to/repo/docs/**` when that folder exists.
-
-## Configuration
-
-Analyze a corpus and emit a suggested `lint-ai.json` config:
-
-```bash
-./lint-ai /path/to/repo/docs --analyze
-```
-
-Example output:
-
-```
-Suggested config:
-{
-  "stopwords": ["group messages", "pairing", "channel routing"],
-  "ignore_sections": ["unscoped", "related"],
-  "ignore_crossref_sections": ["unscoped", "related"],
-  "ignore_paths": [],
-  "allowlist_concepts": []
-}
-
-Stats:
-pages: 31
-top concepts:
-- group messages (25)
-- pairing (25)
-- channel routing (22)
-- slack (11)
-- telegram (11)
-top sections:
-- configuration (41)
-- setup (35)
-- unscoped (31)
-- security (28)
-- related (22)
-```
-
-You can place a `lint-ai.json` file in the target root, or pass `--config /path/to/lint-ai.json`, to control filters.
-
-Use `--strict-config` to fail fast if the config is invalid.
-
-Limit config size:
-
-```bash
-./lint-ai /path/to/repo --max-config-bytes 2000000
-```
-
-Example used for Openclaw channels:
-
-```json
-{
-  "stopwords": ["channel", "message", "messages", "bot", "client", "config"],
-  "ignore_sections": ["related", "unscoped"],
-  "ignore_crossref_sections": ["related", "unscoped"],
-  "ignore_paths": [],
-  "allowlist_concepts": ["discord", "slack", "telegram", "whatsapp", "signal", "matrix"],
-  "scope_prefix": "docs/channels/"
-}
-```
-
-Run it with `./lint-ai /path/to/openclaw/docs/channels --config /path/to/openclaw/lint-ai.json`.
-
-## Contributing
-
-If you want to contribute, the most useful workflow is:
-
-```bash
-cargo build
-cargo test
-cargo fmt --all
-```
-
-Please keep changes focused and include tests when behavior changes.
-
-Useful contribution rules:
-
-- run `cargo test` before opening a PR
-- run `cargo fmt --all` for Rust code changes
-- update docs when CLI flags, benchmarks, or query behavior change
-- include benchmark notes when ranking or retrieval logic changes
-- prefer small PRs with a clear scope
-
-If the change affects query quality, mention the benchmark result it moves.
-
-## Output Examples
-
-Running the linter emits findings tagged with severity and link-debt signals:
-
-```text
-Missing cross-ref in docs/channels/discord.md -> [[signal]] (high)
-Low link density in docs/channels/location.md (outgoing 1, avg 4.2)
-Unreachable page: docs/channels/legacy.md
-Orphan page: docs/channels/unused.md
-```
-
-Use `--show-concepts` when you need the derived concept inventory for tuning stopwords or allowlists in `lint-ai.json`.
+Apache-2.0

--- a/examples/demo-real-terminal/decision-a.md
+++ b/examples/demo-real-terminal/decision-a.md
@@ -1,0 +1,3 @@
+# Gateway Retry Policy
+
+Gateway timeout retry attempts: 5.

--- a/examples/demo-real-terminal/decision-b.md
+++ b/examples/demo-real-terminal/decision-b.md
@@ -1,0 +1,3 @@
+# Gateway Retry Policy
+
+Gateway timeout retry attempts: 2.

--- a/scripts/run_real_terminal_demo.sh
+++ b/scripts/run_real_terminal_demo.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEMO_DIR="examples/demo-real-terminal"
+QUERY='How many retry attempts should we use for gateway timeouts?'
+BIN='./target/release/lint-ai'
+
+prompt() {
+  printf '\n\033[1;36m$ %s\033[0m\n' "$1"
+  sleep 0.7
+}
+
+run_cmd() {
+  prompt "$1"
+  bash -lc "$1"
+  sleep 1.0
+}
+
+clear
+printf '\033[1;37mLint-AI — real terminal recording\033[0m\n'
+printf 'No supersedes metadata. Same policy domain. Newer file wins by chronology.\n'
+sleep 1.2
+
+run_cmd "cat $DEMO_DIR/decision-a.md"
+run_cmd "cat $DEMO_DIR/decision-b.md"
+run_cmd "stat -c '%n  %y' $DEMO_DIR/decision-a.md $DEMO_DIR/decision-b.md | sed 's/\\.000000000 +0000//'"
+
+prompt "$BIN --query \"$QUERY\" $DEMO_DIR | jq '{result: (.results[0] | {doc_id, semantic_status}), aggregation}'"
+"$BIN" --query "$QUERY" "$DEMO_DIR" \
+  | jq '{result: (.results[0] | {doc_id, semantic_status}), aggregation}'
+sleep 1.4
+
+prompt "$BIN --llm-context \"$QUERY\" --result-count 5 $DEMO_DIR | jq '{current_context: ([.top_chunks[] | select(.doc_id == \"decision-b.md\")][0] | {doc_id, text}), stale_value_in_context: any(.top_chunks[]; (.text // \"\") | contains(\"retry attempts: 5\"))}'"
+"$BIN" --llm-context "$QUERY" --result-count 5 "$DEMO_DIR" \
+  | jq '{current_context: ([.top_chunks[] | select(.doc_id == "decision-b.md")][0] | {doc_id, text}), stale_value_in_context: any(.top_chunks[]; (.text // "") | contains("retry attempts: 5"))}'
+sleep 1.8
+
+printf '\n\033[1;32mResult: the current value is 2; stale value 5 is excluded from agent context.\033[0m\n'
+printf '\033[2mRecorded live from the actual lint-ai CLI.\033[0m\n'
+sleep 2


### PR DESCRIPTION
## Summary

- reposition Lint-AI around **current-state memory for AI agents**
- lead with the problem that relevant context can still be stale
- document metadata-free chronological supersession with the real Gateway Retry Policy 5 → 2 example
- explain domain-scoped inferred supersession and historical retrieval behavior
- update benchmark wording to the cleaned LongMemEval-S / normal `IndexStore` query path
- add a reproducible **asciinema PTY recording** that runs the real merged `lint-ai` binary
- include the two metadata-free Markdown fixtures and strict independent assertions used by the demo workflow

## Demo guarantees

The demo establishes deterministic mtimes, contains no `supersedes:` metadata, runs the neutral query `How many retry attempts should we use for gateway timeouts?`, and verifies that only `decision-b.md` is current and that stale value `5` is absent from `--llm-context`.

The `.cast` recording is captured from the live terminal session; GIF/MP4 assets are rendered from that PTY recording rather than reconstructed output.

## History

This branch is intentionally squashed to one commit directly on top of `main`.