### PR TITLE
Make Lint-AI installable by coding agents

### DIFF
--- a/.github/workflows/agent-install-check.yml
+++ b/.github/workflows/agent-install-check.yml
@@ -1,0 +1,45 @@
+name: Agent install contract
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "INSTALL_FOR_AGENTS.md"
+      - "scripts/install.sh"
+      - "scripts/install.ps1"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/agent-install-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "Cargo.toml"
+      - "INSTALL_FOR_AGENTS.md"
+      - "scripts/install.sh"
+      - "scripts/install.ps1"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/agent-install-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  agent-features:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Compile and test bundled agent integrations
+        run: cargo test --features agent-integrations --lib
+      - name: Validate Unix installer syntax
+        run: sh -n scripts/install.sh
+
+  windows-installer:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate PowerShell installer syntax
+        shell: pwsh
+        run: |
+          $source = Get-Content -Raw scripts/install.ps1
+          [void][scriptblock]::Create($source)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             asset_name: lint-ai-macos-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            asset_name: lint-ai-macos-aarch64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             asset_name: lint-ai-windows-x86_64.exe
@@ -31,19 +34,29 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+      - name: Build agent-capable binary
+        run: cargo build --release --target ${{ matrix.target }} --features agent-integrations
 
-      - name: Package (unix)
+      - name: Package and checksum (unix)
         if: runner.os != 'Windows'
+        shell: bash
         run: |
           mkdir -p dist
           cp target/${{ matrix.target }}/release/lint-ai dist/${{ matrix.asset_name }}
-      - name: Package (windows)
+          if command -v sha256sum >/dev/null 2>&1; then
+            (cd dist && sha256sum "${{ matrix.asset_name }}" > "${{ matrix.asset_name }}.sha256")
+          else
+            (cd dist && shasum -a 256 "${{ matrix.asset_name }}" > "${{ matrix.asset_name }}.sha256")
+          fi
+
+      - name: Package and checksum (windows)
         if: runner.os == 'Windows'
+        shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path dist
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
           Copy-Item target\${{ matrix.target }}\release\lint-ai.exe dist\${{ matrix.asset_name }}
+          $hash = (Get-FileHash -Algorithm SHA256 "dist\${{ matrix.asset_name }}").Hash.ToLower()
+          "$hash  ${{ matrix.asset_name }}" | Set-Content -NoNewline "dist\${{ matrix.asset_name }}.sha256"
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ pyo3 = { version = "0.29", features = ["extension-module"], optional = true }
 [features]
 default = ["heuristic-query-semantics"]
 heuristic-query-semantics = []
