### PR TITLE
Make agent memory positioning explicit across GitHub and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 # Lint-AI
 
-**AI memory that knows what is still true.**
+**Current-state agent memory for AI coding agents.**
 
-> Your agent doesn't just forget. It can confidently remember outdated decisions.
+> **AI memory that knows what is still true.** Your agent doesn't just forget; it can confidently remember outdated decisions.
 
-Lint-AI gives coding agents **current, evidence-backed project memory**. It uses **relevance + time + semantic relationships** to distinguish the latest truth from old-but-still-relevant history.
+Lint-AI is an open-source **persistent agent memory** layer for Claude Code, Codex, Gemini CLI, and Antigravity CLI (AGY). It turns project history — sessions, documents, decisions, traces, notes, and code — into **current, evidence-backed context** when an agent needs it.
 
-Search can find the right topic. Lint-AI helps an agent answer the harder question: **is this information still true?**
+Search can find the right topic. Lint-AI helps an agent answer the harder question: **is this information still true?** It uses relevance, time, and semantic relationships to distinguish the latest truth from old-but-still-relevant history.
 
-**Works with Claude Code, Codex, Gemini CLI, and Antigravity CLI (AGY)** through project-scoped memory, lifecycle hooks, and MCP tools.
+[Agent memory guide](docs/agent-memory.md) · [Quickstart](docs/quickstart.md) · [Reproducible demo](#reproducible-terminal-demo) · [Agent integrations](docs/agents.md) · [Benchmarks](#benchmark-highlights) · [Documentation](https://rooagi.github.io/Lint-AI/)
 
-[Quickstart](docs/quickstart.md) · [Real demo](#real-terminal-demo) · [Agent integrations](docs/agents.md) · [Benchmarks](#benchmark-highlights) · [Documentation](https://rooagi.github.io/Lint-AI/)
-
-**Release benchmark:** 83.6% Recall@5 · 95.8% Recall-any@10 · ~4.7 ms average query latency · single CPU · no GPU
+**Current benchmark:** 83.5% fractional Recall@5 · 95.6% any-hit Recall@10 · ~1.88 ms average query latency · single CPU · no GPU
 
 ---
 
@@ -58,11 +56,11 @@ lint-ai --query \
 
 Current-state retrieval returns the newer decision with `semantic_status: current`, and `--llm-context` excludes the stale value.
 
-### Real terminal demo
+### Reproducible terminal demo
 
-![Lint-AI real terminal demo](docs/assets/lint-ai-real-terminal.gif)
+![Lint-AI reproducible terminal demo](docs/assets/lint-ai-real-terminal.gif)
 
-The repository includes a reproducible **asciinema PTY recording** that builds the real `lint-ai` binary, sets deterministic file mtimes, runs the neutral query above, verifies the result, and renders the captured terminal session.
+The repository includes a reproducible **asciinema PTY recording** that builds the actual `lint-ai` binary, sets deterministic file mtimes for a controlled stale-memory scenario, runs the neutral query above, verifies the result, and renders the captured terminal session.
 
 ```bash
 bash scripts/run_real_terminal_demo.sh
@@ -171,23 +169,23 @@ See [agent integrations](docs/agents.md) and the [MCP guide](docs/mcp.md) for th
 
 Lint-AI is evaluated on **LongMemEval-S**, a public benchmark for long-context agent-memory retrieval over multi-session conversations.
 
-The current release benchmark uses the **official cleaned LongMemEval-S dataset**, runs queries through the normal production-style `IndexStore` path, and uses no embedding vectors.
+The current benchmark uses the repository's raw LongMemEval-S dataset, runs 500 question-scoped queries through the heuristic release backend, and uses no embedding vectors.
 
 **500 questions · heuristic release backend · single CPU · no GPU**
 
 | Metric | Result |
 |---|---:|
-| Recall@5 | **83.6%** |
-| Recall@10 | **89.7%** |
-| Recall@20 | **91.2%** |
-| Recall-any@10 | **95.8%** |
-| MRR | **84.1%** |
+| Fractional Recall@5 | **83.5%** |
+| Fractional Recall@10 | **89.5%** |
+| Fractional Recall@20 | **91.1%** |
+| Any-hit Recall@10 | **95.6%** |
+| MRR | **84.0%** |
 | NDCG@10 | **81.8%** |
-| Average query latency | **~4.7 ms** |
+| Average query latency | **~1.88 ms** |
 
-`Recall@k` is fractional recall over all gold sessions. `Recall-any@k` counts a query as successful when any gold session appears in the top *k*.
+`Fractional Recall@k` is the average fraction of all correct answer sessions recovered in the top *k*. `Any-hit Recall@k` counts a query as successful when any correct answer session appears in the top *k*.
 
-The repository keeps the cleaned-dataset downloader, production-style benchmark binary, main-vs-branch comparison workflow, and temporal-reasoning experiment harnesses so results can be reproduced and changes can be evaluated without silently changing the query path.
+The repository keeps the dataset downloader, production-style benchmark binary, shared AgentMemory scorer, comparison workflow, and temporal-reasoning experiment harnesses so results can be reproduced and changes can be evaluated without silently changing the query path.
 
 See [benchmark methodology](docs/benchmark.md), [benchmark results](docs/benchmark-results.md), and [comparison methodology](docs/comparison.md).
 

--- a/docs/agent-memory.md
+++ b/docs/agent-memory.md
@@ -1,5 +1,7 @@
 # Agent Memory for AI Coding Agents
 
+**Lint-AI — AI memory that knows what is still true.**
+
 **Agent memory** lets an AI agent carry useful project knowledge across sessions instead of rediscovering the same decisions, files, failures, and conventions every time it starts work.
 
 Lint-AI is an open-source **current-state agent memory** layer for AI coding agents. It works with Claude Code, Codex, Gemini CLI, and Antigravity CLI (AGY), and exposes project memory through lifecycle hooks, MCP tools, CLI commands, HTTP, Python, and Rust interfaces.

--- a/docs/agent-memory.md
+++ b/docs/agent-memory.md
@@ -1,0 +1,128 @@
+# Agent Memory for AI Coding Agents
+
+**Agent memory** lets an AI agent carry useful project knowledge across sessions instead of rediscovering the same decisions, files, failures, and conventions every time it starts work.
+
+Lint-AI is an open-source **current-state agent memory** layer for AI coding agents. It works with Claude Code, Codex, Gemini CLI, and Antigravity CLI (AGY), and exposes project memory through lifecycle hooks, MCP tools, CLI commands, HTTP, Python, and Rust interfaces.
+
+The problem Lint-AI focuses on is simple: persistent memory can remember something correctly and still give an agent the wrong answer today.
+
+## Persistent memory is only the first step
+
+A basic agent-memory system answers questions such as:
+
+- What did we decide about retries?
+- Which module owns authentication?
+- What failed the last time we tried this migration?
+- Where did we leave the unfinished work?
+
+That is valuable because it reduces repeated repository exploration and user restatement. But long-running projects introduce a second problem: **project truth changes**.
+
+A decision that was correct last month may have been replaced yesterday. An API contract may have changed. Ownership may have moved to another team. A runbook may still be topically relevant even though a newer runbook superseded it.
+
+If an agent-memory layer retrieves both versions without distinguishing their state, the model must spend context tokens reading conflicting evidence and then guess which version is current.
+
+Lint-AI treats agent memory as a **state problem as well as a retrieval problem**.
+
+## Relevant does not always mean current
+
+Imagine a project contains two decisions:
+
+```text
+January: gateway timeout retries = 5
+February: gateway timeout retries = 2
+```
+
+Both memories are relevant to the query:
+
+```text
+How many retry attempts should we use for gateway timeouts?
+```
+
+Semantic similarity alone does not tell the agent which value is active now.
+
+Lint-AI combines relevance with time and semantic relationships so current-state retrieval can rank the newer decision as current while preserving the older decision as historical evidence. Explicit supersession metadata is supported, and simple chronological replacement can also be inferred inside an established semantic domain.
+
+That distinction is useful for architecture decisions, configuration values, API contracts, runbooks, ownership, terminology, implementation plans, and other knowledge that changes over time.
+
+## Agent memory and token budget
+
+Every memory injected into an LLM consumes context. More context is not automatically better context.
+
+An agent-memory system should therefore answer two questions:
+
+1. **What information is relevant enough to retrieve?**
+2. **Which of that information is current enough to act on?**
+
+Filtering stale or superseded evidence before it reaches the model can reduce unnecessary context and reduce ambiguity in the prompt. Lint-AI does not currently claim a universal percentage reduction in tokens versus other third-party memory systems; token use depends on the agent, retrieval settings, task, and integration path.
+
+The repository includes reproducible Claude Code and Codex integration measurements that report model tokens, retrieved context, tool calls, latency, and recall. These are diagnostic workload measurements rather than universal product guarantees. See the [Claude Code performance tests](claude-code-performance-tests.md) and [Codex performance tests](codex-performance-tests.md).
+
+## Agent memory and hallucination risk
+
+Memory cannot eliminate hallucinations. A model can still reason incorrectly or produce unsupported details.
+
+What a memory layer can control is the **evidence supplied to the model**. Stale, contradictory, or weakly sourced context can contribute to confident wrong answers. Lint-AI is designed to make those conditions visible by tracking current versus superseded evidence, temporal intent, provenance, contradictions, and semantic drift.
+
+For that reason, the defensible goal is not “zero hallucinations.” It is **less stale and conflicting context, with evidence the agent can inspect**.
+
+## Retrieval quality and speed
+
+Lint-AI publishes reproducible retrieval and service-load benchmarks in the repository.
+
+On the current 500-question LongMemEval-S retrieval track, the heuristic release backend reports:
+
+| Metric | Result |
+|---|---:|
+| Any-hit Recall@5 | 92.4% |
+| Any-hit Recall@10 | 95.6% |
+| Any-hit Recall@20 | 97.0% |
+| MRR | 84.0% |
+| NDCG@10 | 81.8% |
+| Average in-process query latency | 1.88 ms |
+
+The normalized HTTP load test uses 23,366 records and 100 requests per cell. At concurrency 10, Lint-AI recorded 952 requests per second in that test. Benchmark conditions, scripts, comparison data, and caveats are published in the [benchmark overview](benchmark.md) and [comparison](comparison.md).
+
+## Claude Code memory, Codex memory, and Gemini CLI memory
+
+Lint-AI provides project-scoped memory integrations for major coding-agent clients:
+
+| Agent | Project memory | Lifecycle capture | MCP tools |
+|---|---:|---:|---:|
+| Claude Code | Yes | Yes | Yes |
+| Codex | Yes | Yes | Yes |
+| Gemini CLI | Yes | Yes | Yes |
+| Antigravity CLI / AGY | Yes | Yes | Yes |
+
+Each provider can keep isolated project memory while using Lint-AI's shared retrieval and current-state semantics. See [agent integrations](agents.md) for setup details.
+
+## When current-state agent memory is useful
+
+Lint-AI is a strong fit when an AI coding agent works on a project long enough for history to accumulate and change. Typical cases include long-running codebases, changing architecture decisions, evolving documentation, multi-session implementation work, operational runbooks, and projects where provenance matters.
+
+If the only requirement is simple keyword search over a static set of documents, a current-state memory layer may be more machinery than needed.
+
+## Get started
+
+Install Lint-AI directly from GitHub:
+
+```bash
+cargo install --git https://github.com/RooAGI/Lint-AI
+```
+
+Then index or lint a local project corpus:
+
+```bash
+lint-ai /path/to/repo
+```
+
+Query current project memory:
+
+```bash
+lint-ai --query "what is the current retry policy?" /path/to/repo/docs
+```
+
+For complete installation and integration instructions, see the [quickstart](quickstart.md).
+
+## Related terms
+
+Developers may describe this category as **agent memory**, **AI agent memory**, **persistent agent memory**, **coding agent memory**, **LLM memory**, **Claude Code memory**, **Codex memory**, or **MCP memory**. Lint-AI's specific focus within that category is **current-state memory**: retrieving evidence that is relevant while distinguishing what is still true from what has become historical.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@ hide:
 
 <div class="hero-stack">
 <section class="hero">
-  <div class="hero__eyebrow">CURRENT CONTEXT FOR AI AGENTS</div>
-  <h1>Relevant context<br><span>is not always true.</span></h1>
-  <p class="hero__lede">Lint-AI turns scattered project history, including sessions, documents, decisions, and traces, into current, evidence-backed context at the moment an agent needs it.</p>
+  <div class="hero__eyebrow">AGENT MEMORY FOR AI CODING AGENTS</div>
+  <h1>Agent memory that knows<br><span>what is still true.</span></h1>
+  <p class="hero__lede">Lint-AI is a current-state agent memory layer for Claude Code, Codex, Gemini CLI, and other AI agents. It turns project history — sessions, documents, decisions, traces, and code — into current, evidence-backed context when an agent needs it.</p>
 </section>
 
 <section class="scenario" aria-label="Example of an agent retrieving a superseded decision">
@@ -46,11 +46,12 @@ hide:
 </div>
 
 <section class="solution-intro">
-  <div class="hero__eyebrow">THE MISSING LAYER</div>
-  <h2>Move from relevant retrieval to current understanding.</h2>
-  <p>Search can find the right topic. Lint-AI helps agents distinguish what is relevant from what is still true, while preserving the sources, timestamps, and history behind each answer.</p>
+  <div class="hero__eyebrow">PERSISTENT MEMORY IS THE FIRST STEP</div>
+  <h2>Move from remembering history to understanding current state.</h2>
+  <p>Traditional agent memory helps an AI agent remember. Lint-AI adds time, supersession, and evidence so the agent can distinguish what is relevant from what is still true.</p>
   <div class="hero__actions">
     <a class="md-button md-button--primary" href="quickstart/">Start building</a>
+    <a class="md-button" href="agent-memory/">What is agent memory?</a>
     <a class="md-button" href="https://github.com/RooAGI/Lint-AI">View on GitHub</a>
   </div>
   <div class="install-line">
@@ -58,11 +59,11 @@ hide:
   </div>
 </section>
 
-## See the real CLI run {.landing-heading}
+## See the reproducible CLI run {.landing-heading}
 
-This is a real **asciinema PTY capture** of the merged `lint-ai` binary. The workflow sets deterministic file mtimes, runs the neutral retry-policy query, and independently verifies that the current value is `2` while stale value `5` is excluded from LLM context.
+This is a reproducible **asciinema PTY capture** of the actual `lint-ai` binary running a controlled stale-memory scenario. The workflow sets deterministic file mtimes, runs the neutral retry-policy query, and independently verifies that the current value is `2` while stale value `5` is excluded from LLM context.
 
-![Lint-AI real terminal demo](assets/lint-ai-real-terminal.gif)
+![Lint-AI reproducible terminal demo](assets/lint-ai-real-terminal.gif)
 
 <section class="proof-grid" aria-label="Lint-AI benchmark highlights">
   <div><strong>95.6%</strong><span>recall@10</span></div>
@@ -106,9 +107,9 @@ Agent context is not a pile of text. Decisions supersede older decisions. Terms 
   </article>
 </div>
 
-## Keep your sources. Add a current-state layer. {.landing-heading}
+## Keep your sources. Add a current-state memory layer. {.landing-heading}
 
-Lint-AI does not ask you to discard your existing project knowledge. It indexes the sessions, notes, documents, and decisions you already have, then makes their relationships and history usable at retrieval time. Each provider gets isolated, project-scoped memory, lifecycle capture, and shared MCP controls.
+Lint-AI does not ask you to discard your existing project knowledge. It indexes the sessions, notes, documents, and decisions you already have, then makes their relationships and history usable at retrieval time. Each provider gets isolated, project-scoped agent memory, lifecycle capture, and shared MCP controls.
 
 <div class="integration-grid">
   <a href="codex/"><strong>Codex</strong><span>Hooks, MCP, replay, project memory →</span></a>
@@ -128,6 +129,6 @@ Lint-AI does not ask you to discard your existing project knowledge. It indexes 
 
 <section class="final-cta">
   <p>Start with a local corpus. Keep the evidence.</p>
-  <h2>Make memory inspectable.</h2>
+  <h2>Make agent memory inspectable.</h2>
   <a class="md-button md-button--primary" href="quickstart/">Read the quickstart</a>
 </section>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@ hide:
 
 <div class="hero-stack">
 <section class="hero">
-  <div class="hero__eyebrow">AGENT MEMORY FOR AI CODING AGENTS</div>
-  <h1>Agent memory that knows<br><span>what is still true.</span></h1>
-  <p class="hero__lede">Lint-AI is a current-state agent memory layer for Claude Code, Codex, Gemini CLI, and other AI agents. It turns project history — sessions, documents, decisions, traces, and code — into current, evidence-backed context when an agent needs it.</p>
+  <div class="hero__eyebrow">LINT-AI · CURRENT-STATE AGENT MEMORY</div>
+  <h1>AI memory that knows<br><span>what is still true.</span></h1>
+  <p class="hero__lede"><strong>Current-state agent memory for AI coding agents.</strong> Lint-AI works with Claude Code, Codex, Gemini CLI, and other AI agents, turning project history — sessions, documents, decisions, traces, and code — into current, evidence-backed context when an agent needs it.</p>
 </section>
 
 <section class="scenario" aria-label="Example of an agent retrieving a superseded decision">
@@ -128,7 +128,7 @@ Lint-AI does not ask you to discard your existing project knowledge. It indexes 
 </div>
 
 <section class="final-cta">
-  <p>Start with a local corpus. Keep the evidence.</p>
-  <h2>Make agent memory inspectable.</h2>
+  <p>Current-state agent memory for AI coding agents.</p>
+  <h2>AI memory that knows what is still true.</h2>
   <a class="md-button md-button--primary" href="quickstart/">Read the quickstart</a>
 </section>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Lint-AI
-site_description: Evidence-aware memory and semantic review for AI agents.
+site_description: Current-state agent memory for AI coding agents. Persistent memory for Claude Code, Codex, Gemini CLI, and MCP workflows that filters stale and superseded context.
 site_url: https://rooagi.github.io/Lint-AI/
 repo_url: https://github.com/RooAGI/Lint-AI
 repo_name: RooAGI/Lint-AI
@@ -41,6 +41,7 @@ theme:
 
 nav:
   - Home: index.md
+  - Agent memory: agent-memory.md
   - Get started:
       - Quickstart: quickstart.md
       - HTTP server: server.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Lint-AI
-site_description: Current-state agent memory for AI coding agents. Persistent memory for Claude Code, Codex, Gemini CLI, and MCP workflows that filters stale and superseded context.
+site_description: Lint-AI — AI memory that knows what is still true. Current-state agent memory for Claude Code, Codex, Gemini CLI, and other AI coding agents.
 site_url: https://rooagi.github.io/Lint-AI/
 repo_url: https://github.com/RooAGI/Lint-AI
 repo_name: RooAGI/Lint-AI


### PR DESCRIPTION
## Why

People searching for terms such as `agent memory`, `AI agent memory`, `coding agent memory`, `Claude Code memory`, and `Codex memory` should be able to understand immediately that Lint-AI belongs in this category and how its current-state approach differs.

This PR aligns the GitHub README and documentation around one consistent product hierarchy without keyword stuffing or unsupported claims:

- **Product:** Lint-AI
- **Slogan:** “AI memory that knows what is still true.”
- **Category:** “Current-state agent memory for AI coding agents.”

## What changed

- Make `agent memory` explicit in the README title-level positioning and first paragraph
- Add `docs/agent-memory.md` as an authoritative guide to agent memory, token budget, stale context, and current-state memory
- Add the guide to the docs navigation
- Align the public docs homepage hero with the exact Lint-AI slogan and category line
- Update the docs site description to carry the same product, slogan, and category language
- Rename the demo copy from “real” to “reproducible” and clarify that the scenario is controlled while the binary execution is actual
- Align README benchmark summary with the current revalidated LongMemEval artifact: 83.5% fractional Recall@5, 95.6% any-hit Recall@10, and ~1.88 ms average query latency

## Claim discipline

The new guide explicitly avoids claiming a universal token reduction versus third-party memory systems or a quantified hallucination reduction. It explains the defensible relationship: filtering stale or superseded evidence can reduce unnecessary/conflicting context, while measured token and answer-quality claims require workload-specific benchmarks.

## Remaining metadata step

The connected GitHub tool does not expose the repository About-description/topics editor, so repository metadata is not changed in this PR.