+agent-integrations = ["claude-code", "codex", "gemini-cli", "agy"]
 claude-code = []
 codex = []
 gemini-cli = []

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -1,0 +1,129 @@
+# Install Lint-AI with an AI coding agent
+
+This file is the canonical installation contract for Codex, Claude Code, Gemini CLI, AGY, ChatGPT Work, and other agents that can operate a local terminal with the user's permission.
+
+## Goal
+
+Install the official Lint-AI binary, configure it only for the agent the user requested, verify the MCP runtime, and report exactly what changed.
+
+Do not modify unrelated project files. Do not disable existing MCP servers, hooks, instructions, or user configuration.
+
+## 1. Identify the requested agent
+
+Use the agent explicitly named by the user or the environment you are currently operating in.
+
+Supported values:
+
+| User / environment | Installer value | Lint-AI install flag | Verification flag |
+|---|---|---|---|
+| Codex | `codex` | `--codex-install` | `--codex-verify-mcp` |
+| Claude Code | `claude` | `--claude-code-install` | `--claude-code-verify-mcp` |
+| Gemini CLI | `gemini` | `--gemini-cli-install` | `--gemini-cli-verify-mcp` |
+| Antigravity CLI / AGY | `agy` | `--agy-install` | `--agy-verify-mcp` |
+
+If the user has not identified an agent and the environment is ambiguous, ask which integration they want instead of changing several agent configurations.
+
+## 2. Confirm the project directory
+
+Use the repository or project the user asked you to configure. If you are already operating inside that repository, use its root.
+
+Before installation, confirm the directory exists. Lint-AI's provider installers canonicalize the project path and will refuse a missing path.
+
+## 3. Install on macOS or Linux
+
+Download the installer to a temporary file before executing it:
+
+```bash
+installer="$(mktemp)"
+curl -fsSL https://raw.githubusercontent.com/RooAGI/Lint-AI/main/scripts/install.sh -o "$installer"
+sh "$installer" --agent codex --project "$PWD"
+rm -f "$installer"
+```
+
+Replace `codex` with `claude`, `gemini`, or `agy` when appropriate.
+
+The installer:
+
+1. detects the supported OS/CPU,
+2. downloads the matching official GitHub Release asset,
+3. downloads its `.sha256` sidecar,
+4. verifies the SHA-256 checksum before installation,
+5. installs `lint-ai` under `~/.local/bin` by default,
+6. runs the provider-specific configuration command, and
+7. runs the provider-specific MCP verification command.
+
+A custom binary directory can be supplied with `--install-dir` or `LINT_AI_INSTALL_DIR`.
+
+## 4. Install on Windows
+
+Download the PowerShell installer first, then execute it:
+
+```powershell
+$installer = Join-Path $env:TEMP 'lint-ai-install.ps1'
+Invoke-WebRequest -UseBasicParsing `
+  -Uri 'https://raw.githubusercontent.com/RooAGI/Lint-AI/main/scripts/install.ps1' `
+  -OutFile $installer
+& $installer -Agent codex -Project (Get-Location).Path
+Remove-Item $installer
+```
+
+Replace `codex` with `claude`, `gemini`, or `agy` when appropriate.
+
+The Windows installer verifies the release SHA-256 checksum and adds its default install directory (`$HOME\.local\bin`) to the user's PATH when needed.
+
+## 5. Source-install fallback
+
+A newly merged installer may be newer than the most recent tagged release. If the latest release does not yet contain the checksum sidecar or the required platform asset, **do not install an unverified binary**.
+
+If Rust/Cargo is already available, use the source-install fallback:
+
+```bash
+cargo install --git https://github.com/RooAGI/Lint-AI --features agent-integrations --force
+```
+
+Then configure and verify the requested provider. For Codex:
+
+```bash
+lint-ai --codex-install "$PWD"
+lint-ai --codex-verify-mcp "$PWD"
+```
+
+Use the corresponding flags from the table above for other providers.
+
+## 6. Success criteria
+
+Do not report success only because a binary was downloaded.
+
+Installation is successful when all of the following are true:
+
+- `lint-ai --version` exits successfully,
+- the requested provider installation command exits successfully,
+- the provider MCP verification command exits successfully, and
+- no unrelated configuration was overwritten.
+
+The MCP verification launches the installed Lint-AI provider server, performs the MCP `initialize` handshake, calls `tools/list`, and requires a valid Lint-AI response.
+
+## 7. Report back to the user
+
+Report:
+
+- the installed Lint-AI version,
+- the binary path,
+- the project path,
+- the configured agent,
+- whether MCP verification passed, and
+- any PATH change or restart/reload required by the provider.
+
+If a step fails, stop at that step and show the error. Do not hide a failed checksum, failed provider configuration, or failed MCP verification.
+
+## Example prompt for Codex
+
+```text
+Install Lint-AI in this project. Follow INSTALL_FOR_AGENTS.md from RooAGI/Lint-AI. Use the official release, verify its checksum, configure the Codex integration, run the MCP verification, and tell me exactly what changed. Do not modify unrelated project files.
+```
+
+## Example prompt for ChatGPT Work
+
+```text
+Install Lint-AI in my current project by following RooAGI/Lint-AI's INSTALL_FOR_AGENTS.md. Configure it for the coding agent I use, verify the official release and MCP runtime, and report the installed version and files/configuration changed. Do not modify unrelated project files.
+```

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,82 @@
+param(
+    [ValidateSet('', 'codex', 'claude', 'gemini', 'agy')]
+    [string]$Agent = '',
+    [string]$Project = '.',
+    [string]$InstallDir = "$HOME\.local\bin"
+)
+
+$ErrorActionPreference = 'Stop'
+$Repo = 'RooAGI/Lint-AI'
+$BaseUrl = "https://github.com/$Repo/releases/latest/download"
+$Asset = 'lint-ai-windows-x86_64.exe'
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("lint-ai-" + [guid]::NewGuid().ToString('N'))
+$BinaryTemp = Join-Path $TempDir $Asset
+$ChecksumTemp = "$BinaryTemp.sha256"
+$InstalledBinary = Join-Path $InstallDir 'lint-ai.exe'
+
+New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+try {
+    Write-Host 'Downloading official Lint-AI release for Windows x86_64...'
+    Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/$Asset" -OutFile $BinaryTemp
+    Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/$Asset.sha256" -OutFile $ChecksumTemp
+
+    $Expected = ((Get-Content -Raw $ChecksumTemp).Trim() -split '\s+')[0].ToLowerInvariant()
+    $Actual = (Get-FileHash -Algorithm SHA256 $BinaryTemp).Hash.ToLowerInvariant()
+    if ($Expected -ne $Actual) {
+        throw 'Checksum verification failed; refusing to install.'
+    }
+
+    Write-Host 'Checksum verified.'
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+    Copy-Item -Force $BinaryTemp $InstalledBinary
+
+    $Version = & $InstalledBinary --version
+    Write-Host "Installed $Version to $InstalledBinary"
+
+    $UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $PathEntries = @($UserPath -split ';' | Where-Object { $_ })
+    if ($PathEntries -notcontains $InstallDir) {
+        $NewUserPath = if ([string]::IsNullOrWhiteSpace($UserPath)) { $InstallDir } else { "$UserPath;$InstallDir" }
+        [Environment]::SetEnvironmentVariable('Path', $NewUserPath, 'User')
+        Write-Host "Added $InstallDir to your user PATH. Open a new terminal to use lint-ai by name."
+    }
+    if (($env:Path -split ';') -notcontains $InstallDir) {
+        $env:Path = "$InstallDir;$env:Path"
+    }
+
+    if ($Agent) {
+        switch ($Agent) {
+            'codex' {
+                $InstallFlag = '--codex-install'
+                $VerifyFlag = '--codex-verify-mcp'
+            }
+            'claude' {
+                $InstallFlag = '--claude-code-install'
+                $VerifyFlag = '--claude-code-verify-mcp'
+            }
+            'gemini' {
+                $InstallFlag = '--gemini-cli-install'
+                $VerifyFlag = '--gemini-cli-verify-mcp'
+            }
+            'agy' {
+                $InstallFlag = '--agy-install'
+                $VerifyFlag = '--agy-verify-mcp'
+            }
+        }
+
+        Write-Host "Configuring Lint-AI for $Agent in $Project..."
+        & $InstalledBinary $InstallFlag $Project
+        if ($LASTEXITCODE -ne 0) { throw "Lint-AI $Agent configuration failed." }
+
+        Write-Host 'Verifying the Lint-AI MCP runtime...'
+        & $InstalledBinary $VerifyFlag $Project
+        if ($LASTEXITCODE -ne 0) { throw 'Lint-AI MCP verification failed.' }
+
+        Write-Host "Lint-AI is installed, configured for $Agent, and MCP verification passed."
+    } else {
+        Write-Host 'Lint-AI is installed. Re-run with -Agent codex|claude|gemini|agy to configure an agent.'
+    }
+}
+finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $TempDir
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="RooAGI/Lint-AI"
+BASE_URL="https://github.com/${REPO}/releases/latest/download"
+INSTALL_DIR="${LINT_AI_INSTALL_DIR:-${HOME}/.local/bin}"
+AGENT=""
+PROJECT="."
+
+usage() {
+  cat <<'EOF'
+Install the latest official Lint-AI release and optionally configure an agent.
+
+Usage:
+  install.sh [--agent codex|claude|gemini|agy] [--project PATH] [--install-dir DIR]
+
+Examples:
+  install.sh
+  install.sh --agent codex --project .
+  install.sh --agent claude --project /path/to/project
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --agent)
+      [ "$#" -ge 2 ] || { echo "--agent requires a value" >&2; exit 2; }
+      AGENT="$2"
+      shift 2
+      ;;
+    --project)
+      [ "$#" -ge 2 ] || { echo "--project requires a value" >&2; exit 2; }
+      PROJECT="$2"
+      shift 2
+      ;;
+    --install-dir)
+      [ "$#" -ge 2 ] || { echo "--install-dir requires a value" >&2; exit 2; }
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$AGENT" in
+  ""|codex|claude|gemini|agy) ;;
+  *) echo "unsupported agent: $AGENT" >&2; exit 2 ;;
+esac
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "${OS}:${ARCH}" in
+  Linux:x86_64|Linux:amd64)
+    ASSET="lint-ai-linux-x86_64"
+    ;;
+  Darwin:x86_64|Darwin:amd64)
+    ASSET="lint-ai-macos-x86_64"
+    ;;
+  Darwin:arm64|Darwin:aarch64)
+    ASSET="lint-ai-macos-aarch64"
+    ;;
+  *)
+    echo "No prebuilt Lint-AI release for ${OS} ${ARCH}." >&2
+    echo "Fallback: cargo install --git https://github.com/${REPO} --features agent-integrations" >&2
+    exit 1
+    ;;
+esac
+
+if command -v curl >/dev/null 2>&1; then
+  fetch() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+  fetch() { wget -qO "$2" "$1"; }
+else
+  echo "curl or wget is required" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+BIN_TMP="${TMP_DIR}/${ASSET}"
+SUM_TMP="${TMP_DIR}/${ASSET}.sha256"
+
+echo "Downloading official Lint-AI release for ${OS} ${ARCH}..."
+fetch "${BASE_URL}/${ASSET}" "$BIN_TMP"
+fetch "${BASE_URL}/${ASSET}.sha256" "$SUM_TMP"
+
+EXPECTED="$(awk '{print $1}' "$SUM_TMP")"
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL="$(sha256sum "$BIN_TMP" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL="$(shasum -a 256 "$BIN_TMP" | awk '{print $1}')"
+else
+  echo "sha256sum or shasum is required to verify the release" >&2
+  exit 1
+fi
+
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "Checksum verification failed; refusing to install." >&2
+  exit 1
+fi
+
+echo "Checksum verified."
+mkdir -p "$INSTALL_DIR"
+chmod 0755 "$BIN_TMP"
+cp "$BIN_TMP" "${INSTALL_DIR}/lint-ai"
+BIN="${INSTALL_DIR}/lint-ai"
+
+echo "Installed $($BIN --version) to ${BIN}"
+
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    echo "Note: ${INSTALL_DIR} is not currently on PATH."
+    echo "Add it to your shell profile, for example: export PATH=\"${INSTALL_DIR}:\$PATH\""
+    ;;
+esac
+
+if [ -n "$AGENT" ]; then
+  case "$AGENT" in
+    codex)
+      INSTALL_FLAG="--codex-install"
+      VERIFY_FLAG="--codex-verify-mcp"
+      ;;
+    claude)
+      INSTALL_FLAG="--claude-code-install"
+      VERIFY_FLAG="--claude-code-verify-mcp"
+      ;;
+    gemini)
+      INSTALL_FLAG="--gemini-cli-install"
+      VERIFY_FLAG="--gemini-cli-verify-mcp"
+      ;;
+    agy)
+      INSTALL_FLAG="--agy-install"
+      VERIFY_FLAG="--agy-verify-mcp"
+      ;;
+  esac
+
+  echo "Configuring Lint-AI for ${AGENT} in ${PROJECT}..."
+  "$BIN" "$INSTALL_FLAG" "$PROJECT"
+  echo "Verifying the Lint-AI MCP runtime..."
+  "$BIN" "$VERIFY_FLAG" "$PROJECT"
+  echo "Lint-AI is installed, configured for ${AGENT}, and MCP verification passed."
+else
+  echo "Lint-AI is installed. To configure an agent, rerun with --agent codex|claude|gemini|agy."
+fi


### PR DESCRIPTION
## Why

Installing Lint-AI should be something a user can delegate to Codex, Claude Code, Gemini CLI, AGY, or ChatGPT Work instead of manually cloning, building feature-gated binaries, editing agent configuration, and guessing whether MCP setup worked.

This PR creates a deterministic agent-install path around the provider installers and MCP health check that already exist in Lint-AI.

## What changed

- Add an `agent-integrations` Cargo feature bundle for Claude Code, Codex, Gemini CLI, and AGY.
- Build tagged release binaries with that bundle enabled so official downloads actually contain the provider install/serve/verify commands.
- Add an Apple Silicon macOS release artifact.
- Publish a SHA-256 sidecar for every release binary.
- Add `scripts/install.sh` for macOS/Linux and `scripts/install.ps1` for Windows. The installers download an official GitHub Release asset, verify its SHA-256 checksum, install the binary, optionally configure one requested agent, and run that provider's MCP verification.
- Add root-level `INSTALL_FOR_AGENTS.md` with a deterministic contract that coding agents can follow, including success criteria, provider flag mapping, a source-build fallback, and example prompts for Codex and ChatGPT Work.
- Add CI that compiles/tests the bundled agent feature set and syntax-checks both installer scripts.

## Intended UX

A user can tell Codex:

> Install Lint-AI in this project. Follow `INSTALL_FOR_AGENTS.md` from `RooAGI/Lint-AI`, configure the Codex integration, verify the official release and MCP runtime, and tell me exactly what changed.

The agent has one canonical document describing how to perform and verify the install safely.

## Security / failure behavior

- Release binaries are not installed unless their SHA-256 sidecar matches.
- If a newly merged installer is ahead of the latest tagged release and the checksum sidecar does not exist yet, the agent instructions explicitly require using the Cargo source-install fallback rather than installing an unverified binary.
- Provider configuration uses the existing Lint-AI installers, which preserve unrelated user configuration.
- MCP success is verified through the existing initialize + tools/list health check instead of assuming that configuration writes succeeded.

## Release note

The verified binary installers become fully usable after the first tag produced by the updated release workflow, because older release assets do not contain the new `.sha256` sidecars or Apple Silicon artifact.